### PR TITLE
Lbaa s v2 timeouts

### DIFF
--- a/openstack/lb_v2_shared.go
+++ b/openstack/lb_v2_shared.go
@@ -212,3 +212,19 @@ func resourceLBV2PoolRefreshFunc(networkingClient *gophercloud.ServiceClient, po
 		return pool, "ACTIVE", nil
 	}
 }
+
+func waitForLBV2viaPool(networkingClient *gophercloud.ServiceClient, id string, target string, timeout time.Duration) error {
+	pool, err := pools.Get(networkingClient, id).Extract()
+	if err != nil {
+		return err
+	}
+
+	if pool.Loadbalancers != nil {
+		// we know each pool has an LB
+		lbID := pool.Loadbalancers[0].ID
+		return waitForLBV2LoadBalancer(networkingClient, lbID, target, nil, timeout)
+	}
+
+	// got a pool but no LB - this is wrong
+	return fmt.Errorf("No Load Balancer on pool %s", id)
+}

--- a/openstack/resource_openstack_lb_listener_v2.go
+++ b/openstack/resource_openstack_lb_listener_v2.go
@@ -166,12 +166,6 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating listener: %s", err)
 	}
 
-	// Wait for Listener to become active
-	err = waitForLBV2Listener(networkingClient, listener.ID, "ACTIVE", nil, timeout)
-	if err != nil {
-		return err
-	}
-
 	// Wait for LoadBalancer to become active again before continuing
 	err = waitForLBV2LoadBalancer(networkingClient, lbID, "ACTIVE", nil, timeout)
 	if err != nil {
@@ -269,12 +263,6 @@ func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error updating listener %s: %s", d.Id(), err)
 	}
 
