### PR TITLE
Request to integrate the Openlab CI to Terraform-provider-openstack

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,18 @@
+- project:
+    name: terraform-providers/terraform-provider-openstack
+    check:
+      jobs:
+        - terraform-provider-openstack-unittest
+        - terraform-provider-openstack-acceptance-test
+    recheck-mitaka:
+      jobs:
+        - terraform-provider-openstack-acceptance-test-mitaka
+    recheck-newton:
+      jobs:
+        - terraform-provider-openstack-acceptance-test-newton
+    recheck-ocata:
+      jobs:
+        - terraform-provider-openstack-acceptance-test-ocata
+    recheck-pike:
+      jobs:
+        - terraform-provider-openstack-acceptance-test-pike


### PR DESCRIPTION
I'd like to introduce a CI system "Openlab" into
Terraform-provider-openstack. The Openlab CI system is built based on
zuul[1] and nodepool[2] tools and some other components, it is for
running tests of OpenStack SDKs (e.g.Gophercloud, Terraform) based on a
devstack[3] environment. For more details about Openlab, please see[4].
We have  done the integration of Openlab CI and Gophercloud in
PR[5]. For now, the CI system can also basically work OK with
Terraform-provider-openstack, see[6]. We will long-term maintain the CI
system and would like to integrate the CI system to
Terraform-provider-openstack official repo.

FYI, the zuul jobs definition is in[7], the zuul jobs status web page is
in [8], the logs of testing jobs is in[9].

[1] https://docs.openstack.org/infra/zuul/
[2] https://docs.openstack.org/infra/nodepool/
[3] https://docs.openstack.org/devstack/latest/
[4] http://openlabtesting.org/
[5] https://github.com/gophercloud/gophercloud/pull/593
[6] https://github.com/theopenlab/terraform-provider-openstack/pull/2
[7] https://github.com/theopenlab/openlab-zuul-jobs
[8] http://status.openlabtesting.org/
[9] http://logs.openlabtesting.org/logs/

For #181