### PR TITLE
Make a unique hash by adding the MAC address so that the same IP addr…

### DIFF
--- a/openstack/resource_openstack_networking_port_v2.go
+++ b/openstack/resource_openstack_networking_port_v2.go
@@ -418,7 +418,7 @@ func resourcePortAdminStateUpV2(d *schema.ResourceData) *bool {
 func allowedAddressPairsHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s", m["ip_address"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-%s", m["ip_address"].(string), m["mac_address"].(string)))
 
 	return hashcode.String(buf.String())
 }


### PR DESCRIPTION
…ess can be used multiple times

It may be needed to add the same ip_address in allow_address_pairs with a different mac_address.
The actual code can't as the hash is only generated on the ip_address. This fixes the issue by adding the hash of the mac_address used as well.