### PR TITLE
r/lb_loadbalancer_v2: Remove 'provider' field

### DIFF
--- a/openstack/resource_openstack_lb_loadbalancer_v2.go
+++ b/openstack/resource_openstack_lb_loadbalancer_v2.go
@@ -81,14 +81,6 @@ func resourceLoadBalancerV2() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"provider": &schema.Schema{
-				Type:       schema.TypeString,
-				Optional:   true,
-				Computed:   true,
-				ForceNew:   true,
-				Deprecated: "Please use loadbalancer_provider",
-			},
-
 			"loadbalancer_provider": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,

--- a/website/docs/r/lb_loadbalancer_v2.html.markdown
+++ b/website/docs/r/lb_loadbalancer_v2.html.markdown
@@ -50,8 +50,6 @@ The following arguments are supported:
 * `flavor` - (Optional) The UUID of a flavor. Changing this creates a new
     loadbalancer.
 
-* `provider` - (Deprecated) Use `loadbalancer_provider` instead.
-
 * `loadbalancer_provider` - (Optional) The name of the provider. Changing this
   creates a new loadbalancer.
 


### PR DESCRIPTION
Deprecation was added in https://github.com/hashicorp/terraform/pull/12239 (in February 2017).

That said the user wouldn't ever see the deprecation message because the whole field (along with some other reserved fields) is removed before CRUD even gets chance to process it.

https://github.com/hashicorp/terraform/blob/5bcc1bae5925f44208a83279b6d4d250da01597b/config/loader_hcl.go#L673-L676

This is first step towards bumping `hashicorp/terraform` to `v0.10.0` which has validation for these kinds of things (see https://github.com/hashicorp/terraform/pull/15562).