### PR TITLE
Add Region to Provider

### DIFF
--- a/openstack/config.go
+++ b/openstack/config.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 
@@ -24,6 +25,7 @@ type Config struct {
 	IdentityEndpoint string
 	Insecure         bool
 	Password         string
+	Region           string
 	Swauth           bool
 	TenantID         string
 	TenantName       string
@@ -135,44 +137,55 @@ func (c *Config) loadAndValidate() error {
 	return nil
 }
 
+func (c *Config) determineRegion(region string) string {
+	// If a resource-level region was not specified, and a provider-level region was set,
+	// use the provider-level region.
+	if region == "" && c.Region != "" {
+		region = c.Region
+	}
+
+	log.Printf("[DEBUG] OpenStack Region is: %s", region)
+	return region
+}
+
 func (c *Config) blockStorageV1Client(region string) (*gophercloud.ServiceClient, error) {
 	return openstack.NewBlockStorageV1(c.osClient, gophercloud.EndpointOpts{
-		Region:       region,
+		Region:       c.determineRegion(region),
 		Availability: c.getEndpointType(),
 	})
 }
 
 func (c *Config) blockStorageV2Client(region string) (*gophercloud.ServiceClient, error) {
 	return openstack.NewBlockStorageV2(c.osClient, gophercloud.EndpointOpts{
-		Region:       region,
+		Region:       c.determineRegion(region),
 		Availability: c.getEndpointType(),
 	})
 }
 
 func (c *Config) computeV2Client(region string) (*gophercloud.ServiceClient, error) {
 	return openstack.NewComputeV2(c.osClient, gophercloud.EndpointOpts{
-		Region:       region,
+		Region:       c.determineRegion(region),
 		Availability: c.getEndpointType(),
 	})
 }
 
 func (c *Config) dnsV2Client(region string) (*gophercloud.ServiceClient, error) {
 	return openstack.NewDNSV2(c.osClient, gophercloud.EndpointOpts{
-		Region:       region,
+		Region:       c.determineRegion(region),
 		Availability: c.getEndpointType(),
 	})
 }
 
 func (c *Config) imageV2Client(region string) (*gophercloud.ServiceClient, error) {
 	return openstack.NewImageServiceV2(c.osClient, gophercloud.EndpointOpts{
-		Region:       region,
+		Region:       c.determineRegion(region),
 		Availability: c.getEndpointType(),
 	})
 }
 
 func (c *Config) networkingV2Client(region string) (*gophercloud.ServiceClient, error) {
 	return openstack.NewNetworkV2(c.osClient, gophercloud.EndpointOpts{
-		Region:       region,
+		Region:       c.determineRegion(region),
 		Availability: c.getEndpointType(),
 	})
 }
@@ -187,7 +200,7 @@ func (c *Config) objectStorageV1Client(region string) (*gophercloud.ServiceClien
 	}
 
 	return openstack.NewObjectStorageV1(c.osClient, gophercloud.EndpointOpts{
-		Region:       region,
+		Region:       c.determineRegion(region),
 		Availability: c.getEndpointType(),
 	})
 }

