### PR TITLE
LBaaSv2: Make subnet_id for members optional

### DIFF
--- a/openstack/resource_openstack_lb_member_v2.go
+++ b/openstack/resource_openstack_lb_member_v2.go
@@ -72,7 +72,7 @@ func resourceMemberV2() *schema.Resource {
 
 			"subnet_id": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 

--- a/website/docs/r/lb_member_v2.html.markdown
+++ b/website/docs/r/lb_member_v2.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 * `pool_id` - (Required) The id of the pool that this member will be
     assigned to.
 
-* `subnet_id` - (Required) The subnet in which to access the member
+* `subnet_id` - (Optional) The subnet in which to access the member
 
 * `name` - (Optional) Human-readable name for the member.
 


### PR DESCRIPTION
Fixes #188 

All signs point to this being correct. It's not required in Gophercloud. In Terraform, we're even checking to see if it's set as if it was an optional parameter:

https://github.com/terraform-providers/terraform-provider-openstack/blob/master/openstack/resource_openstack_lb_member_v2.go#L111-L114