### PR TITLE
Added reread of security group before deleting default rules

### DIFF
--- a/openstack/resource_openstack_networking_secgroup_v2.go
+++ b/openstack/resource_openstack_networking_secgroup_v2.go
@@ -82,6 +82,10 @@ func resourceNetworkingSecGroupV2Create(d *schema.ResourceData, meta interface{}
 	// Delete the default security group rules if it has been requested.
 	deleteDefaultRules := d.Get("delete_default_rules").(bool)
 	if deleteDefaultRules {
+		security_group, err := groups.Get(networkingClient, security_group.ID).Extract()
+		if err != nil {
+			return err
+		}
 		for _, rule := range security_group.Rules {
 			if err := rules.Delete(networkingClient, rule.ID).ExtractErr(); err != nil {
 				return fmt.Errorf(


### PR DESCRIPTION
Creating a security group with the attribute delete_default_rules set did not remove the default rules.

This addition makes the provider reread the security group before looping over the rules inside.