### PR TITLE
DNS v2: Skip Zone data source acceptance test

### DIFF
--- a/openstack/data_source_openstack_dns_zone_v2_test.go
+++ b/openstack/data_source_openstack_dns_zone_v2_test.go
@@ -13,7 +13,7 @@ var zoneName = fmt.Sprintf("ACPTTEST%s.com.", acctest.RandString(5))
 
 func TestAccOpenStackDNSZoneV2DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckDNS(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{


### PR DESCRIPTION
The OpenStack environment used for testing doesn't support Designate yet. 