### PR TITLE
openstack_networking_router: enable/disable snat

### DIFF
--- a/openstack/resource_openstack_networking_router_v2.go
+++ b/openstack/resource_openstack_networking_router_v2.go
@@ -57,6 +57,12 @@ func resourceNetworkingRouterV2() *schema.Resource {
 				ForceNew: false,
 				Computed: true,
 			},
+			"enable_snat": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
 			"tenant_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -103,6 +109,14 @@ func resourceNetworkingRouterV2Create(d *schema.ResourceData, meta interface{}) 
 			NetworkID: externalGateway,
 		}
 		createOpts.GatewayInfo = &gatewayInfo
+	}
+
+	if esRaw, ok := d.GetOk("enable_snat"); ok {
+		if externalGateway == "" {
+			return fmt.Errorf("Error setting enable_snat: option requires external_gateway to be set")
+		}
+		es := esRaw.(bool)
+		createOpts.GatewayInfo.EnableSNAT = &es
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
@@ -153,6 +167,7 @@ func resourceNetworkingRouterV2Read(d *schema.ResourceData, meta interface{}) er
 	d.Set("distributed", n.Distributed)
 	d.Set("tenant_id", n.TenantID)
 	d.Set("external_gateway", n.GatewayInfo.NetworkID)
+	d.Set("enable_snat", n.GatewayInfo.EnableSNAT)
 	d.Set("region", GetRegion(d, config))
 
 	return nil
@@ -177,13 +192,22 @@ func resourceNetworkingRouterV2Update(d *schema.ResourceData, meta interface{}) 
 		asu := d.Get("admin_state_up").(bool)
 		updateOpts.AdminStateUp = &asu
 	}
