### PR TITLE
make it possible to search for non active networks

### DIFF
--- a/openstack/data_source_openstack_networking_network_v2.go
+++ b/openstack/data_source_openstack_networking_network_v2.go
@@ -31,6 +31,10 @@ func dataSourceNetworkingNetworkV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"status": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"matching_subnet_cidr": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -64,7 +68,10 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 		ID:       d.Get("network_id").(string),
 		Name:     d.Get("name").(string),
 		TenantID: d.Get("tenant_id").(string),
-		Status:   "ACTIVE",
+	}
+
+	if v, ok := d.GetOk("status"); ok {
+		listOpts.Status = v.(string)
 	}
 
 	pages, err := networks.List(networkingClient, listOpts).AllPages()

--- a/website/docs/d/networking_network_v2.html.markdown
+++ b/website/docs/d/networking_network_v2.html.markdown
@@ -28,6 +28,8 @@ data "openstack_networking_network_v2" "network" {
 
 * `name` - (Optional) The name of the network.
 
+* `status` - (Optional) The status of the network.
+
 * `matching_subnet_cidr` - (Optional) The CIDR of a subnet within the network.
 
 * `tenant_id` - (Optional) The owner of the network.


### PR DESCRIPTION
Hi all,

my openstack provider for some reasons does not allow to filter the external network by status. So the default filter "&status=ACTIVE" will not show the external network when searching for it. 

I created a new attribute called **only_active**, which can be set to false to remove the ACTIVE filter. If this attribute is not used, it defaults to the ACTIVE filter, so it shouldn't breaking existing terraform scripts.

I am **NOT** a Go programmer, so if this can be done in a more elegant way, just mention it and I will change it accordingly.

Cheers,
Christian