### PR TITLE
Networking v2: Updates to openstack_networking_router_v2

### DIFF
--- a/openstack/resource_openstack_networking_router_v2.go
+++ b/openstack/resource_openstack_networking_router_v2.go
@@ -52,16 +52,43 @@ func resourceNetworkingRouterV2() *schema.Resource {
 				Computed: true,
 			},
 			"external_gateway": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: false,
-				Computed: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      false,
+				Computed:      true,
+				Deprecated:    "use external_network_id instead",
+				ConflictsWith: []string{"external_network_id"},
+			},
+			"external_network_id": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      false,
+				Computed:      true,
+				ConflictsWith: []string{"external_gateway"},
 			},
 			"enable_snat": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: false,
 				Computed: true,
+			},
+			"external_fixed_ip": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"subnet_id": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"ip_address": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
 			},
 			"tenant_id": &schema.Schema{
 				Type:     schema.TypeString,
@@ -103,20 +130,37 @@ func resourceNetworkingRouterV2Create(d *schema.ResourceData, meta interface{}) 
 		createOpts.Distributed = &d
 	}
 
-	externalGateway := d.Get("external_gateway").(string)
-	if externalGateway != "" {
+	// Gateway settings
+	var externalNetworkID string
+	if v := d.Get("external_gateway").(string); v != "" {
+		externalNetworkID = v
+	}
+
+	if v := d.Get("external_network_id").(string); v != "" {
+		externalNetworkID = v
+	}
+
+	if externalNetworkID != "" {
 		gatewayInfo := routers.GatewayInfo{
-			NetworkID: externalGateway,
+			NetworkID: externalNetworkID,
 		}
 		createOpts.GatewayInfo = &gatewayInfo
 	}
 
 	if esRaw, ok := d.GetOk("enable_snat"); ok {
-		if externalGateway == "" {
-			return fmt.Errorf("Error setting enable_snat: option requires external_gateway to be set")
+		if externalNetworkID == "" {
+			return fmt.Errorf("setting enable_snat requires external_network_id to be set")
 		}
 		es := esRaw.(bool)
 		createOpts.GatewayInfo.EnableSNAT = &es
+	}
+
+	externalFixedIPs := resourceRouterExternalFixedIPsV2(d)
+	if len(externalFixedIPs) > 0 {
+		if externalNetworkID == "" {
+			return fmt.Errorf("setting an external_fixed_ip requires external_network_id to be set")
+		}
+		createOpts.GatewayInfo.ExternalFixedIPs = externalFixedIPs
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
@@ -166,9 +210,24 @@ func resourceNetworkingRouterV2Read(d *schema.ResourceData, meta interface{}) er
 	d.Set("admin_state_up", n.AdminStateUp)
 	d.Set("distributed", n.Distributed)
 	d.Set("tenant_id", n.TenantID)
-	d.Set("external_gateway", n.GatewayInfo.NetworkID)
-	d.Set("enable_snat", n.GatewayInfo.EnableSNAT)
 	d.Set("region", GetRegion(d, config))
+
+	// Gateway settings
+	d.Set("external_gateway", n.GatewayInfo.NetworkID)
+	d.Set("external_network_id", n.GatewayInfo.NetworkID)
+	d.Set("enable_snat", n.GatewayInfo.EnableSNAT)
+
+	var externalFixedIPs []map[string]string
+	for _, v := range n.GatewayInfo.ExternalFixedIPs {
+		externalFixedIPs = append(externalFixedIPs, map[string]string{
+			"subnet_id":  v.SubnetID,
+			"ip_address": v.IPAddress,
+		})
+	}
+
+	if err = d.Set("external_fixed_ip", externalFixedIPs); err != nil {
+		log.Printf("[DEBUG] unable to set external_fixed_ip: %s", err)
+	}
 
 	return nil
 }
@@ -193,22 +252,55 @@ func resourceNetworkingRouterV2Update(d *schema.ResourceData, meta interface{}) 
 		updateOpts.AdminStateUp = &asu
 	}
 
+	// Gateway settings
+	var updateGatewaySettings bool
+	var externalNetworkID string
 	gatewayInfo := routers.GatewayInfo{}
-	externalGateway := d.Get("external_gateway").(string)
-	if externalGateway != "" {
-		gatewayInfo.NetworkID = externalGateway
+
+	if v := d.Get("external_gateway").(string); v != "" {
+		externalNetworkID = v
 	}
+
+	if v := d.Get("external_network_id").(string); v != "" {
+		externalNetworkID = v
+	}
+
+	if externalNetworkID != "" {
+		gatewayInfo.NetworkID = externalNetworkID
+	}
+
 	if d.HasChange("external_gateway") {
-		updateOpts.GatewayInfo = &gatewayInfo
+		updateGatewaySettings = true
 	}
+
+	if d.HasChange("external_network_id") {
+		updateGatewaySettings = true
+	}
+
 	if d.HasChange("enable_snat") {
+		updateGatewaySettings = true
+		if externalNetworkID == "" {
+			return fmt.Errorf("setting enable_snat requires external_network_id to be set")
+		}
+
 		enableSNAT := d.Get("enable_snat").(bool)
 		gatewayInfo.EnableSNAT = &enableSNAT
-		if gatewayInfo.NetworkID != "" {
-			updateOpts.GatewayInfo = &gatewayInfo
-		} else {
-			return fmt.Errorf("Error setting enable_snat: option requires external_gateway to be set")
+	}
+
+	if d.HasChange("external_fixed_ip") {
+		updateGatewaySettings = true
+
+		externalFixedIPs := resourceRouterExternalFixedIPsV2(d)
+		gatewayInfo.ExternalFixedIPs = externalFixedIPs
+		if len(externalFixedIPs) > 0 {
+			if externalNetworkID == "" {
+				return fmt.Errorf("setting an external_fixed_ip requires external_network_id to be set")
+			}
 		}
+	}
+
+	if updateGatewaySettings {
+		updateOpts.GatewayInfo = &gatewayInfo
 	}
 
 	log.Printf("[DEBUG] Updating Router %s with options: %+v", d.Id(), updateOpts)
@@ -283,4 +375,20 @@ func waitForRouterDelete(networkingClient *gophercloud.ServiceClient, routerId s
 		log.Printf("[DEBUG] OpenStack Router %s still active.\n", routerId)
 		return r, "ACTIVE", nil
 	}
+}
+
+func resourceRouterExternalFixedIPsV2(d *schema.ResourceData) []routers.ExternalFixedIP {
+	var externalFixedIPs []routers.ExternalFixedIP
+	eFIPs := d.Get("external_fixed_ip").([]interface{})
+
+	for _, eFIP := range eFIPs {
+		v := eFIP.(map[string]interface{})
+		fip := routers.ExternalFixedIP{
+			SubnetID:  v["subnet_id"].(string),
+			IPAddress: v["ip_address"].(string),
+		}
+		externalFixedIPs = append(externalFixedIPs, fip)
+	}
+
+	return externalFixedIPs
 }

--- a/openstack/resource_openstack_networking_router_v2_test.go
+++ b/openstack/resource_openstack_networking_router_v2_test.go
@@ -35,7 +35,7 @@ func TestAccNetworkingV2Router_basic(t *testing.T) {
 	})
 }
 