+
+	gatewayInfo := routers.GatewayInfo{}
+	externalGateway := d.Get("external_gateway").(string)
+	if externalGateway != "" {
+		gatewayInfo.NetworkID = externalGateway
+	}
 	if d.HasChange("external_gateway") {
-		externalGateway := d.Get("external_gateway").(string)
-		if externalGateway != "" {
-			gatewayInfo := routers.GatewayInfo{
-				NetworkID: externalGateway,
-			}
+		updateOpts.GatewayInfo = &gatewayInfo
+	}
+	if d.HasChange("enable_snat") {
+		enableSNAT := d.Get("enable_snat").(bool)
+		gatewayInfo.EnableSNAT = &enableSNAT
+		if gatewayInfo.NetworkID != "" {
 			updateOpts.GatewayInfo = &gatewayInfo
+		} else {
+			return fmt.Errorf("Error setting enable_snat: option requires external_gateway to be set")
 		}
 	}
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/doc.go
@@ -1,0 +1,108 @@
+/*
+Package routers enables management and retrieval of Routers from the OpenStack
+Networking service.
+
+Example to List Routers
+
+	listOpts := routers.ListOpts{}
+	allPages, err := routers.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allRouters, err := routers.ExtractRouters(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, router := range allRoutes {
+		fmt.Printf("%+v\n", router)
+	}
+
+Example to Create a Router
+
+	iTrue := true
+	gwi := routers.GatewayInfo{
+		NetworkID: "8ca37218-28ff-41cb-9b10-039601ea7e6b",
+	}
+
+	createOpts := routers.CreateOpts{
+		Name:         "router_1",
+		AdminStateUp: &iTrue,
+		GatewayInfo:  &gwi,
+	}
+
+	router, err := routers.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Router
+
+	routerID := "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
+
+	routes := []routers.Route{{
+		DestinationCIDR: "40.0.1.0/24",
+		NextHop:         "10.1.0.10",
+	}}
+
+	updateOpts := routers.UpdateOpts{
+		Name:   "new_name",
+		Routes: routes,
+	}
+
+	router, err := routers.Update(networkClient, routerID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Remove all Routes from a Router
+
+	routerID := "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
+
+	routes := []routers.Route{}
+
+	updateOpts := routers.UpdateOpts{
+		Routes: routes,
+	}
+
+	router, err := routers.Update(networkClient, routerID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Router
+
+	routerID := "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
+	err := routers.Delete(networkClient, routerID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Add an Interface to a Router
+
+	routerID := "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
+
+	intOpts := routers.AddInterfaceOpts{
+		SubnetID: "a2f1f29d-571b-4533-907f-5803ab96ead1",
+	}
+
+	interface, err := routers.AddInterface(networkClient, routerID, intOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Remove an Interface from a Router
+
+	routerID := "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
+
+	intOpts := routers.RemoveInterfaceOpts{
+		SubnetID: "a2f1f29d-571b-4533-907f-5803ab96ead1",
+	}
+
+	interface, err := routers.RemoveInterface(networkClient, routerID, intOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
+package routers

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/requests.go
@@ -40,10 +40,8 @@ func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
 	})
 }
 
-// CreateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Create operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToRouterCreateMap() (map[string]interface{}, error)
 }
@@ -58,6 +56,7 @@ type CreateOpts struct {
 	GatewayInfo  *GatewayInfo `json:"external_gateway_info,omitempty"`
 }
 
+// ToRouterCreateMap builds a create request body from CreateOpts.
 func (opts CreateOpts) ToRouterCreateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "router")
 }
@@ -86,6 +85,8 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToRouterUpdateMap() (map[string]interface{}, error)
 }
@@ -99,6 +100,7 @@ type UpdateOpts struct {
 	Routes       []Route      `json:"routes"`
 }
 
+// ToRouterUpdateMap builds an update body based on UpdateOpts.
 func (opts UpdateOpts) ToRouterUpdateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "router")
 }
@@ -126,21 +128,19 @@ func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	return
 }
 
-// AddInterfaceOptsBuilder is what types must satisfy to be used as AddInterface
-// options.
+// AddInterfaceOptsBuilder allows extensions to add additional parameters to
+// the AddInterface request.
 type AddInterfaceOptsBuilder interface {
 	ToRouterAddInterfaceMap() (map[string]interface{}, error)
 }
 
-// AddInterfaceOpts allow you to work with operations that either add
-// an internal interface from a router.
+// AddInterfaceOpts represents the options for adding an interface to a router.
 type AddInterfaceOpts struct {
 	SubnetID string `json:"subnet_id,omitempty" xor:"PortID"`
 	PortID   string `json:"port_id,omitempty" xor:"SubnetID"`
 }
 
-// ToRouterAddInterfaceMap allows InterfaceOpts to satisfy the InterfaceOptsBuilder
-// interface
+// ToRouterAddInterfaceMap builds a request body from AddInterfaceOpts.
 func (opts AddInterfaceOpts) ToRouterAddInterfaceMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "")
 }
@@ -178,21 +178,21 @@ func AddInterface(c *gophercloud.ServiceClient, id string, opts AddInterfaceOpts
 	return
 }
 
-// RemoveInterfaceOptsBuilder is what types must satisfy to be used as RemoveInterface
-// options.
+// RemoveInterfaceOptsBuilder allows extensions to add additional parameters to
+// the RemoveInterface request.
 type RemoveInterfaceOptsBuilder interface {
 	ToRouterRemoveInterfaceMap() (map[string]interface{}, error)
 }
 
-// RemoveInterfaceOpts allow you to work with operations that either add or remote
-// an internal interface from a router.
+// RemoveInterfaceOpts represents options for removing an interface from
+// a router.
 type RemoveInterfaceOpts struct {
 	SubnetID string `json:"subnet_id,omitempty" or:"PortID"`
 	PortID   string `json:"port_id,omitempty" or:"SubnetID"`
 }
 
-// ToRouterRemoveInterfaceMap allows RemoveInterfaceOpts to satisfy the RemoveInterfaceOptsBuilder
-// interface
+// ToRouterRemoveInterfaceMap builds a request body based on
+// RemoveInterfaceOpts.
 func (opts RemoveInterfaceOpts) ToRouterRemoveInterfaceMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "")
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/results.go
@@ -8,7 +8,16 @@ import (
 // GatewayInfo represents the information of an external gateway for any
 // particular network router.
 type GatewayInfo struct {
-	NetworkID string `json:"network_id"`
+	NetworkID        string            `json:"network_id"`
+	EnableSNAT       *bool             `json:"enable_snat,omitempty"`
+	ExternalFixedIPs []ExternalFixedIP `json:"external_fixed_ips,omitempty"`
+}
+
+// ExternalFixedIP is the IP address and subnet ID of the external gateway of a
+// router.
+type ExternalFixedIP struct {
+	IPAddress string `json:"ip_address"`
+	SubnetID  string `json:"subnet_id"`
 }
 
 // Route is a possible route in a router.
@@ -26,28 +35,30 @@ type Route struct {
 // whenever a router is associated with a subnet, a port for that router
 // interface is added to the subnet's network.
 type Router struct {
-	// Indicates whether or not a router is currently operational.
+	// Status indicates whether or not a router is currently operational.
 	Status string `json:"status"`
 
-	// Information on external gateway for the router.
+	// GateayInfo provides information on external gateway for the router.
 	GatewayInfo GatewayInfo `json:"external_gateway_info"`
 
-	// Administrative state of the router.
+	// AdminStateUp is the administrative state of the router.
 	AdminStateUp bool `json:"admin_state_up"`
 
-	// Whether router is disitrubted or not..
+	// Distributed is whether router is disitrubted or not.
 	Distributed bool `json:"distributed"`
 
-	// Human readable name for the router. Does not have to be unique.
+	// Name is the human readable name for the router. It does not have to be
+	// unique.
 	Name string `json:"name"`
 
-	// Unique identifier for the router.
+	// ID is the unique identifier for the router.
 	ID string `json:"id"`
 
-	// Owner of the router. Only admin users can specify a tenant identifier
-	// other than its own.
+	// TenantID is the owner of the router. Only admin users can specify a tenant
+	// identifier other than its own.
 	TenantID string `json:"tenant_id"`
 
+	// Routes are a collection of static routes that the router will host.
 	Routes []Route `json:"routes"`
 }
 
@@ -101,22 +112,26 @@ func (r commonResult) Extract() (*Router, error) {
 	return s.Router, err
 }
 
-// CreateResult represents the result of a create operation.
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Router.
 type CreateResult struct {
 	commonResult
 }
 
-// GetResult represents the result of a get operation.
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Router.
 type GetResult struct {
 	commonResult
 }
 
-// UpdateResult represents the result of an update operation.
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Router.
 type UpdateResult struct {
 	commonResult
 }
 
-// DeleteResult represents the result of a delete operation.
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
@@ -125,21 +140,22 @@ type DeleteResult struct {
 // mentioned above, in order for a router to forward to a subnet, it needs an
 // interface.
 type InterfaceInfo struct {
-	// The ID of the subnet which this interface is associated with.
+	// SubnetID is the ID of the subnet which this interface is associated with.
 	SubnetID string `json:"subnet_id"`
 
-	// The ID of the port that is a part of the subnet.
+	// PortID is the ID of the port that is a part of the subnet.
 	PortID string `json:"port_id"`
 
-	// The UUID of the interface.
+	// ID is the UUID of the interface.
 	ID string `json:"id"`
 
-	// Owner of the interface.
+	// TenantID is the owner of the interface.
 	TenantID string `json:"tenant_id"`
 }
 
 // InterfaceResult represents the result of interface operations, such as
-// AddInterface() and RemoveInterface().
+// AddInterface() and RemoveInterface(). Call its Extract method to interpret
+// the result as a InterfaceInfo.
 type InterfaceResult struct {
 	gophercloud.Result
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -439,10 +439,10 @@
 			"revisionTime": "2017-03-10T01:59:53Z"
 		},
 		{
-			"checksumSHA1": "Mjt7GwFygyqPxygY8xZZnUasHmk=",
+			"checksumSHA1": "MwH3GAr/ULiw/D2slN4vxYjQDjI=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "d6667ee368f58dfeeb69ae9c11ba37f9fc7e0c58",
+			"revisionTime": "2017-10-27T02:34:43Z"
 		},
 		{
 			"checksumSHA1": "mCTz2rnyVfhjJ+AD/WihCNcYWiY=",

--- a/website/docs/r/networking_router_v2.html.markdown
+++ b/website/docs/r/networking_router_v2.html.markdown
@@ -44,6 +44,11 @@ The following arguments are supported:
     instances or load balancers will be using floating IPs. Changing this
     updates the `external_gateway` of an existing router.
 
+* `enable_snat` - (Optional) Enable Source NAT for the router.
+    (must be "true" or "false" if provided). An `external_gateway` has to be 
+    set in order to set the `enable_snat` property. Changing this
+    updates the `enable_snat` of an existing router.
+
 * `tenant_id` - (Optional) The owner of the floating IP. Required if admin wants
     to create a router for another tenant. Changing this creates a new router.
 
@@ -58,6 +63,7 @@ The following attributes are exported:
 * `name` - See Argument Reference above.
 * `admin_state_up` - See Argument Reference above.
 * `external_gateway` - See Argument Reference above.
+* `enable_snat` - See Argument Reference above.
 * `tenant_id` - See Argument Reference above.
 * `value_specs` - See Argument Reference above.
 


### PR DESCRIPTION
Hi!

This is for #134

This PR adds the `enable_snat` property to the networking_router_v2 resource to enable/disable snat for neutron routers.

I've testet this against my openstack provider and it works fine! But again, I don't really know GO, so if this can be done more elegant, I'm open for suggestions :)

I am also not sure if it is the right thing to raise an error if `external_gateway` is not set, or if I should just ignore the parameter in that case.

Cheers,
Christian