### PR TITLE
Added retry logic to retry when OpenStack returns 409

### DIFF
--- a/openstack/resource_openstack_lb_listener_v2.go
+++ b/openstack/resource_openstack_lb_listener_v2.go
@@ -139,7 +139,22 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
-	listener, err := listeners.Create(networkingClient, createOpts).Extract()
+	var listener *listeners.Listener
+	err = resource.Retry(10*time.Minute, func() *resource.RetryError {
+		var err error
+		log.Printf("[DEBUG] Attempting to create listener")
+		listener, err = listeners.Create(networkingClient, createOpts).Extract()
+		if err != nil {
+			if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
+				if errCode.Actual == 409 || errCode.Actual == 500 {
+					log.Printf("[DEBUG] OpenStack listener received retryable response code:%d", errCode.Actual)
+					return resource.RetryableError(err)
+				}
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack LBaaSV2 listener: %s", err)
 	}


### PR DESCRIPTION
OpenStack will return 409 when creating multiple listeners at the same time. This patch will allow it to retry for 10 minutes when 409 or 500 is being returned.

**Testing**
Tested with the test case in https://github.com/hashicorp/terraform/issues/15207
The listeners are now created as expected.
