### PR TITLE
LBaaS v2: Don't send connection_limit unless it has been set

### DIFF
--- a/openstack/resource_openstack_lb_listener_v2.go
+++ b/openstack/resource_openstack_lb_listener_v2.go
@@ -86,6 +86,7 @@ func resourceListenerV2() *schema.Resource {
 			"connection_limit": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 
 			"default_tls_container_ref": &schema.Schema{
@@ -122,7 +123,6 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	adminStateUp := d.Get("admin_state_up").(bool)
-	connLimit := d.Get("connection_limit").(int)
 	var sniContainerRefs []string
 	if raw, ok := d.GetOk("sni_container_refs"); ok {
 		for _, v := range raw.([]interface{}) {
@@ -137,10 +137,14 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 		Name:                   d.Get("name").(string),
 		DefaultPoolID:          d.Get("default_pool_id").(string),
 		Description:            d.Get("description").(string),
-		ConnLimit:              &connLimit,
 		DefaultTlsContainerRef: d.Get("default_tls_container_ref").(string),
 		SniContainerRefs:       sniContainerRefs,
 		AdminStateUp:           &adminStateUp,
+	}
+
+	if v, ok := d.GetOk("connection_limit"); ok {
+		connectionLimit := v.(int)
+		createOpts.ConnLimit = &connectionLimit
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)

--- a/openstack/resource_openstack_lb_listener_v2_test.go
+++ b/openstack/resource_openstack_lb_listener_v2_test.go
@@ -21,6 +21,8 @@ func TestAccLBV2Listener_basic(t *testing.T) {
 				Config: TestAccLBV2ListenerConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLBV2ListenerExists("openstack_lb_listener_v2.listener_1", &listener),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_listener_v2.listener_1", "connection_limit", "-1"),
 				),
 			},
 			resource.TestStep{


### PR DESCRIPTION
This commit changes the behavior of the `openstack_lb_listener_v2`
resource so that the `connection_limit` argument is not sent
unless it has been explicitly defined in the configuration.

Fixes #87 