### PR TITLE
Networking v2: Import router interface subnet

### DIFF
--- a/openstack/import_openstack_networking_router_interface_v2_test.go
+++ b/openstack/import_openstack_networking_router_interface_v2_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccNetworkingV2RouterInterface_importBasic(t *testing.T) {
+func TestAccNetworkingV2RouterInterface_importBasic_port(t *testing.T) {
 	resourceName := "openstack_networking_router_interface_v2.int_1"
 
 	resource.Test(t, resource.TestCase{
@@ -16,6 +16,27 @@ func TestAccNetworkingV2RouterInterface_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccNetworkingV2RouterInterface_basic_port,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2RouterInterface_importBasic_subnet(t *testing.T) {
+	resourceName := "openstack_networking_router_interface_v2.int_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2RouterInterfaceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2RouterInterface_basic_subnet,
 			},
 
 			resource.TestStep{

--- a/openstack/resource_openstack_networking_router_interface_v2.go
+++ b/openstack/resource_openstack_networking_router_interface_v2.go
@@ -42,6 +42,7 @@ func resourceNetworkingRouterInterfaceV2() *schema.Resource {
 			"subnet_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"port_id": &schema.Schema{
@@ -112,6 +113,16 @@ func resourceNetworkingRouterInterfaceV2Read(d *schema.ResourceData, meta interf
 
 	d.Set("router_id", n.DeviceID)
 	d.Set("port_id", n.ID)
+
+	// Set the subnet ID by looking at thet port's FixedIPs.
+	// If there's more than one FixedIP, do not set the subnet
+	// as it's not possible to confidently determine which subnet
+	// belongs to this interface. However, that situation should
+	// not happen.
+	if len(n.FixedIPs) == 1 {
+		d.Set("subnet_id", n.FixedIPs[0].SubnetID)
+	}
+
 	d.Set("region", GetRegion(d, config))
 
 	return nil


### PR DESCRIPTION
This commit amends the router interface import feature
by setting the subnet_id when the subnet_id can be
confidently determined.

For #108 