### PR TITLE
Fix Security Group setting on an OpenStack LBaaS

### DIFF
--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/requests.go
@@ -120,7 +120,7 @@ type UpdateOpts struct {
 	DeviceID            string        `json:"device_id,omitempty"`
 	DeviceOwner         string        `json:"device_owner,omitempty"`
 	SecurityGroups      []string      `json:"security_groups"`
-	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs"`
+	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs,omitempty"`
 }
 
 // ToPortUpdateMap casts an UpdateOpts struct to a map.


### PR DESCRIPTION
Using the `security_group_ids` parameter of an `openstack_lb_loadbalancer_v2` resource
leads to an `Invalid request due to incorrect syntax or missing required parameters.`
error message.

This is because terraform sends, in its request to OpenStack, an `allowed_address_pairs`
field with a value of `null` whereas OpenStack expects a list.

This change fixes the issue by not sending this field anymore.

Fixes #126