### PR TITLE
wait for lb active state before trying to create pool or monitor

### DIFF
--- a/openstack/resource_openstack_lb_loadbalancer_v2.go
+++ b/openstack/resource_openstack_lb_loadbalancer_v2.go
@@ -337,19 +337,3 @@ func checkForLoadBalancerDelete(networkingClient *gophercloud.ServiceClient, lbI
 		return lb, "ACTIVE", nil
 	}
 }
-
-func checkForRetryableError(err error) *resource.RetryError {
-	switch errCode := err.(type) {
-	case gophercloud.ErrDefault500:
-		return resource.RetryableError(err)
-	case gophercloud.ErrUnexpectedResponseCode:
-		switch errCode.Actual {
-		case 409, 503:
-			return resource.RetryableError(err)
-		default:
-			return resource.NonRetryableError(err)
-		}
-	default:
-		return resource.NonRetryableError(err)
-	}
-}

--- a/openstack/resource_openstack_lb_loadbalancer_v2.go
+++ b/openstack/resource_openstack_lb_loadbalancer_v2.go
@@ -139,16 +139,7 @@ func resourceLoadBalancerV2Create(d *schema.ResourceData, meta interface{}) erro
 
 	log.Printf("[DEBUG] Waiting for Openstack LoadBalancer (%s) to become available.", lb.ID)
 
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"PENDING_CREATE"},
-		Target:     []string{"ACTIVE"},
-		Refresh:    waitForLoadBalancerActive(networkingClient, lb.ID),
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
-		MinTimeout: 3 * time.Second,
-	}
-
-	_, err = stateConf.WaitForState()
+	err = waitForLoadBalancerActive(d, networkingClient, lb.ID)
 	if err != nil {
 		return err
 	}
@@ -250,7 +241,7 @@ func resourceLoadBalancerV2Delete(d *schema.ResourceData, meta interface{}) erro
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE", "PENDING_DELETE"},
 		Target:     []string{"DELETED"},