-func TestAccNetworkingV2Router_update_external_gw(t *testing.T) {
+func TestAccNetworkingV2Router_updateExternalGateway(t *testing.T) {
 	var router routers.Router
 
 	resource.Test(t, resource.TestCase{
@@ -44,16 +44,16 @@ func TestAccNetworkingV2Router_update_external_gw(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkingV2RouterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccNetworkingV2Router_update_external_gw_1,
+				Config: testAccNetworkingV2Router_updateExternalGateway1,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2RouterExists("openstack_networking_router_v2.router_1", &router),
 				),
 			},
 			resource.TestStep{
-				Config: testAccNetworkingV2Router_update_external_gw_2,
+				Config: testAccNetworkingV2Router_updateExternalGateway2,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"openstack_networking_router_v2.router_1", "external_gateway", OS_EXTGW_ID),
+						"openstack_networking_router_v2.router_1", "external_network_id", OS_EXTGW_ID),
 				),
 			},
 		},
@@ -147,7 +147,7 @@ resource "openstack_networking_router_v2" "router_1" {
 }
 `
 
-const testAccNetworkingV2Router_update_external_gw_1 = `
+const testAccNetworkingV2Router_updateExternalGateway1 = `
 resource "openstack_networking_router_v2" "router_1" {
 	name = "router"
 	admin_state_up = "true"
@@ -155,12 +155,12 @@ resource "openstack_networking_router_v2" "router_1" {
 }
 `
 