-	// Wait for Listener to become active before continuing
-	err = waitForLBV2Listener(networkingClient, d.Id(), "ACTIVE", nil, timeout)
-	if err != nil {
-		return err
-	}
-
 	// Wait for LoadBalancer to become active again before continuing
 	err = waitForLBV2LoadBalancer(networkingClient, lbID, "ACTIVE", nil, timeout)
 	if err != nil {
@@ -311,6 +299,12 @@ func resourceListenerV2Delete(d *schema.ResourceData, meta interface{}) error {
 
 	if err != nil {
 		return fmt.Errorf("Error deleting listener %s: %s", d.Id(), err)
+	}
+
+	// Wait for LoadBalancer to become active again before continuing
+	err = waitForLBV2LoadBalancer(networkingClient, lbID, "ACTIVE", nil, timeout)
+	if err != nil {
+		return err
 	}
 
 	// Wait for Listener to delete

--- a/openstack/resource_openstack_lb_pool_v2.go
+++ b/openstack/resource_openstack_lb_pool_v2.go
@@ -186,16 +186,14 @@ func resourcePoolV2Create(d *schema.ResourceData, meta interface{}) error {
 	// Wait for LoadBalancer to become active before continuing
 	timeout := d.Timeout(schema.TimeoutCreate)
 	lbID := createOpts.LoadbalancerID
+	listenerID := createOpts.ListenerID
 	if lbID != "" {
 		err = waitForLBV2LoadBalancer(networkingClient, lbID, "ACTIVE", nil, timeout)
 		if err != nil {
 			return err
 		}
-	}
-
-	// Wait for Listener to become active before continuing
-	listenerID := createOpts.ListenerID
-	if listenerID != "" {
+	} else if listenerID != "" {
+		// Wait for Listener to become active before continuing
 		err = waitForLBV2Listener(networkingClient, listenerID, "ACTIVE", nil, timeout)
 		if err != nil {
 			return err
@@ -216,26 +214,15 @@ func resourcePoolV2Create(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating pool: %s", err)
 	}
 
-	// Wait for Pool to become active
-	err = waitForLBV2Pool(networkingClient, pool.ID, "ACTIVE", nil, timeout)
-	if err != nil {
-		return err
-	}
-
 	// Wait for LoadBalancer to become active before continuing
 	if lbID != "" {
 		err = waitForLBV2LoadBalancer(networkingClient, lbID, "ACTIVE", nil, timeout)
-		if err != nil {
-			return err
-		}
+	} else {
+		// Pool exists by now so we can ask for lbID
+		err = waitForLBV2viaPool(networkingClient, pool.ID, "ACTIVE", timeout)
 	}
-
-	// Wait for Listener to become active before continuing
-	if listenerID != "" {
-		err = waitForLBV2Listener(networkingClient, listenerID, "ACTIVE", nil, timeout)
-		if err != nil {
-			return err
-		}
+	if err != nil {
+		return err
 	}
 
 	d.SetId(pool.ID)
@@ -297,18 +284,11 @@ func resourcePoolV2Update(d *schema.ResourceData, meta interface{}) error {
 	lbID := d.Get("loadbalancer_id").(string)
 	if lbID != "" {
 		err = waitForLBV2LoadBalancer(networkingClient, lbID, "ACTIVE", nil, timeout)
-		if err != nil {
-			return err
-		}
+	} else {
+		err = waitForLBV2viaPool(networkingClient, d.Id(), "ACTIVE", timeout)
 	}
-
-	// Wait for Listener to become active before continuing
-	listenerID := d.Get("listener_id").(string)
-	if listenerID != "" {
-		err = waitForLBV2Listener(networkingClient, listenerID, "ACTIVE", nil, timeout)
-		if err != nil {
-			return err
-		}
+	if err != nil {
+		return err
 	}
 
 	log.Printf("[DEBUG] Updating pool %s with options: %#v", d.Id(), updateOpts)
@@ -324,26 +304,14 @@ func resourcePoolV2Update(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Unable to update pool %s: %s", d.Id(), err)
 	}
 
-	// Wait for Pool to become active
-	err = waitForLBV2Pool(networkingClient, d.Id(), "ACTIVE", nil, timeout)
-	if err != nil {
-		return err
-	}
-
 	// Wait for LoadBalancer to become active before continuing
 	if lbID != "" {
 		err = waitForLBV2LoadBalancer(networkingClient, lbID, "ACTIVE", nil, timeout)
-		if err != nil {
-			return err
-		}
+	} else {
+		err = waitForLBV2viaPool(networkingClient, d.Id(), "ACTIVE", timeout)
 	}
-
-	// Wait for Listener to become active before continuing
-	if listenerID != "" {
-		err = waitForLBV2Listener(networkingClient, listenerID, "ACTIVE", nil, timeout)
-		if err != nil {
-			return err
-		}
+	if err != nil {
+		return err
 	}
 
 	return resourcePoolV2Read(d, meta)
@@ -366,15 +334,6 @@ func resourcePoolV2Delete(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	// Wait for Listener to become active before continuing
-	listenerID := d.Get("listener_id").(string)
-	if listenerID != "" {
-		err = waitForLBV2Listener(networkingClient, listenerID, "ACTIVE", nil, timeout)
-		if err != nil {
-			return err
-		}
-	}
-
 	log.Printf("[DEBUG] Attempting to delete pool %s", d.Id())
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err = pools.Delete(networkingClient, d.Id()).ExtractErr()
@@ -384,8 +343,12 @@ func resourcePoolV2Delete(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	})
 
-	// Wait for Pool to delete
-	err = waitForLBV2Pool(networkingClient, d.Id(), "DELETED", nil, timeout)
+	if lbID != "" {
+		err = waitForLBV2LoadBalancer(networkingClient, lbID, "ACTIVE", nil, timeout)
+	} else {
+		// Wait for Pool to delete
+		err = waitForLBV2Pool(networkingClient, d.Id(), "DELETED", nil, timeout)
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In most cases it is is sufficient to just wait for the LB to become
ACTIVE again. In areas where the lbID wasn't readilt available
retrive it through the pool object and wait on LB.