-		Refresh:    waitForLoadBalancerDelete(networkingClient, d.Id()),
+		Refresh:    checkForLoadBalancerDelete(networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      5 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -285,7 +276,7 @@ func resourceLoadBalancerV2SecurityGroups(networkingClient *gophercloud.ServiceC
 	return nil
 }
 
-func waitForLoadBalancerActive(networkingClient *gophercloud.ServiceClient, lbID string) resource.StateRefreshFunc {
+func checkForLoadBalancerActive(networkingClient *gophercloud.ServiceClient, lbID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		lb, err := loadbalancers.Get(networkingClient, lbID).Extract()
 		if err != nil {
@@ -293,15 +284,25 @@ func waitForLoadBalancerActive(networkingClient *gophercloud.ServiceClient, lbID
 		}
 
 		log.Printf("[DEBUG] OpenStack LBaaSV2 LoadBalancer: %+v", lb)
-		if lb.ProvisioningStatus == "ACTIVE" {
-			return lb, "ACTIVE", nil
-		}
-
 		return lb, lb.ProvisioningStatus, nil
 	}
 }
 
-func waitForLoadBalancerDelete(networkingClient *gophercloud.ServiceClient, lbID string) resource.StateRefreshFunc {
+func waitForLoadBalancerActive(d *schema.ResourceData, networkingClient *gophercloud.ServiceClient, lbID string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"PENDING_CREATE", "PENDING_UPDATE"},
+		Target:     []string{"ACTIVE"},
+		Refresh:    checkForLoadBalancerActive(networkingClient, lbID),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err := stateConf.WaitForState()
+	return err
+}
+
+func checkForLoadBalancerDelete(networkingClient *gophercloud.ServiceClient, lbID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		log.Printf("[DEBUG] Attempting to delete OpenStack LBaaSV2 LoadBalancer %s", lbID)
 
@@ -334,5 +335,21 @@ func waitForLoadBalancerDelete(networkingClient *gophercloud.ServiceClient, lbID
 
 		log.Printf("[DEBUG] OpenStack LBaaSV2 LoadBalancer (%s) still active.", lbID)
 		return lb, "ACTIVE", nil
+	}
+}
+
+func checkForRetryableError(err error) *resource.RetryError {
+	switch errCode := err.(type) {
+	case gophercloud.ErrDefault500:
+		return resource.RetryableError(err)
+	case gophercloud.ErrUnexpectedResponseCode:
+		switch errCode.Actual {
+		case 409, 503:
+			return resource.RetryableError(err)
+		default:
+			return resource.NonRetryableError(err)
+		}
+	default:
+		return resource.NonRetryableError(err)
 	}
 }

--- a/openstack/resource_openstack_lb_member_v2.go
+++ b/openstack/resource_openstack_lb_member_v2.go
@@ -156,7 +156,7 @@ func resourceMemberV2Create(d *schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"PENDING_CREATE"},
 		Target:     []string{"ACTIVE"},
-		Refresh:    waitForMemberActive(networkingClient, poolID, member.ID),
+		Refresh:    checkForMemberActive(networkingClient, poolID, member.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      5 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -238,7 +238,7 @@ func resourceMemberV2Delete(d *schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE", "PENDING_DELETE"},
 		Target:     []string{"DELETED"},
-		Refresh:    waitForMemberDelete(networkingClient, d.Get("pool_id").(string), d.Id()),
+		Refresh:    checkForMemberDelete(networkingClient, d.Get("pool_id").(string), d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      5 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -253,7 +253,7 @@ func resourceMemberV2Delete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func waitForMemberActive(networkingClient *gophercloud.ServiceClient, poolID string, memberID string) resource.StateRefreshFunc {
+func checkForMemberActive(networkingClient *gophercloud.ServiceClient, poolID string, memberID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		member, err := pools.GetMember(networkingClient, poolID, memberID).Extract()
 		if err != nil {
@@ -266,7 +266,7 @@ func waitForMemberActive(networkingClient *gophercloud.ServiceClient, poolID str
 	}
 }
 
-func waitForMemberDelete(networkingClient *gophercloud.ServiceClient, poolID string, memberID string) resource.StateRefreshFunc {
+func checkForMemberDelete(networkingClient *gophercloud.ServiceClient, poolID string, memberID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		log.Printf("[DEBUG] Attempting to delete OpenStack LBaaSV2 Member %s", memberID)
 

--- a/openstack/resource_openstack_lb_monitor_v2.go
+++ b/openstack/resource_openstack_lb_monitor_v2.go
@@ -131,7 +131,7 @@ func resourceMonitorV2Create(d *schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"PENDING_CREATE"},
 		Target:     []string{"ACTIVE"},
-		Refresh:    waitForMonitorActive(networkingClient, monitor.ID),
+		Refresh:    checkForMonitorActive(networkingClient, monitor.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      5 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -231,7 +231,7 @@ func resourceMonitorV2Delete(d *schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE", "PENDING_DELETE"},
 		Target:     []string{"DELETED"},
-		Refresh:    waitForMonitorDelete(networkingClient, d.Id()),
+		Refresh:    checkForMonitorDelete(networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      5 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -246,7 +246,7 @@ func resourceMonitorV2Delete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func waitForMonitorActive(networkingClient *gophercloud.ServiceClient, monitorID string) resource.StateRefreshFunc {
+func checkForMonitorActive(networkingClient *gophercloud.ServiceClient, monitorID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		monitor, err := monitors.Get(networkingClient, monitorID).Extract()
 		if err != nil {
@@ -258,7 +258,7 @@ func waitForMonitorActive(networkingClient *gophercloud.ServiceClient, monitorID
 	}
 }
 
-func waitForMonitorDelete(networkingClient *gophercloud.ServiceClient, monitorID string) resource.StateRefreshFunc {
+func checkForMonitorDelete(networkingClient *gophercloud.ServiceClient, monitorID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		log.Printf("[DEBUG] Attempting to delete OpenStack LBaaSV2 Monitor %s", monitorID)
 


### PR DESCRIPTION
For #4 

This PR waits until the load balancer is in an "ACTIVE" state before trying to create a pool or monitor that depends on the load balancer. Note that if the load balancer ID is not used in the resource's definition in the Terraform configuration file, this check will not happen.

Also of note is that the underlying issue is [seemingly] in OpenStack, where it will return a `409`, yet still create the resource (possibly due to a race condition of getting hammered several times in a few milliseconds with create requests). Even the fix in this PR cannot completely prevent that race condition:
Consider: 
1. a resource is waiting on a load balancer to become "ACTIVE".
2. a different resource is simultaneously waiting on that load balancer to become "ACTIVE".
3. the load balancer goes to an "ACTIVE" state.
4. the two resources will race to OpenStack to update the load balancer.

In addition, it makes 2 other small changes:
1. creates a `checkForRetryableError` function, and
2. renames the `waitFor*Active` and `waitFor*Delete` functions to `checkFor*Active` and `checkFor*Delete`, respectively. Naming those functions that way (I think) was a legacy thing and is a misnomer: the functions don't actually do any waiting. I created a function named `waitForLoadBalancerActive` that actually does wait, so the name changes were also to prevent ambiguity with that new function.