### PR TITLE
Added support for import of router routes

### DIFF
--- a/openstack/import_openstack_networking_router_route_v2_test.go
+++ b/openstack/import_openstack_networking_router_route_v2_test.go
@@ -1,0 +1,28 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccNetworkingV2RouterRoute_importBasic(t *testing.T) {
+	resourceName := "openstack_networking_router_route_v2.router_route_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2RouterRouteDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2RouterRoute_create,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/openstack/resource_openstack_networking_router_route_v2.go
+++ b/openstack/resource_openstack_networking_router_route_v2.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 
@@ -15,6 +16,9 @@ func resourceNetworkingRouterRouteV2() *schema.Resource {
 		Create: resourceNetworkingRouterRouteV2Create,
 		Read:   resourceNetworkingRouterRouteV2Read,
 		Delete: resourceNetworkingRouterRouteV2Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{
@@ -115,6 +119,26 @@ func resourceNetworkingRouterRouteV2Read(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
+	destCidr := d.Get("destination_cidr").(string)
+	nextHop := d.Get("next_hop").(string)
+
+	routeIDParts := []string{}
+	if d.Id() != "" && strings.Contains(d.Id(), "-route-") {
+		routeIDParts = strings.Split(d.Id(), "-route-")
+		routeLastIDParts := strings.Split(routeIDParts[1], "-")
+
+		if routerId == "" {
+			routerId = routeIDParts[0]
+			d.Set("router_id", routerId)
+		}
+		if destCidr == "" {
+			destCidr = routeLastIDParts[0]
+		}
+		if nextHop == "" {
+			nextHop = routeLastIDParts[1]
+		}
+	}
+
 	n, err := routers.Get(networkingClient, routerId).Extract()
 	if err != nil {
 		if _, ok := err.(gophercloud.ErrDefault404); ok {
@@ -126,9 +150,6 @@ func resourceNetworkingRouterRouteV2Read(d *schema.ResourceData, meta interface{
 	}
 
 	log.Printf("[DEBUG] Retrieved Router %s: %+v", routerId, n)
-
-	var destCidr string = d.Get("destination_cidr").(string)
-	var nextHop string = d.Get("next_hop").(string)
 
 	d.Set("next_hop", "")
 	d.Set("destination_cidr", "")

--- a/website/docs/r/networking_router_route_v2.html.markdown
+++ b/website/docs/r/networking_router_route_v2.html.markdown
@@ -74,3 +74,11 @@ The following attributes are exported:
 The `next_hop` IP address must be directly reachable from the router at the ``openstack_networking_router_route_v2``
 resource creation time.  You can ensure that by explicitly specifying a dependency on the ``openstack_networking_router_interface_v2``
 resource that connects the next hop to the router, as in the example above.
+
+## Import
+
+Routing entries can be imported using a combined ID using the following format: ``<router_id>-route-<destination_cidr>-<next_hop>``
+
+```
+$ terraform import openstack_networking_router_route_v2.router_route_1 686fe248-386c-4f70-9f6c-281607dad079-route-10.0.1.0/24-192.168.199.25
+```


### PR DESCRIPTION
Added support for import of router routes (#108)

TestAcc passed: 
```shell
$ make testacc TEST=./openstack TESTARGS="-run TestAccNetworkingV2RouterRoute_importBasic"
=== RUN   TestAccNetworkingV2RouterRoute_importBasic
--- PASS: TestAccNetworkingV2RouterRoute_importBasic (73.31s)
PASS
ok      github.com/terraform-providers/terraform-provider-openstack/openstack   73.400s
```