### PR TITLE
Adding support for 'TERMINATED_HTTPS' for lb_listeners backed by A10 networks LBs

### DIFF
--- a/openstack/resource_openstack_lb_listener_v2.go
+++ b/openstack/resource_openstack_lb_listener_v2.go
@@ -38,9 +38,9 @@ func resourceListenerV2() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
-					if value != "TCP" && value != "HTTP" && value != "HTTPS" {
+					if value != "TCP" && value != "HTTP" && value != "HTTPS" && value != "TERMINATED_HTTPS" {
 						errors = append(errors, fmt.Errorf(
-							"Only 'TCP', 'HTTP', and 'HTTPS' are supported values for 'protocol'"))
+							"Only 'TCP', 'HTTP', 'HTTPS' and 'TERMINATED_HTTPS' are supported values for 'protocol'"))
 					}
 					return
 				},

--- a/openstack/resource_openstack_lb_listener_v2_test.go
+++ b/openstack/resource_openstack_lb_listener_v2_test.go
@@ -89,26 +89,6 @@ func testAccCheckLBV2ListenerExists(n string, listener *listeners.Listener) reso
 	}
 }
 
-func TestAccLBV2Listener_terminated_https_basic(t *testing.T) {
-	var listener listeners.Listener
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLBV2ListenerDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: TestAccLBV2ListenerConfig_terminated_https_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLBV2ListenerExists("openstack_lb_listener_v2.listener_1", &listener),
-					resource.TestCheckResourceAttr(
-						"openstack_lb_listener_v2.listener_1", "protocol", "TERMINATED_HTTPS"),
-				),
-			},
-		},
-	})
-}
-
 const TestAccLBV2ListenerConfig_basic = `
 resource "openstack_networking_network_v2" "network_1" {
   name = "network_1"
@@ -162,40 +142,6 @@ resource "openstack_lb_loadbalancer_v2" "loadbalancer_1" {
 resource "openstack_lb_listener_v2" "listener_1" {
   name = "listener_1_updated"
   protocol = "HTTP"
-  protocol_port = 8080
-  connection_limit = 100
-  admin_state_up = "true"
-  loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"
-
-	timeouts {
-		create = "5m"
-		update = "5m"
-		delete = "5m"
-	}
-}
-`
-
-const TestAccLBV2ListenerConfig_terminated_https_basic = `
-resource "openstack_networking_network_v2" "network_1" {
-  name = "network_1"
-  admin_state_up = "true"
-}
-
-resource "openstack_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
-  ip_version = 4
-  network_id = "${openstack_networking_network_v2.network_1.id}"
-}
-
-resource "openstack_lb_loadbalancer_v2" "loadbalancer_1" {
-  name = "loadbalancer_1"
-  vip_subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
-}
-
-resource "openstack_lb_listener_v2" "listener_1" {
-  name = "listener_1_updated"
-  protocol = "TERMINATED_HTTPS"
   protocol_port = 8080
   connection_limit = 100
   admin_state_up = "true"

--- a/website/docs/r/lb_listener_v2.html.markdown
+++ b/website/docs/r/lb_listener_v2.html.markdown
@@ -29,7 +29,7 @@ The following arguments are supported:
     `region` argument of the provider is used. Changing this creates a new
     Listener.
 
-* `protocol` = (Required) The protocol - can either be TCP, HTTP or HTTPS.
+* `protocol` = (Required) The protocol - can either be TCP, HTTP, HTTPS or TERMINATED_HTTPS.
     Changing this creates a new Listener.
 
 * `protocol_port` = (Required) The port on which to listen for client traffic.


### PR DESCRIPTION
The existing `HTTPS` protocol on a `openstack_lb_listener_v2` resource does not function properly if it's passing to an A10 backed loadbalancer.  This LB needs to have the protocol defined in neutron as "TERMINATED_HTTPS".