### PR TITLE
Expose Config.LoadAndValidate func and Config.OsClient type field.

### DIFF
--- a/openstack/config.go
+++ b/openstack/config.go
@@ -33,10 +33,10 @@ type Config struct {
 	Username         string
 	UserID           string
 
-	osClient *gophercloud.ProviderClient
+	OsClient *gophercloud.ProviderClient
 }
 
-func (c *Config) loadAndValidate() error {
+func (c *Config) LoadAndValidate() error {
 	validEndpoint := false
 	validEndpoints := []string{
 		"internal", "internalURL",
@@ -132,7 +132,7 @@ func (c *Config) loadAndValidate() error {
 		}
 	}
 
-	c.osClient = client
+	c.OsClient = client
 
 	return nil
 }
@@ -149,42 +149,42 @@ func (c *Config) determineRegion(region string) string {
 }
 
 func (c *Config) blockStorageV1Client(region string) (*gophercloud.ServiceClient, error) {
-	return openstack.NewBlockStorageV1(c.osClient, gophercloud.EndpointOpts{
+	return openstack.NewBlockStorageV1(c.OsClient, gophercloud.EndpointOpts{
 		Region:       c.determineRegion(region),
 		Availability: c.getEndpointType(),
 	})
 }
 
 func (c *Config) blockStorageV2Client(region string) (*gophercloud.ServiceClient, error) {
-	return openstack.NewBlockStorageV2(c.osClient, gophercloud.EndpointOpts{
+	return openstack.NewBlockStorageV2(c.OsClient, gophercloud.EndpointOpts{
 		Region:       c.determineRegion(region),
 		Availability: c.getEndpointType(),
 	})
 }
 
 func (c *Config) computeV2Client(region string) (*gophercloud.ServiceClient, error) {
-	return openstack.NewComputeV2(c.osClient, gophercloud.EndpointOpts{
+	return openstack.NewComputeV2(c.OsClient, gophercloud.EndpointOpts{
 		Region:       c.determineRegion(region),
 		Availability: c.getEndpointType(),
 	})
 }
 
 func (c *Config) dnsV2Client(region string) (*gophercloud.ServiceClient, error) {
-	return openstack.NewDNSV2(c.osClient, gophercloud.EndpointOpts{
+	return openstack.NewDNSV2(c.OsClient, gophercloud.EndpointOpts{
 		Region:       c.determineRegion(region),
 		Availability: c.getEndpointType(),
 	})
 }
 
 func (c *Config) imageV2Client(region string) (*gophercloud.ServiceClient, error) {
-	return openstack.NewImageServiceV2(c.osClient, gophercloud.EndpointOpts{
+	return openstack.NewImageServiceV2(c.OsClient, gophercloud.EndpointOpts{
 		Region:       c.determineRegion(region),
 		Availability: c.getEndpointType(),
 	})
 }
 
 func (c *Config) networkingV2Client(region string) (*gophercloud.ServiceClient, error) {
-	return openstack.NewNetworkV2(c.osClient, gophercloud.EndpointOpts{
+	return openstack.NewNetworkV2(c.OsClient, gophercloud.EndpointOpts{
 		Region:       c.determineRegion(region),
 		Availability: c.getEndpointType(),
 	})
@@ -193,13 +193,13 @@ func (c *Config) networkingV2Client(region string) (*gophercloud.ServiceClient, 
 func (c *Config) objectStorageV1Client(region string) (*gophercloud.ServiceClient, error) {
 	// If Swift Authentication is being used, return a swauth client.
 	if c.Swauth {
-		return swauth.NewObjectStorageV1(c.osClient, swauth.AuthOpts{
+		return swauth.NewObjectStorageV1(c.OsClient, swauth.AuthOpts{
 			User: c.Username,
 			Key:  c.Password,
 		})
 	}
 
-	return openstack.NewObjectStorageV1(c.osClient, gophercloud.EndpointOpts{
+	return openstack.NewObjectStorageV1(c.OsClient, gophercloud.EndpointOpts{
 		Region:       c.determineRegion(region),
 		Availability: c.getEndpointType(),
 	})

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -249,7 +249,7 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		UserID:           d.Get("user_id").(string),
 	}
 
-	if err := config.loadAndValidate(); err != nil {
+	if err := config.LoadAndValidate(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Rename existing uses of `osClient` to `OsClient`.
This is a rework of hashicorp/terraform@f3c52416a56d7772bd633f08cab48c10696bcf3d

Required for https://github.com/hashicorp/terraform/pull/13871