### PR TITLE
Firewall v1: Fix value_specs during create

### DIFF
--- a/openstack/resource_openstack_fw_firewall_v1.go
+++ b/openstack/resource_openstack_fw_firewall_v1.go
@@ -91,12 +91,15 @@ func resourceFWFirewallV1Create(d *schema.ResourceData, meta interface{}) error 
 	var createOpts firewalls.CreateOptsBuilder
 
 	adminStateUp := d.Get("admin_state_up").(bool)
-	createOpts = &firewalls.CreateOpts{
-		Name:         d.Get("name").(string),
-		Description:  d.Get("description").(string),
-		PolicyID:     d.Get("policy_id").(string),
-		AdminStateUp: &adminStateUp,
-		TenantID:     d.Get("tenant_id").(string),
+	createOpts = FirewallCreateOpts{
+		firewalls.CreateOpts{
+			Name:         d.Get("name").(string),
+			Description:  d.Get("description").(string),
+			PolicyID:     d.Get("policy_id").(string),
+			AdminStateUp: &adminStateUp,
+			TenantID:     d.Get("tenant_id").(string),
+		},
+		MapValueSpecs(d),
 	}
 
 	associatedRoutersRaw := d.Get("associated_routers").(*schema.Set).List()
@@ -121,11 +124,6 @@ func resourceFWFirewallV1Create(d *schema.ResourceData, meta interface{}) error 
 			CreateOptsBuilder: createOpts,
 			RouterIDs:         routerIds,
 		}
-	}
-
-	createOpts = &FirewallCreateOpts{
-		createOpts,
-		MapValueSpecs(d),
 	}
 
 	log.Printf("[DEBUG] Create firewall: %#v", createOpts)

--- a/openstack/types.go
+++ b/openstack/types.go
@@ -161,19 +161,14 @@ type Firewall struct {
 
 // FirewallCreateOpts represents the attributes used when creating a new firewall.
 type FirewallCreateOpts struct {
-	firewalls.CreateOptsBuilder
+	firewalls.CreateOpts
 	ValueSpecs map[string]string `json:"value_specs,omitempty"`
 }
 
 // ToFirewallCreateMap casts a CreateOptsExt struct to a map.
 // It overrides firewalls.ToFirewallCreateMap to add the ValueSpecs field.
 func (opts FirewallCreateOpts) ToFirewallCreateMap() (map[string]interface{}, error) {
-	body, err := opts.CreateOptsBuilder.ToFirewallCreateMap()
-	if err != nil {
-		return nil, err
-	}
-
-	return AddValueSpecs(body), nil
+	return BuildRequest(opts, "firewall")
 }
 
 //FirewallUpdateOpts


### PR DESCRIPTION
This commit fixes a bug where `value_specs` was not being sent
in the body of the create request.

Fixes #66 