--- a/openstack/data_source_openstack_images_image_v2.go
+++ b/openstack/data_source_openstack_images_image_v2.go
@@ -17,10 +17,10 @@ func dataSourceImagesImageV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 
 			"name": {
@@ -143,7 +143,7 @@ func dataSourceImagesImageV2() *schema.Resource {
 // dataSourceImagesImageV2Read performs the image lookup.
 func dataSourceImagesImageV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	imageClient, err := config.imageV2Client(GetRegion(d))
+	imageClient, err := config.imageV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack image client: %s", err)
 	}

--- a/openstack/data_source_openstack_networking_network_v2.go
+++ b/openstack/data_source_openstack_networking_network_v2.go
@@ -17,6 +17,12 @@ func dataSourceNetworkingNetworkV2() *schema.Resource {
 		Read: dataSourceNetworkingNetworkV2Read,
 
 		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"network_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -28,11 +34,6 @@ func dataSourceNetworkingNetworkV2() *schema.Resource {
 			"matching_subnet_cidr": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-			},
-			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"tenant_id": &schema.Schema{
 				Type:     schema.TypeString,
@@ -57,7 +58,7 @@ func dataSourceNetworkingNetworkV2() *schema.Resource {
 
 func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 
 	listOpts := networks.ListOpts{
 		ID:       d.Get("network_id").(string),
@@ -111,7 +112,7 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 	d.Set("admin_state_up", strconv.FormatBool(network.AdminStateUp))
 	d.Set("shared", strconv.FormatBool(network.Shared))
 	d.Set("tenant_id", network.TenantID)
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -20,6 +20,13 @@ func Provider() terraform.ResourceProvider {
 				Description: descriptions["auth_url"],
 			},
 
+			"region": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions["region"],
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+			},
+
 			"user_name": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -187,6 +194,8 @@ func init() {
 	descriptions = map[string]string{
 		"auth_url": "The Identity authentication URL.",
 
+		"region": "The OpenStack region to connect to.",
+
 		"user_name": "Username to login with.",
 
 		"user_id": "User ID to login with.",
@@ -231,6 +240,7 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		IdentityEndpoint: d.Get("auth_url").(string),
 		Insecure:         d.Get("insecure").(bool),
 		Password:         d.Get("password").(string),
+		Region:           d.Get("region").(string),
 		Swauth:           d.Get("swauth").(bool),
 		Token:            d.Get("token").(string),
 		TenantID:         d.Get("tenant_id").(string),

--- a/openstack/resource_openstack_blockstorage_volume_attach_v2.go
+++ b/openstack/resource_openstack_blockstorage_volume_attach_v2.go
@@ -26,10 +26,10 @@ func resourceBlockStorageVolumeAttachV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 
 			"volume_id": &schema.Schema{
@@ -136,7 +136,7 @@ func resourceBlockStorageVolumeAttachV2() *schema.Resource {
 
 func resourceBlockStorageVolumeAttachV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.blockStorageV2Client(GetRegion(d))
+	client, err := config.blockStorageV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
 	}
@@ -276,7 +276,7 @@ func resourceBlockStorageVolumeAttachV2Create(d *schema.ResourceData, meta inter
 
 func resourceBlockStorageVolumeAttachV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.blockStorageV2Client(GetRegion(d))
+	client, err := config.blockStorageV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
 	}
@@ -307,7 +307,7 @@ func resourceBlockStorageVolumeAttachV2Read(d *schema.ResourceData, meta interfa
 
 func resourceBlockStorageVolumeAttachV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.blockStorageV2Client(GetRegion(d))
+	client, err := config.blockStorageV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
 	}

--- a/openstack/resource_openstack_blockstorage_volume_v1.go
+++ b/openstack/resource_openstack_blockstorage_volume_v1.go
@@ -31,11 +31,12 @@ func resourceBlockStorageVolumeV1() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
+
 			"size": &schema.Schema{
 				Type:     schema.TypeInt,
 				Required: true,
@@ -111,7 +112,7 @@ func resourceBlockStorageVolumeV1() *schema.Resource {
 
 func resourceBlockStorageVolumeV1Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	blockStorageClient, err := config.blockStorageV1Client(GetRegion(d))
+	blockStorageClient, err := config.blockStorageV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
 	}
@@ -165,7 +166,7 @@ func resourceBlockStorageVolumeV1Create(d *schema.ResourceData, meta interface{}
 func resourceBlockStorageVolumeV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	blockStorageClient, err := config.blockStorageV1Client(GetRegion(d))
+	blockStorageClient, err := config.blockStorageV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
 	}
@@ -185,7 +186,7 @@ func resourceBlockStorageVolumeV1Read(d *schema.ResourceData, meta interface{}) 
 	d.Set("source_vol_id", v.SourceVolID)
 	d.Set("volume_type", v.VolumeType)
 	d.Set("metadata", v.Metadata)
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	attachments := make([]map[string]interface{}, len(v.Attachments))
 	for i, attachment := range v.Attachments {
@@ -202,7 +203,7 @@ func resourceBlockStorageVolumeV1Read(d *schema.ResourceData, meta interface{}) 
 
 func resourceBlockStorageVolumeV1Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	blockStorageClient, err := config.blockStorageV1Client(GetRegion(d))
+	blockStorageClient, err := config.blockStorageV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
 	}
@@ -226,7 +227,7 @@ func resourceBlockStorageVolumeV1Update(d *schema.ResourceData, meta interface{}
 
 func resourceBlockStorageVolumeV1Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	blockStorageClient, err := config.blockStorageV1Client(GetRegion(d))
+	blockStorageClient, err := config.blockStorageV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
 	}
@@ -239,7 +240,7 @@ func resourceBlockStorageVolumeV1Delete(d *schema.ResourceData, meta interface{}
 	// make sure this volume is detached from all instances before deleting
 	if len(v.Attachments) > 0 {
 		log.Printf("[DEBUG] detaching volumes")
-		if computeClient, err := config.computeV2Client(GetRegion(d)); err != nil {
+		if computeClient, err := config.computeV2Client(GetRegion(d, config)); err != nil {
 			return err
 		} else {
 			for _, volumeAttachment := range v.Attachments {

--- a/openstack/resource_openstack_blockstorage_volume_v2.go
+++ b/openstack/resource_openstack_blockstorage_volume_v2.go
@@ -31,11 +31,12 @@ func resourceBlockStorageVolumeV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
+
 			"size": &schema.Schema{
 				Type:     schema.TypeInt,
 				Required: true,
@@ -121,7 +122,7 @@ func resourceBlockStorageVolumeV2() *schema.Resource {
 
 func resourceBlockStorageVolumeV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	blockStorageClient, err := config.blockStorageV2Client(GetRegion(d))
+	blockStorageClient, err := config.blockStorageV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
 	}
@@ -176,7 +177,7 @@ func resourceBlockStorageVolumeV2Create(d *schema.ResourceData, meta interface{}
 
 func resourceBlockStorageVolumeV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	blockStorageClient, err := config.blockStorageV2Client(GetRegion(d))
+	blockStorageClient, err := config.blockStorageV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
 	}
@@ -196,7 +197,7 @@ func resourceBlockStorageVolumeV2Read(d *schema.ResourceData, meta interface{}) 
 	d.Set("source_vol_id", v.SourceVolID)
 	d.Set("volume_type", v.VolumeType)
 	d.Set("metadata", v.Metadata)
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	attachments := make([]map[string]interface{}, len(v.Attachments))
 	for i, attachment := range v.Attachments {
@@ -213,7 +214,7 @@ func resourceBlockStorageVolumeV2Read(d *schema.ResourceData, meta interface{}) 
 
 func resourceBlockStorageVolumeV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	blockStorageClient, err := config.blockStorageV2Client(GetRegion(d))
+	blockStorageClient, err := config.blockStorageV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
 	}
@@ -237,7 +238,7 @@ func resourceBlockStorageVolumeV2Update(d *schema.ResourceData, meta interface{}
 
 func resourceBlockStorageVolumeV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	blockStorageClient, err := config.blockStorageV2Client(GetRegion(d))
+	blockStorageClient, err := config.blockStorageV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
 	}
@@ -250,7 +251,7 @@ func resourceBlockStorageVolumeV2Delete(d *schema.ResourceData, meta interface{}
 	// make sure this volume is detached from all instances before deleting
 	if len(v.Attachments) > 0 {
 		log.Printf("[DEBUG] detaching volumes")
-		if computeClient, err := config.computeV2Client(GetRegion(d)); err != nil {
+		if computeClient, err := config.computeV2Client(GetRegion(d, config)); err != nil {
 			return err
 		} else {
 			for _, volumeAttachment := range v.Attachments {

--- a/openstack/resource_openstack_compute_floatingip_associate_v2.go
+++ b/openstack/resource_openstack_compute_floatingip_associate_v2.go
@@ -23,11 +23,12 @@ func resourceComputeFloatingIPAssociateV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
+
 			"floating_ip": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -49,7 +50,7 @@ func resourceComputeFloatingIPAssociateV2() *schema.Resource {
 
 func resourceComputeFloatingIPAssociateV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
@@ -83,7 +84,7 @@ func resourceComputeFloatingIPAssociateV2Create(d *schema.ResourceData, meta int
 
 func resourceComputeFloatingIPAssociateV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
@@ -97,7 +98,7 @@ func resourceComputeFloatingIPAssociateV2Read(d *schema.ResourceData, meta inter
 	// Now check and see whether the floating IP still exists.
 	// First try to do this by querying the Network API.
 	networkEnabled := true
-	networkClient, err := config.networkingV2Client(GetRegion(d))
+	networkClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		networkEnabled = false
 	}
@@ -146,14 +147,14 @@ func resourceComputeFloatingIPAssociateV2Read(d *schema.ResourceData, meta inter
 	d.Set("floating_ip", floatingIP)
 	d.Set("instance_id", instanceId)
 	d.Set("fixed_ip", fixedIP)
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceComputeFloatingIPAssociateV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}

--- a/openstack/resource_openstack_compute_floatingip_v2.go
+++ b/openstack/resource_openstack_compute_floatingip_v2.go
@@ -20,10 +20,10 @@ func resourceComputeFloatingIPV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 
 			"pool": &schema.Schema{
@@ -53,7 +53,7 @@ func resourceComputeFloatingIPV2() *schema.Resource {
 
 func resourceComputeFloatingIPV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
@@ -74,7 +74,7 @@ func resourceComputeFloatingIPV2Create(d *schema.ResourceData, meta interface{})
 
 func resourceComputeFloatingIPV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
@@ -90,14 +90,14 @@ func resourceComputeFloatingIPV2Read(d *schema.ResourceData, meta interface{}) e
 	d.Set("instance_id", fip.InstanceID)
 	d.Set("address", fip.IP)
 	d.Set("fixed_ip", fip.FixedIP)
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceComputeFloatingIPV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}

--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -607,6 +607,9 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 	// Set the availability zone
 	d.Set("availability_zone", serverWithAZ.AvailabilityZone)
 
+	// Set the region
+	d.Set("region", GetRegion(d, config))
+
 	return nil
 }
 

--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -42,11 +42,12 @@ func resourceComputeInstanceV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
+
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -348,7 +349,7 @@ func resourceComputeInstanceV2() *schema.Resource {
 
 func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
@@ -495,7 +496,7 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 	// if volumes were specified, attach them after the instance has launched.
 	if v, ok := d.GetOk("volume"); ok {
 		vols := v.(*schema.Set).List()
-		if blockClient, err := config.blockStorageV1Client(GetRegion(d)); err != nil {
+		if blockClient, err := config.blockStorageV1Client(GetRegion(d, config)); err != nil {
 			return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
 		} else {
 			if err := attachVolumesToInstance(computeClient, blockClient, d.Id(), vols); err != nil {
@@ -509,7 +510,7 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 
 func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
@@ -611,7 +612,7 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 
 func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
@@ -771,7 +772,7 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 		oldAttachmentSet := oldAttachments.(*schema.Set).List()
 
 		log.Printf("[DEBUG] Attempting to detach the following volumes: %#v", oldAttachmentSet)
-		if blockClient, err := config.blockStorageV1Client(GetRegion(d)); err != nil {
+		if blockClient, err := config.blockStorageV1Client(GetRegion(d, config)); err != nil {
 			return err
 		} else {
 			if err := detachVolumesFromInstance(computeClient, blockClient, d.Id(), oldAttachmentSet); err != nil {
@@ -781,7 +782,7 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 
 		// for each new attachment, attach the volume
 		newAttachmentSet := newAttachments.(*schema.Set).List()
-		if blockClient, err := config.blockStorageV1Client(GetRegion(d)); err != nil {
+		if blockClient, err := config.blockStorageV1Client(GetRegion(d, config)); err != nil {
 			return err
 		} else {
 			if err := attachVolumesToInstance(computeClient, blockClient, d.Id(), newAttachmentSet); err != nil {
@@ -858,7 +859,7 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 
 func resourceComputeInstanceV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
@@ -869,7 +870,7 @@ func resourceComputeInstanceV2Delete(d *schema.ResourceData, meta interface{}) e
 		volumeList := volumeSet.List()
 		if len(volumeList) > 0 {
 			log.Printf("[DEBUG] Attempting to detach the following volumes: %#v", volumeList)
-			if blockClient, err := config.blockStorageV1Client(GetRegion(d)); err != nil {
+			if blockClient, err := config.blockStorageV1Client(GetRegion(d, config)); err != nil {
 				return err
 			} else {
 				if err := detachVolumesFromInstance(computeClient, blockClient, d.Id(), volumeList); err != nil {

--- a/openstack/resource_openstack_compute_keypair_v2.go
+++ b/openstack/resource_openstack_compute_keypair_v2.go
@@ -19,11 +19,12 @@ func resourceComputeKeypairV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
+
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -45,7 +46,7 @@ func resourceComputeKeypairV2() *schema.Resource {
 
 func resourceComputeKeypairV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
@@ -71,7 +72,7 @@ func resourceComputeKeypairV2Create(d *schema.ResourceData, meta interface{}) er
 
 func resourceComputeKeypairV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
@@ -83,14 +84,14 @@ func resourceComputeKeypairV2Read(d *schema.ResourceData, meta interface{}) erro
 
 	d.Set("name", kp.Name)
 	d.Set("public_key", kp.PublicKey)
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceComputeKeypairV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}

--- a/openstack/resource_openstack_compute_secgroup_v2.go
+++ b/openstack/resource_openstack_compute_secgroup_v2.go
@@ -30,11 +30,12 @@ func resourceComputeSecGroupV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
+
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -99,7 +100,7 @@ func resourceComputeSecGroupV2() *schema.Resource {
 
 func resourceComputeSecGroupV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
@@ -137,7 +138,7 @@ func resourceComputeSecGroupV2Create(d *schema.ResourceData, meta interface{}) e
 
 func resourceComputeSecGroupV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
@@ -157,14 +158,14 @@ func resourceComputeSecGroupV2Read(d *schema.ResourceData, meta interface{}) err
 	log.Printf("[DEBUG] rulesToMap(sg.Rules): %+v", rtm)
 	d.Set("rule", rtm)
 
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceComputeSecGroupV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
@@ -219,7 +220,7 @@ func resourceComputeSecGroupV2Update(d *schema.ResourceData, meta interface{}) e
 
 func resourceComputeSecGroupV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}

--- a/openstack/resource_openstack_compute_servergroup_v2.go
+++ b/openstack/resource_openstack_compute_servergroup_v2.go
@@ -20,11 +20,12 @@ func resourceComputeServerGroupV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
+
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				ForceNew: true,
@@ -52,7 +53,7 @@ func resourceComputeServerGroupV2() *schema.Resource {
 
 func resourceComputeServerGroupV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
@@ -78,7 +79,7 @@ func resourceComputeServerGroupV2Create(d *schema.ResourceData, meta interface{}
 
 func resourceComputeServerGroupV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
@@ -107,14 +108,14 @@ func resourceComputeServerGroupV2Read(d *schema.ResourceData, meta interface{}) 
 	}
 	d.Set("members", members)
 
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceComputeServerGroupV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}

--- a/openstack/resource_openstack_compute_volume_attach_v2.go
+++ b/openstack/resource_openstack_compute_volume_attach_v2.go
@@ -29,10 +29,10 @@ func resourceComputeVolumeAttachV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 
 			"instance_id": &schema.Schema{
@@ -58,7 +58,7 @@ func resourceComputeVolumeAttachV2() *schema.Resource {
 
 func resourceComputeVolumeAttachV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
@@ -109,7 +109,7 @@ func resourceComputeVolumeAttachV2Create(d *schema.ResourceData, meta interface{
 
 func resourceComputeVolumeAttachV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
@@ -129,14 +129,14 @@ func resourceComputeVolumeAttachV2Read(d *schema.ResourceData, meta interface{})
 	d.Set("instance_id", attachment.ServerID)
 	d.Set("volume_id", attachment.VolumeID)
 	d.Set("device", attachment.Device)
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceComputeVolumeAttachV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d))
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}

--- a/openstack/resource_openstack_dns_recordset_v2.go
+++ b/openstack/resource_openstack_dns_recordset_v2.go
@@ -31,10 +31,10 @@ func resourceDNSRecordSetV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
 			},
 			"zone_id": &schema.Schema{
 				Type:     schema.TypeString,
@@ -80,7 +80,7 @@ func resourceDNSRecordSetV2() *schema.Resource {
 
 func resourceDNSRecordSetV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d))
+	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack DNS client: %s", err)
 	}
@@ -131,7 +131,7 @@ func resourceDNSRecordSetV2Create(d *schema.ResourceData, meta interface{}) erro
 
 func resourceDNSRecordSetV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d))
+	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack DNS client: %s", err)
 	}
@@ -154,7 +154,7 @@ func resourceDNSRecordSetV2Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("ttl", n.TTL)
 	d.Set("type", n.Type)
 	d.Set("records", n.Records)
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 	d.Set("zone_id", zoneID)
 
 	return nil
@@ -162,7 +162,7 @@ func resourceDNSRecordSetV2Read(d *schema.ResourceData, meta interface{}) error 
 
 func resourceDNSRecordSetV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d))
+	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack DNS client: %s", err)
 	}
@@ -215,7 +215,7 @@ func resourceDNSRecordSetV2Update(d *schema.ResourceData, meta interface{}) erro
 
 func resourceDNSRecordSetV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d))
+	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack DNS client: %s", err)
 	}

--- a/openstack/resource_openstack_dns_zone_v2.go
+++ b/openstack/resource_openstack_dns_zone_v2.go
@@ -30,10 +30,10 @@ func resourceDNSZoneV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -85,7 +85,7 @@ func resourceDNSZoneV2() *schema.Resource {
 
 func resourceDNSZoneV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d))
+	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack DNS client: %s", err)
 	}
@@ -141,7 +141,7 @@ func resourceDNSZoneV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceDNSZoneV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d))
+	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack DNS client: %s", err)
 	}
@@ -160,14 +160,14 @@ func resourceDNSZoneV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("type", n.Type)
 	d.Set("attributes", n.Attributes)
 	d.Set("masters", n.Masters)
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceDNSZoneV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d))
+	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack DNS client: %s", err)
 	}
@@ -215,7 +215,7 @@ func resourceDNSZoneV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceDNSZoneV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d))
+	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack DNS client: %s", err)
 	}

--- a/openstack/resource_openstack_fw_firewall_v1.go
+++ b/openstack/resource_openstack_fw_firewall_v1.go
@@ -30,10 +30,10 @@ func resourceFWFirewallV1() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -82,7 +82,7 @@ func resourceFWFirewallV1() *schema.Resource {
 func resourceFWFirewallV1Create(d *schema.ResourceData, meta interface{}) error {
 
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -157,7 +157,7 @@ func resourceFWFirewallV1Read(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Retrieve information about firewall: %s", d.Id())
 
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -175,8 +175,8 @@ func resourceFWFirewallV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("policy_id", firewall.PolicyID)
 	d.Set("admin_state_up", firewall.AdminStateUp)
 	d.Set("tenant_id", firewall.TenantID)
-	d.Set("region", GetRegion(d))
 	d.Set("associated_routers", firewall.RouterIDs)
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
@@ -184,7 +184,7 @@ func resourceFWFirewallV1Read(d *schema.ResourceData, meta interface{}) error {
 func resourceFWFirewallV1Update(d *schema.ResourceData, meta interface{}) error {
 
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -254,7 +254,7 @@ func resourceFWFirewallV1Delete(d *schema.ResourceData, meta interface{}) error 
 	log.Printf("[DEBUG] Destroy firewall: %s", d.Id())
 
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_fw_policy_v1.go
+++ b/openstack/resource_openstack_fw_policy_v1.go
@@ -27,10 +27,10 @@ func resourceFWPolicyV1() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -71,7 +71,7 @@ func resourceFWPolicyV1() *schema.Resource {
 
 func resourceFWPolicyV1Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -122,7 +122,7 @@ func resourceFWPolicyV1Read(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Retrieve information about firewall policy: %s", d.Id())
 
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -140,14 +140,14 @@ func resourceFWPolicyV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("audited", policy.Audited)
 	d.Set("tenant_id", policy.TenantID)
 	d.Set("rules", policy.Rules)
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceFWPolicyV1Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -189,7 +189,7 @@ func resourceFWPolicyV1Delete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Destroy firewall policy: %s", d.Id())
 
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_fw_rule_v1.go
+++ b/openstack/resource_openstack_fw_rule_v1.go
@@ -22,10 +22,10 @@ func resourceFWRuleV1() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -86,7 +86,7 @@ func resourceFWRuleV1() *schema.Resource {
 func resourceFWRuleV1Create(d *schema.ResourceData, meta interface{}) error {
 
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -131,7 +131,7 @@ func resourceFWRuleV1Read(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Retrieve information about firewall rule: %s", d.Id())
 
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -159,14 +159,14 @@ func resourceFWRuleV1Read(d *schema.ResourceData, meta interface{}) error {
 		d.Set("protocol", rule.Protocol)
 	}
 
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceFWRuleV1Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -238,7 +238,7 @@ func resourceFWRuleV1Delete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Destroy firewall rule: %s", d.Id())
 
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_images_image_v2.go
+++ b/openstack/resource_openstack_images_image_v2.go
@@ -34,6 +34,13 @@ func resourceImagesImageV2() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
 			"checksum": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -122,13 +129,6 @@ func resourceImagesImageV2() *schema.Resource {
 				Default:  false,
 			},
 
-			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
-			},
-
 			"schema": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -169,7 +169,7 @@ func resourceImagesImageV2() *schema.Resource {
 
 func resourceImagesImageV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	imageClient, err := config.imageV2Client(GetRegion(d))
+	imageClient, err := config.imageV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack image client: %s", err)
 	}
@@ -246,7 +246,7 @@ func resourceImagesImageV2Create(d *schema.ResourceData, meta interface{}) error
 
 func resourceImagesImageV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	imageClient, err := config.imageV2Client(GetRegion(d))
+	imageClient, err := config.imageV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack image client: %s", err)
 	}
@@ -282,7 +282,7 @@ func resourceImagesImageV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceImagesImageV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	imageClient, err := config.imageV2Client(GetRegion(d))
+	imageClient, err := config.imageV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack image client: %s", err)
 	}
@@ -320,7 +320,7 @@ func resourceImagesImageV2Update(d *schema.ResourceData, meta interface{}) error
 
 func resourceImagesImageV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	imageClient, err := config.imageV2Client(GetRegion(d))
+	imageClient, err := config.imageV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack image client: %s", err)
 	}

--- a/openstack/resource_openstack_images_image_v2.go
+++ b/openstack/resource_openstack_images_image_v2.go
@@ -277,6 +277,8 @@ func resourceImagesImageV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("size_bytes", img.SizeBytes)
 	d.Set("tags", img.Tags)
 	d.Set("visibility", img.Visibility)
+	d.Set("region", GetRegion(d, config))
+
 	return nil
 }
 

--- a/openstack/resource_openstack_lb_listener_v2.go
+++ b/openstack/resource_openstack_lb_listener_v2.go
@@ -21,10 +21,10 @@ func resourceListenerV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 
 			"protocol": &schema.Schema{
@@ -111,7 +111,7 @@ func resourceListenerV2() *schema.Resource {
 
 func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -168,7 +168,7 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceListenerV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -197,7 +197,7 @@ func resourceListenerV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -243,7 +243,7 @@ func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceListenerV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_lb_listener_v2.go
+++ b/openstack/resource_openstack_lb_listener_v2.go
@@ -191,6 +191,7 @@ func resourceListenerV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("connection_limit", listener.ConnLimit)
 	d.Set("sni_container_refs", listener.SniContainerRefs)
 	d.Set("default_tls_container_ref", listener.DefaultTlsContainerRef)
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }

--- a/openstack/resource_openstack_lb_loadbalancer_v2.go
+++ b/openstack/resource_openstack_lb_loadbalancer_v2.go
@@ -188,6 +188,7 @@ func resourceLoadBalancerV2Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("admin_state_up", lb.AdminStateUp)
 	d.Set("flavor", lb.Flavor)
 	d.Set("loadbalancer_provider", lb.Provider)
+	d.Set("region", GetRegion(d, config))
 
 	// Get any security groups on the VIP Port
 	if lb.VipPortID != "" {

--- a/openstack/resource_openstack_lb_loadbalancer_v2.go
+++ b/openstack/resource_openstack_lb_loadbalancer_v2.go
@@ -27,10 +27,10 @@ func resourceLoadBalancerV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 
 			"name": &schema.Schema{
@@ -108,7 +108,7 @@ func resourceLoadBalancerV2() *schema.Resource {
 
 func resourceLoadBalancerV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -167,7 +167,7 @@ func resourceLoadBalancerV2Create(d *schema.ResourceData, meta interface{}) erro
 
 func resourceLoadBalancerV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -204,7 +204,7 @@ func resourceLoadBalancerV2Read(d *schema.ResourceData, meta interface{}) error 
 
 func resourceLoadBalancerV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -241,7 +241,7 @@ func resourceLoadBalancerV2Update(d *schema.ResourceData, meta interface{}) erro
 
 func resourceLoadBalancerV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_lb_member_v1.go
+++ b/openstack/resource_openstack_lb_member_v1.go
@@ -29,10 +29,10 @@ func resourceLBMemberV1() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"tenant_id": &schema.Schema{
 				Type:     schema.TypeString,
@@ -71,7 +71,7 @@ func resourceLBMemberV1() *schema.Resource {
 
 func resourceLBMemberV1Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -125,7 +125,7 @@ func resourceLBMemberV1Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceLBMemberV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -142,14 +142,14 @@ func resourceLBMemberV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("port", m.ProtocolPort)
 	d.Set("weight", m.Weight)
 	d.Set("admin_state_up", m.AdminStateUp)
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceLBMemberV1Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -172,7 +172,7 @@ func resourceLBMemberV1Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceLBMemberV1Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_lb_member_v2.go
+++ b/openstack/resource_openstack_lb_member_v2.go
@@ -194,6 +194,7 @@ func resourceMemberV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("address", member.Address)
 	d.Set("protocol_port", member.ProtocolPort)
 	d.Set("id", member.ID)
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }

--- a/openstack/resource_openstack_lb_member_v2.go
+++ b/openstack/resource_openstack_lb_member_v2.go
@@ -26,10 +26,10 @@ func resourceMemberV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 
 			"name": &schema.Schema{
@@ -99,7 +99,7 @@ func resourceMemberV2() *schema.Resource {
 
 func resourceMemberV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -174,7 +174,7 @@ func resourceMemberV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceMemberV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -200,7 +200,7 @@ func resourceMemberV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceMemberV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -229,7 +229,7 @@ func resourceMemberV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceMemberV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_lb_monitor_v1.go
+++ b/openstack/resource_openstack_lb_monitor_v1.go
@@ -30,10 +30,10 @@ func resourceLBMonitorV1() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"tenant_id": &schema.Schema{
 				Type:     schema.TypeString,
@@ -88,7 +88,7 @@ func resourceLBMonitorV1() *schema.Resource {
 
 func resourceLBMonitorV1Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -147,7 +147,7 @@ func resourceLBMonitorV1Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceLBMonitorV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -168,14 +168,14 @@ func resourceLBMonitorV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("http_method", m.HTTPMethod)
 	d.Set("expected_codes", m.ExpectedCodes)
 	d.Set("admin_state_up", strconv.FormatBool(m.AdminStateUp))
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceLBMonitorV1Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -212,7 +212,7 @@ func resourceLBMonitorV1Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceLBMonitorV1Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_lb_monitor_v2.go
+++ b/openstack/resource_openstack_lb_monitor_v2.go
@@ -172,6 +172,7 @@ func resourceMonitorV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("expected_codes", monitor.ExpectedCodes)
 	d.Set("admin_state_up", monitor.AdminStateUp)
 	d.Set("name", monitor.Name)
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }

--- a/openstack/resource_openstack_lb_monitor_v2.go
+++ b/openstack/resource_openstack_lb_monitor_v2.go
@@ -26,10 +26,10 @@ func resourceMonitorV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 
 			"pool_id": &schema.Schema{
@@ -99,7 +99,7 @@ func resourceMonitorV2() *schema.Resource {
 
 func resourceMonitorV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -149,7 +149,7 @@ func resourceMonitorV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceMonitorV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -178,7 +178,7 @@ func resourceMonitorV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceMonitorV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -222,7 +222,7 @@ func resourceMonitorV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceMonitorV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_lb_pool_v1.go
+++ b/openstack/resource_openstack_lb_pool_v1.go
@@ -33,10 +33,10 @@ func resourceLBPoolV1() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -120,7 +120,7 @@ func resourceLBPoolV1() *schema.Resource {
 
 func resourceLBPoolV1Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -190,7 +190,7 @@ func resourceLBPoolV1Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceLBPoolV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -210,14 +210,14 @@ func resourceLBPoolV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("tenant_id", p.TenantID)
 	d.Set("monitor_ids", p.MonitorIDs)
 	d.Set("member_ids", p.MemberIDs)
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceLBPoolV1Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -314,7 +314,7 @@ func resourceLBPoolV1Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceLBPoolV1Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_lb_pool_v2.go
+++ b/openstack/resource_openstack_lb_pool_v2.go
@@ -239,6 +239,7 @@ func resourcePoolV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", pool.Name)
 	d.Set("id", pool.ID)
 	d.Set("persistence", pool.Persistence)
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }

--- a/openstack/resource_openstack_lb_pool_v2.go
+++ b/openstack/resource_openstack_lb_pool_v2.go
@@ -26,10 +26,10 @@ func resourcePoolV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 
 			"tenant_id": &schema.Schema{
@@ -136,7 +136,7 @@ func resourcePoolV2() *schema.Resource {
 
 func resourcePoolV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -219,7 +219,7 @@ func resourcePoolV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourcePoolV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -245,7 +245,7 @@ func resourcePoolV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourcePoolV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -277,7 +277,7 @@ func resourcePoolV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourcePoolV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_lb_vip_v1.go
+++ b/openstack/resource_openstack_lb_vip_v1.go
@@ -29,10 +29,10 @@ func resourceLBVipV1() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -110,7 +110,7 @@ func resourceLBVipV1() *schema.Resource {
 
 func resourceLBVipV1Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -166,7 +166,7 @@ func resourceLBVipV1Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceLBVipV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -200,14 +200,14 @@ func resourceLBVipV1Read(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("persistence", persistence)
 
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceLBVipV1Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -287,7 +287,7 @@ func resourceLBVipV1Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceLBVipV1Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_networking_floatingip_v2.go
+++ b/openstack/resource_openstack_networking_floatingip_v2.go
@@ -31,10 +31,10 @@ func resourceNetworkingFloatingIPV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"address": &schema.Schema{
 				Type:     schema.TypeString,
@@ -73,7 +73,7 @@ func resourceNetworkingFloatingIPV2() *schema.Resource {
 
 func resourceNetworkFloatingIPV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack network client: %s", err)
 	}
@@ -120,7 +120,7 @@ func resourceNetworkFloatingIPV2Create(d *schema.ResourceData, meta interface{})
 
 func resourceNetworkFloatingIPV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack network client: %s", err)
 	}
@@ -140,14 +140,14 @@ func resourceNetworkFloatingIPV2Read(d *schema.ResourceData, meta interface{}) e
 	d.Set("pool", poolName)
 	d.Set("tenant_id", floatingIP.TenantID)
 
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceNetworkFloatingIPV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack network client: %s", err)
 	}
@@ -171,7 +171,7 @@ func resourceNetworkFloatingIPV2Update(d *schema.ResourceData, meta interface{})
 
 func resourceNetworkFloatingIPV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack network client: %s", err)
 	}
@@ -196,7 +196,7 @@ func resourceNetworkFloatingIPV2Delete(d *schema.ResourceData, meta interface{})
 
 func getNetworkID(d *schema.ResourceData, meta interface{}, networkName string) (string, error) {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return "", fmt.Errorf("Error creating OpenStack network client: %s", err)
 	}
@@ -226,7 +226,7 @@ func getNetworkID(d *schema.ResourceData, meta interface{}, networkName string) 
 
 func getNetworkName(d *schema.ResourceData, meta interface{}, networkID string) (string, error) {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return "", fmt.Errorf("Error creating OpenStack network client: %s", err)
 	}

--- a/openstack/resource_openstack_networking_network_v2.go
+++ b/openstack/resource_openstack_networking_network_v2.go
@@ -31,10 +31,10 @@ func resourceNetworkingNetworkV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -94,7 +94,7 @@ func resourceNetworkingNetworkV2() *schema.Resource {
 
 func resourceNetworkingNetworkV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -166,7 +166,7 @@ func resourceNetworkingNetworkV2Create(d *schema.ResourceData, meta interface{})
 
 func resourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -182,14 +182,14 @@ func resourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{}) e
 	d.Set("admin_state_up", strconv.FormatBool(n.AdminStateUp))
 	d.Set("shared", strconv.FormatBool(n.Shared))
 	d.Set("tenant_id", n.TenantID)
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceNetworkingNetworkV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -231,7 +231,7 @@ func resourceNetworkingNetworkV2Update(d *schema.ResourceData, meta interface{})
 
 func resourceNetworkingNetworkV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_networking_port_v2.go
+++ b/openstack/resource_openstack_networking_port_v2.go
@@ -31,10 +31,10 @@ func resourceNetworkingPortV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -137,7 +137,7 @@ func resourceNetworkingPortV2() *schema.Resource {
 
 func resourceNetworkingPortV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -184,7 +184,7 @@ func resourceNetworkingPortV2Create(d *schema.ResourceData, meta interface{}) er
 
 func resourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -224,14 +224,14 @@ func resourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) erro
 	}
 	d.Set("allowed_address_pairs", pairs)
 
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceNetworkingPortV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -277,7 +277,7 @@ func resourceNetworkingPortV2Update(d *schema.ResourceData, meta interface{}) er
 
 func resourceNetworkingPortV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_networking_router_interface_v2.go
+++ b/openstack/resource_openstack_networking_router_interface_v2.go
@@ -106,6 +106,8 @@ func resourceNetworkingRouterInterfaceV2Read(d *schema.ResourceData, meta interf
 
 	log.Printf("[DEBUG] Retrieved Router Interface %s: %+v", d.Id(), n)
 
+	d.Set("region", GetRegion(d, config))
+
 	return nil
 }
 

--- a/openstack/resource_openstack_networking_router_interface_v2.go
+++ b/openstack/resource_openstack_networking_router_interface_v2.go
@@ -26,10 +26,10 @@ func resourceNetworkingRouterInterfaceV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"router_id": &schema.Schema{
 				Type:     schema.TypeString,
@@ -52,7 +52,7 @@ func resourceNetworkingRouterInterfaceV2() *schema.Resource {
 
 func resourceNetworkingRouterInterfaceV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -89,7 +89,7 @@ func resourceNetworkingRouterInterfaceV2Create(d *schema.ResourceData, meta inte
 
 func resourceNetworkingRouterInterfaceV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -111,7 +111,7 @@ func resourceNetworkingRouterInterfaceV2Read(d *schema.ResourceData, meta interf
 
 func resourceNetworkingRouterInterfaceV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_networking_router_route_v2.go
+++ b/openstack/resource_openstack_networking_router_route_v2.go
@@ -142,6 +142,8 @@ func resourceNetworkingRouterRouteV2Read(d *schema.ResourceData, meta interface{
 		}
 	}
 
+	d.Set("region", GetRegion(d, config))
+
 	return nil
 }
 

--- a/openstack/resource_openstack_networking_router_route_v2.go
+++ b/openstack/resource_openstack_networking_router_route_v2.go
@@ -18,10 +18,10 @@ func resourceNetworkingRouterRouteV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"router_id": &schema.Schema{
 				Type:     schema.TypeString,
@@ -52,7 +52,7 @@ func resourceNetworkingRouterRouteV2Create(d *schema.ResourceData, meta interfac
 	var nextHop string = d.Get("next_hop").(string)
 
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -110,7 +110,7 @@ func resourceNetworkingRouterRouteV2Read(d *schema.ResourceData, meta interface{
 	routerId := d.Get("router_id").(string)
 
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -153,7 +153,7 @@ func resourceNetworkingRouterRouteV2Delete(d *schema.ResourceData, meta interfac
 
 	config := meta.(*Config)
 
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_networking_router_v2.go
+++ b/openstack/resource_openstack_networking_router_v2.go
@@ -70,7 +70,7 @@ func resourceNetworkingRouterV2() *schema.Resource {
 
 func resourceNetworkingRouterV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -127,7 +127,7 @@ func resourceNetworkingRouterV2Create(d *schema.ResourceData, meta interface{}) 
 
 func resourceNetworkingRouterV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -159,7 +159,7 @@ func resourceNetworkingRouterV2Update(d *schema.ResourceData, meta interface{}) 
 	defer osMutexKV.Unlock(routerId)
 
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -194,7 +194,7 @@ func resourceNetworkingRouterV2Update(d *schema.ResourceData, meta interface{}) 
 
 func resourceNetworkingRouterV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_networking_router_v2.go
+++ b/openstack/resource_openstack_networking_router_v2.go
@@ -149,6 +149,7 @@ func resourceNetworkingRouterV2Read(d *schema.ResourceData, meta interface{}) er
 	d.Set("distributed", n.Distributed)
 	d.Set("tenant_id", n.TenantID)
 	d.Set("external_gateway", n.GatewayInfo.NetworkID)
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }

--- a/openstack/resource_openstack_networking_secgroup_rule_v2.go
+++ b/openstack/resource_openstack_networking_secgroup_rule_v2.go
@@ -29,10 +29,10 @@ func resourceNetworkingSecGroupRuleV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"direction": &schema.Schema{
 				Type:     schema.TypeString,
@@ -95,7 +95,7 @@ func resourceNetworkingSecGroupRuleV2() *schema.Resource {
 func resourceNetworkingSecGroupRuleV2Create(d *schema.ResourceData, meta interface{}) error {
 
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -152,7 +152,7 @@ func resourceNetworkingSecGroupRuleV2Read(d *schema.ResourceData, meta interface
 	log.Printf("[DEBUG] Retrieve information about security group rule: %s", d.Id())
 
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -172,7 +172,7 @@ func resourceNetworkingSecGroupRuleV2Read(d *schema.ResourceData, meta interface
 	d.Set("remote_ip_prefix", security_group_rule.RemoteIPPrefix)
 	d.Set("security_group_id", security_group_rule.SecGroupID)
 	d.Set("tenant_id", security_group_rule.TenantID)
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
@@ -181,7 +181,7 @@ func resourceNetworkingSecGroupRuleV2Delete(d *schema.ResourceData, meta interfa
 	log.Printf("[DEBUG] Destroy security group rule: %s", d.Id())
 
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_networking_secgroup_v2.go
+++ b/openstack/resource_openstack_networking_secgroup_v2.go
@@ -29,10 +29,10 @@ func resourceNetworkingSecGroupV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -61,7 +61,7 @@ func resourceNetworkingSecGroupV2() *schema.Resource {
 func resourceNetworkingSecGroupV2Create(d *schema.ResourceData, meta interface{}) error {
 
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -101,7 +101,7 @@ func resourceNetworkingSecGroupV2Read(d *schema.ResourceData, meta interface{}) 
 	log.Printf("[DEBUG] Retrieve information about security group: %s", d.Id())
 
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -115,14 +115,14 @@ func resourceNetworkingSecGroupV2Read(d *schema.ResourceData, meta interface{}) 
 	d.Set("description", security_group.Description)
 	d.Set("tenant_id", security_group.TenantID)
 	d.Set("name", security_group.Name)
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceNetworkingSecGroupV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -155,7 +155,7 @@ func resourceNetworkingSecGroupV2Delete(d *schema.ResourceData, meta interface{}
 	log.Printf("[DEBUG] Destroy security group: %s", d.Id())
 
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_networking_subnet_v2.go
+++ b/openstack/resource_openstack_networking_subnet_v2.go
@@ -29,10 +29,10 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"network_id": &schema.Schema{
 				Type:     schema.TypeString,
@@ -130,7 +130,7 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 
 func resourceNetworkingSubnetV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -197,7 +197,7 @@ func resourceNetworkingSubnetV2Create(d *schema.ResourceData, meta interface{}) 
 
 func resourceNetworkingSubnetV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -231,14 +231,14 @@ func resourceNetworkingSubnetV2Read(d *schema.ResourceData, meta interface{}) er
 	}
 	d.Set("allocation_pools", allocationPools)
 
-	d.Set("region", GetRegion(d))
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceNetworkingSubnetV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
@@ -308,7 +308,7 @@ func resourceNetworkingSubnetV2Update(d *schema.ResourceData, meta interface{}) 
 
 func resourceNetworkingSubnetV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d))
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}

--- a/openstack/resource_openstack_objectstorage_container_v1.go
+++ b/openstack/resource_openstack_objectstorage_container_v1.go
@@ -17,10 +17,10 @@ func resourceObjectStorageContainerV1() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -63,7 +63,7 @@ func resourceObjectStorageContainerV1() *schema.Resource {
 
 func resourceObjectStorageContainerV1Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	objectStorageClient, err := config.objectStorageV1Client(GetRegion(d))
+	objectStorageClient, err := config.objectStorageV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack object storage client: %s", err)
 	}
@@ -98,7 +98,7 @@ func resourceObjectStorageContainerV1Read(d *schema.ResourceData, meta interface
 
 func resourceObjectStorageContainerV1Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	objectStorageClient, err := config.objectStorageV1Client(GetRegion(d))
+	objectStorageClient, err := config.objectStorageV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack object storage client: %s", err)
 	}
@@ -125,7 +125,7 @@ func resourceObjectStorageContainerV1Update(d *schema.ResourceData, meta interfa
 
 func resourceObjectStorageContainerV1Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	objectStorageClient, err := config.objectStorageV1Client(GetRegion(d))
+	objectStorageClient, err := config.objectStorageV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack object storage client: %s", err)
 	}

--- a/openstack/resource_openstack_objectstorage_container_v1.go
+++ b/openstack/resource_openstack_objectstorage_container_v1.go
@@ -93,6 +93,9 @@ func resourceObjectStorageContainerV1Create(d *schema.ResourceData, meta interfa
 }
 
 func resourceObjectStorageContainerV1Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	d.Set("region", GetRegion(d, config))
+
 	return nil
 }
 

--- a/openstack/util.go
+++ b/openstack/util.go
@@ -35,8 +35,9 @@ func CheckDeleted(d *schema.ResourceData, err error, msg string) error {
 	return fmt.Errorf("%s: %s", msg, err)
 }
 
-// GetRegion returns the region from either d.Get("region") or config.Region
-// which is either specified in the config or pulled from OS_REGION_NAME.
+// GetRegion returns the region that was specified in the resource. If a
+// region was not set, the provider-level region is checked. The provider-level
+// region can either be set by the region argument or by OS_REGION_NAME.
 func GetRegion(d *schema.ResourceData, config *Config) string {
 	if v, ok := d.GetOk("region"); ok {
 		return v.(string)

--- a/openstack/util.go
+++ b/openstack/util.go
@@ -3,7 +3,6 @@ package openstack
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"sort"
 	"strings"
 
@@ -36,17 +35,14 @@ func CheckDeleted(d *schema.ResourceData, err error, msg string) error {
 	return fmt.Errorf("%s: %s", msg, err)
 }
 
-// GetRegion returns the region from either d.Get("region") or OS_REGION_NAME
-func GetRegion(d *schema.ResourceData) string {
+// GetRegion returns the region from either d.Get("region") or config.Region
+// which is either specified in the config or pulled from OS_REGION_NAME.
+func GetRegion(d *schema.ResourceData, config *Config) string {
 	if v, ok := d.GetOk("region"); ok {
 		return v.(string)
 	}
 
-	if v := os.Getenv("OS_REGION_NAME"); v != "" {
-		return v
-	}
-
-	return ""
+	return config.Region
 }
 
 // AddValueSpecs expands the 'value_specs' object and removes 'value_specs'

--- a/website/docs/d/images_image_v2.html.markdown
+++ b/website/docs/d/images_image_v2.html.markdown
@@ -21,9 +21,9 @@ data "openstack_images_image_v2" "ubuntu" {
 
 ## Argument Reference
 
-* `region` - (Required) The region in which to obtain the V2 Glance client.
+* `region` - (Optional) The region in which to obtain the V2 Glance client.
     A Glance client is needed to create an Image that can be used with
-    a compute instance. If omitted, the `OS_REGION_NAME` environment variable
+    a compute instance. If omitted, the `region` argument of the provider
     is used.
 
 * `most_recent` - (Optional) If more than one result is returned, use the most

--- a/website/docs/d/networking_network_v2.html.markdown
+++ b/website/docs/d/networking_network_v2.html.markdown
@@ -20,9 +20,9 @@ data "openstack_networking_network_v2" "network" {
 
 ## Argument Reference
 
-* `region` - (Required) The region in which to obtain the V2 Neutron client.
+* `region` - (Optional) The region in which to obtain the V2 Neutron client.
   A Neutron client is needed to retrieve networks ids. If omitted, the
-  `OS_REGION_NAME` environment variable is used.
+  `region` argument of the provider is used.
 
 * `network_id` - (Optional) The ID of the network.
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -40,7 +40,10 @@ The following arguments are supported:
   `OS_AUTH_URL` environment variable is used.
 
 * `region` - (Optional) The region of the OpenStack cloud to use. If omitted,
-  the `OS_REGION_NAME` environment variable is used.
+  the `OS_REGION_NAME` environment variable is used. If `OS_REGION_NAME` is
+  not set, then no region will be used. It should be possible to omit the
+  region in single-region OpenStack environments, but this behavior may vary
+  depending on the OpenStack environment being used.
 
 * `user_name` - (Optional) The Username to login with. If omitted, the
   `OS_USERNAME` environment variable is used.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -23,6 +23,7 @@ provider "openstack" {
   tenant_name = "admin"
   password    = "pwd"
   auth_url    = "http://myauthurl:5000/v2.0"
+  region      = "RegionOne"
 }
 
 # Create a web server
@@ -37,6 +38,9 @@ The following arguments are supported:
 
 * `auth_url` - (Required) The Identity authentication URL. If omitted, the
   `OS_AUTH_URL` environment variable is used.
+
+* `region` - (Optional) The region of the OpenStack cloud to use. If omitted,
+  the `OS_REGION_NAME` environment variable is used.
 
 * `user_name` - (Optional) The Username to login with. If omitted, the
   `OS_USERNAME` environment variable is used.

--- a/website/docs/r/blockstorage_volume_attach_v2.html.markdown
+++ b/website/docs/r/blockstorage_volume_attach_v2.html.markdown
@@ -45,10 +45,10 @@ resource "openstack_blockstorage_volume_attach_v2" "va_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Block Storage
+* `region` - (Optional) The region in which to obtain the V2 Block Storage
     client. A Block Storage client is needed to create a volume attachment.
-    If omitted, the `OS_REGION_NAME` environment variable is used. Changing
-    this creates a new volume attachment.
+    If omitted, the `region` argument of the provider is used. Changing this
+    creates a new volume attachment.
 
 * `attach_mode` - (Optional) Specify whether to attach the volume as Read-Only
   (`ro`) or Read-Write (`rw`). Only values of `ro` and `rw` are accepted.

--- a/website/docs/r/blockstorage_volume_v1.html.markdown
+++ b/website/docs/r/blockstorage_volume_v1.html.markdown
@@ -25,8 +25,8 @@ resource "openstack_blockstorage_volume_v1" "volume_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to create the volume. If
-    omitted, the `OS_REGION_NAME` environment variable is used. Changing this
+* `region` - (Optional) The region in which to create the volume. If
+    omitted, the `region` argument of the provider is used. Changing this
     creates a new volume.
 
 * `size` - (Required) The size of the volume to create (in gigabytes). Changing

--- a/website/docs/r/blockstorage_volume_v2.html.markdown
+++ b/website/docs/r/blockstorage_volume_v2.html.markdown
@@ -25,8 +25,8 @@ resource "openstack_blockstorage_volume_v2" "volume_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to create the volume. If
-    omitted, the `OS_REGION_NAME` environment variable is used. Changing this
+* `region` - (Optional) The region in which to create the volume. If
+    omitted, the `region` argument of the provider is used. Changing this
     creates a new volume.
 
 * `size` - (Required) The size of the volume to create (in gigabytes). Changing

--- a/website/docs/r/compute_floatingip_associate_v2.html.markdown
+++ b/website/docs/r/compute_floatingip_associate_v2.html.markdown
@@ -68,9 +68,9 @@ resource "openstack_compute_floatingip_associate_v2" "fip_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Compute client.
+* `region` - (Optional) The region in which to obtain the V2 Compute client.
     Keypairs are associated with accounts, but a Compute client is needed to
-    create one. If omitted, the `OS_REGION_NAME` environment variable is used.
+    create one. If omitted, the `region` argument of the provider is used.
     Changing this creates a new floatingip_associate.
 
 * `floating_ip` - (Required) The floating IP to associate.

--- a/website/docs/r/compute_floatingip_v2.html.markdown
+++ b/website/docs/r/compute_floatingip_v2.html.markdown
@@ -25,9 +25,9 @@ resource "openstack_compute_floatingip_v2" "floatip_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Compute client.
+* `region` - (Optional) The region in which to obtain the V2 Compute client.
     A Compute client is needed to create a floating IP that can be used with
-    a compute instance. If omitted, the `OS_REGION_NAME` environment variable
+    a compute instance. If omitted, the `region` argument of the provider
     is used. Changing this creates a new floating IP (which may or may not
     have a different address).
 

--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -283,8 +283,8 @@ function, or the `template_cloudinit_config` resource.
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to create the server instance. If
-    omitted, the `OS_REGION_NAME` environment variable is used. Changing this
+* `region` - (Optional) The region in which to create the server instance. If
+    omitted, the `region` argument of the provider is used. Changing this
     creates a new server.
 
 * `name` - (Required) A unique name for the resource.

--- a/website/docs/r/compute_keypair_v2.html.markdown
+++ b/website/docs/r/compute_keypair_v2.html.markdown
@@ -23,9 +23,9 @@ resource "openstack_compute_keypair_v2" "test-keypair" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Compute client.
+* `region` - (Optional) The region in which to obtain the V2 Compute client.
     Keypairs are associated with accounts, but a Compute client is needed to
-    create one. If omitted, the `OS_REGION_NAME` environment variable is used.
+    create one. If omitted, the `region` argument of the provider is used.
     Changing this creates a new keypair.
 
 * `name` - (Required) A unique name for the keypair. Changing this creates a new

--- a/website/docs/r/compute_secgroup_v2.html.markdown
+++ b/website/docs/r/compute_secgroup_v2.html.markdown
@@ -37,9 +37,9 @@ resource "openstack_compute_secgroup_v2" "secgroup_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Compute client.
+* `region` - (Optional) The region in which to obtain the V2 Compute client.
     A Compute client is needed to create a security group. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     security group.
 
 * `name` - (Required) A unique name for the security group. Changing this

--- a/website/docs/r/compute_servergroup_v2.html.markdown
+++ b/website/docs/r/compute_servergroup_v2.html.markdown
@@ -23,8 +23,8 @@ resource "openstack_compute_servergroup_v2" "test-sg" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Compute client.
-    If omitted, the `OS_REGION_NAME` environment variable is used. Changing
+* `region` - (Optional) The region in which to obtain the V2 Compute client.
+    If omitted, the `region` argument of the provider is used. Changing
     this creates a new server group.
 
 * `name` - (Required) A unique name for the server group. Changing this creates

--- a/website/docs/r/compute_volume_attach_v2.html.markdown
+++ b/website/docs/r/compute_volume_attach_v2.html.markdown
@@ -34,9 +34,9 @@ resource "openstack_compute_volume_attach_v2" "va_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Compute client.
+* `region` - (Optional) The region in which to obtain the V2 Compute client.
     A Compute client is needed to create a volume attachment. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a
+    `region` argument of the provider is used. Changing this creates a
     new volume attachment.
 
 * `instance_id` - (Required) The ID of the Instance to attach the Volume to.

--- a/website/docs/r/dns_recordset_v2.html.markdown
+++ b/website/docs/r/dns_recordset_v2.html.markdown
@@ -37,8 +37,8 @@ resource "openstack_dns_recordset_v2" "rs_example_com" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 DNS client.
-    If omitted, the `OS_REGION_NAME` environment variable is used.
+* `region` - (Optional) The region in which to obtain the V2 DNS client.
+    If omitted, the `region` argument of the provider is used.
     Changing this creates a new DNS  record set.
 
 * `zone_id` - (Required) The ID of the zone in which to create the record set.

--- a/website/docs/r/dns_zone_v2.html.markdown
+++ b/website/docs/r/dns_zone_v2.html.markdown
@@ -28,9 +28,9 @@ resource "openstack_dns_zone_v2" "example.com" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Compute client.
+* `region` - (Optional) The region in which to obtain the V2 Compute client.
     Keypairs are associated with accounts, but a Compute client is needed to
-    create one. If omitted, the `OS_REGION_NAME` environment variable is used.
+    create one. If omitted, the `region` argument of the provider is used.
     Changing this creates a new DNS zone.
 
 * `name` - (Required) The name of the zone. Note the `.` at the end of the name.

--- a/website/docs/r/fw_firewall_v1.html.markdown
+++ b/website/docs/r/fw_firewall_v1.html.markdown
@@ -49,9 +49,9 @@ resource "openstack_fw_firewall_v1" "firewall_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the v1 networking client.
+* `region` - (Optional) The region in which to obtain the v1 networking client.
     A networking client is needed to create a firewall. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     firewall.
 
 * `policy_id` - (Required) The policy resource id for the firewall. Changing

--- a/website/docs/r/fw_policy_v1.html.markdown
+++ b/website/docs/r/fw_policy_v1.html.markdown
@@ -44,9 +44,9 @@ resource "openstack_fw_policy_v1" "policy_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the v1 networking client.
+* `region` - (Optional) The region in which to obtain the v1 networking client.
     A networking client is needed to create a firewall policy. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     firewall policy.
 
 * `name` - (Optional) A name for the firewall policy. Changing this

--- a/website/docs/r/fw_rule_v1.html.markdown
+++ b/website/docs/r/fw_rule_v1.html.markdown
@@ -27,9 +27,9 @@ resource "openstack_fw_rule_v1" "rule_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the v1 Compute client.
+* `region` - (Optional) The region in which to obtain the v1 Compute client.
     A Compute client is needed to create a firewall rule. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     firewall rule.
 
 * `name` - (Optional) A unique name for the firewall rule. Changing this

--- a/website/docs/r/images_image_v2.html.markdown
+++ b/website/docs/r/images_image_v2.html.markdown
@@ -55,9 +55,9 @@ The following arguments are supported:
 * `protected` - (Optional) If true, image will not be deletable.
    Defaults to false.
 
-* `region` - (Required) The region in which to obtain the V2 Glance client.
+* `region` - (Optional) The region in which to obtain the V2 Glance client.
     A Glance client is needed to create an Image that can be used with
-    a compute instance. If omitted, the `OS_REGION_NAME` environment variable
+    a compute instance. If omitted, the `region` argument of the provider
     is used. Changing this creates a new Image.
 
 * `tags` - (Optional) The tags of the image. It must be a list of strings.

--- a/website/docs/r/lb_listener_v2.html.markdown
+++ b/website/docs/r/lb_listener_v2.html.markdown
@@ -24,9 +24,9 @@ resource "openstack_lb_listener_v2" "listener_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Networking client.
+* `region` - (Optional) The region in which to obtain the V2 Networking client.
     A Networking client is needed to create an . If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     Listener.
 
 * `protocol` = (Required) The protocol - can either be TCP, HTTP or HTTPS.

--- a/website/docs/r/lb_loadbalancer_v2.html.markdown
+++ b/website/docs/r/lb_loadbalancer_v2.html.markdown
@@ -22,9 +22,9 @@ resource "openstack_lb_loadbalancer_v2" "lb_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Networking client.
+* `region` - (Optional) The region in which to obtain the V2 Networking client.
     A Networking client is needed to create an LB member. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     LB member.
 
 * `vip_subnet_id` - (Required) The network on which to allocate the

--- a/website/docs/r/lb_member_v1.html.markdown
+++ b/website/docs/r/lb_member_v1.html.markdown
@@ -24,9 +24,9 @@ resource "openstack_lb_member_v1" "member_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Networking client.
+* `region` - (Optional) The region in which to obtain the V2 Networking client.
     A Networking client is needed to create an LB member. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     LB member.
 
 * `pool_id` - (Required)  The ID of the LB pool. Changing this creates a new

--- a/website/docs/r/lb_member_v2.html.markdown
+++ b/website/docs/r/lb_member_v2.html.markdown
@@ -23,9 +23,9 @@ resource "openstack_lb_member_v2" "member_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Networking client.
+* `region` - (Optional) The region in which to obtain the V2 Networking client.
     A Networking client is needed to create an . If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     member.
 
 * `pool_id` - (Required) The id of the pool that this member will be

--- a/website/docs/r/lb_monitor_v1.html.markdown
+++ b/website/docs/r/lb_monitor_v1.html.markdown
@@ -26,9 +26,9 @@ resource "openstack_lb_monitor_v1" "monitor_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Networking client.
+* `region` - (Optional) The region in which to obtain the V2 Networking client.
     A Networking client is needed to create an LB monitor. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     LB monitor.
 
 * `type` - (Required) The type of probe, which is PING, TCP, HTTP, or HTTPS,

--- a/website/docs/r/lb_monitor_v2.html.markdown
+++ b/website/docs/r/lb_monitor_v2.html.markdown
@@ -26,9 +26,9 @@ resource "openstack_lb_monitor_v2" "monitor_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Networking client.
+* `region` - (Optional) The region in which to obtain the V2 Networking client.
     A Networking client is needed to create an . If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     monitor.
     
 * `pool_id` - (Required) The id of the pool that this monitor will be assigned to.

--- a/website/docs/r/lb_pool_v1.html.markdown
+++ b/website/docs/r/lb_pool_v1.html.markdown
@@ -115,9 +115,9 @@ resource "openstack_lb_vip_v1" "vip_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Networking client.
+* `region` - (Optional) The region in which to obtain the V2 Networking client.
     A Networking client is needed to create an LB pool. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     LB pool.
 
 * `name` - (Required) The name of the pool. Changing this updates the name of

--- a/website/docs/r/lb_pool_v2.html.markdown
+++ b/website/docs/r/lb_pool_v2.html.markdown
@@ -29,9 +29,9 @@ resource "openstack_lb_pool_v2" "pool_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Networking client.
+* `region` - (Optional) The region in which to obtain the V2 Networking client.
     A Networking client is needed to create an . If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     pool.
 
 * `tenant_id` - (Optional) Required for admins. The UUID of the tenant who owns

--- a/website/docs/r/lb_vip_v1.html.markdown
+++ b/website/docs/r/lb_vip_v1.html.markdown
@@ -26,9 +26,9 @@ resource "openstack_lb_vip_v1" "vip_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Networking client.
+* `region` - (Optional) The region in which to obtain the V2 Networking client.
     A Networking client is needed to create a VIP. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     VIP.
 
 * `name` - (Required) The name of the vip. Changing this updates the name of

--- a/website/docs/r/networking_floatingip_v2.html.markdown
+++ b/website/docs/r/networking_floatingip_v2.html.markdown
@@ -25,10 +25,10 @@ resource "openstack_networking_floatingip_v2" "floatip_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Networking client.
+* `region` - (Optional) The region in which to obtain the V2 Networking client.
     A Networking client is needed to create a floating IP that can be used with
     another networking resource, such as a load balancer. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     floating IP (which may or may not have a different address).
 
 * `pool` - (Required) The name of the pool from which to obtain the floating

--- a/website/docs/r/networking_network_v2.html.markdown
+++ b/website/docs/r/networking_network_v2.html.markdown
@@ -63,9 +63,9 @@ resource "openstack_compute_instance_v2" "instance_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Networking client.
+* `region` - (Optional) The region in which to obtain the V2 Networking client.
     A Networking client is needed to create a Neutron network. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     network.
 
 * `name` - (Optional) The name of the network. Changing this updates the name of

--- a/website/docs/r/networking_port_v2.html.markdown
+++ b/website/docs/r/networking_port_v2.html.markdown
@@ -29,9 +29,9 @@ resource "openstack_networking_port_v2" "port_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 networking client.
+* `region` - (Optional) The region in which to obtain the V2 networking client.
     A networking client is needed to create a port. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     port.
 
 * `name` - (Optional) A unique name for the port. Changing this

--- a/website/docs/r/networking_router_interface_v2.html.markdown
+++ b/website/docs/r/networking_router_interface_v2.html.markdown
@@ -39,9 +39,9 @@ resource "openstack_networking_router_interface_v2" "router_interface_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 networking client.
+* `region` - (Optional) The region in which to obtain the V2 networking client.
     A networking client is needed to create a router. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     router interface.
 
 * `router_id` - (Required) ID of the router this interface belongs to. Changing

--- a/website/docs/r/networking_router_route_v2.html.markdown
+++ b/website/docs/r/networking_router_route_v2.html.markdown
@@ -46,9 +46,9 @@ resource "openstack_networking_router_route_v2" "router_route_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 networking client.
+* `region` - (Optional) The region in which to obtain the V2 networking client.
     A networking client is needed to configure a routing entry on a router. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     routing entry.
 
 * `router_id` - (Required) ID of the router this routing entry belongs to. Changing

--- a/website/docs/r/networking_router_v2.html.markdown
+++ b/website/docs/r/networking_router_v2.html.markdown
@@ -23,9 +23,9 @@ resource "openstack_networking_router_v2" "router_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 networking client.
+* `region` - (Optional) The region in which to obtain the V2 networking client.
     A networking client is needed to create a router. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     router.
 
 * `name` - (Optional) A unique name for the router. Changing this

--- a/website/docs/r/networking_secgroup_rule_v2.html.markdown
+++ b/website/docs/r/networking_secgroup_rule_v2.html.markdown
@@ -35,9 +35,9 @@ resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 networking client.
+* `region` - (Optional) The region in which to obtain the V2 networking client.
     A networking client is needed to create a port. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     security group rule.
 
 * `direction` - (Required) The direction of the rule, valid values are __ingress__

--- a/website/docs/r/networking_secgroup_v2.html.markdown
+++ b/website/docs/r/networking_secgroup_v2.html.markdown
@@ -25,9 +25,9 @@ resource "openstack_networking_secgroup_v2" "secgroup_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 networking client.
+* `region` - (Optional) The region in which to obtain the V2 networking client.
     A networking client is needed to create a port. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     security group.
 
 * `name` - (Required) A unique name for the security group.

--- a/website/docs/r/networking_subnet_v2.html.markdown
+++ b/website/docs/r/networking_subnet_v2.html.markdown
@@ -28,9 +28,9 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to obtain the V2 Networking client.
+* `region` - (Optional) The region in which to obtain the V2 Networking client.
     A Networking client is needed to create a Neutron subnet. If omitted, the
-    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    `region` argument of the provider is used. Changing this creates a new
     subnet.
 
 * `network_id` - (Required) The UUID of the parent network. Changing this

--- a/website/docs/r/objectstorage_container_v1.html.markdown
+++ b/website/docs/r/objectstorage_container_v1.html.markdown
@@ -29,8 +29,8 @@ resource "openstack_objectstorage_container_v1" "container_1" {
 
 The following arguments are supported:
 
-* `region` - (Required) The region in which to create the container. If
-    omitted, the `OS_REGION_NAME` environment variable is used. Changing this
+* `region` - (Optional) The region in which to create the container. If
+    omitted, the `region` argument of the provider is used. Changing this
     creates a new container.
 
 * `name` - (Required) A unique name for the container. Changing this creates a


### PR DESCRIPTION
This commit adds the region argument to the OpenStack provider.
This enables a user to specify the region once at the provider-level
and have all resources within that provider be built in that region.

If a resource-level region was specified, it is still recognized
and will override the provider-level region.

Fixes #17 