-var testAccNetworkingV2Router_update_external_gw_2 = fmt.Sprintf(`
+var testAccNetworkingV2Router_updateExternalGateway2 = fmt.Sprintf(`
 resource "openstack_networking_router_v2" "router_1" {
 	name = "router"
 	admin_state_up = "true"
 	distributed = "false"
-	external_gateway = "%s"
+	external_network_id = "%s"
 }
 `, OS_EXTGW_ID)
 

--- a/website/docs/r/networking_router_v2.html.markdown
+++ b/website/docs/r/networking_router_v2.html.markdown
@@ -14,8 +14,9 @@ Manages a V2 router resource within OpenStack.
 
 ```hcl
 resource "openstack_networking_router_v2" "router_1" {
-  name             = "my_router"
-  external_gateway = "f67f0d72-0ddf-11e4-9d95-e1f29f417e2f"
+  name                = "my_router"
+  admin_state_up      = true
+  external_network_id = "f67f0d72-0ddf-11e4-9d95-e1f29f417e2f"
 }
 ```
 
@@ -39,20 +40,36 @@ The following arguments are supported:
     distributed router. The default policy setting in Neutron restricts
     usage of this property to administrative users only.
 
-* `external_gateway` - (Optional) The network UUID of an external gateway for
-    the router. A router with an external gateway is required if any compute
-    instances or load balancers will be using floating IPs. Changing this
-    updates the `external_gateway` of an existing router.
+* `external_gateway` - (Deprecated - use `external_network_id` instead) The
+    network UUID of an external gateway for the router. A router with an
+    external gateway is required if any compute instances or load balancers
+    will be using floating IPs. Changing this updates the external gateway
+    of an existing router.
 
-* `enable_snat` - (Optional) Enable Source NAT for the router.
-    (must be "true" or "false" if provided). An `external_gateway` has to be 
-    set in order to set the `enable_snat` property. Changing this
-    updates the `enable_snat` of an existing router.
+* `external_network_id` - (Optional) The network UUID of an external gateway
+    for the router. A router with an external gateway is required if any
+    compute instances or load balancers will be using floating IPs. Changing
+    this updates the external gateway of the router.
+
+* `enable_snat` - (Optional) Enable Source NAT for the router. Valid values are
+    "true" or "false". An `external_network_id` has to be set in order to
+    set this property. Changing this updates the `enable_snat` of the router.
+
+* `external_fixed_ip` - (Optional) An external fixed IP for the router. This
+    can be repeated. The structure is described below. An `external_network_id`
+    has to be set in order to set this property. Changing this updates the
+    external fixed IPs of the router.
 
 * `tenant_id` - (Optional) The owner of the floating IP. Required if admin wants
     to create a router for another tenant. Changing this creates a new router.
 
 * `value_specs` - (Optional) Map of additional driver-specific options.
+
+The `external_fixed_ip` block supports:
+
+* `subnet_id` - (Optional) Subnet in which the fixed IP belongs to.
+
+* `ip_address` - (Optional) The IP address to set on the router.
 
 ## Attributes Reference
 
@@ -63,7 +80,9 @@ The following attributes are exported:
 * `name` - See Argument Reference above.
 * `admin_state_up` - See Argument Reference above.
 * `external_gateway` - See Argument Reference above.
+* `external_network_id` - See Argument Reference above.
 * `enable_snat` - See Argument Reference above.
+* `external_fixed_ip` - See Argument Reference above.
 * `tenant_id` - See Argument Reference above.
 * `value_specs` - See Argument Reference above.
 


### PR DESCRIPTION
This commit makes two changes to the openstack_networking_router_v2
resource:

1. Deprecates external_gateway in favor of external_network_id. The
new name provides a better indication of what value should be set.

2. Adds support for external_fixed_ips. These can be specified by
the user as well as are set by the API when not specified.