### PR TITLE
Compute v2: Flavor Data Source

### DIFF
--- a/openstack/data_source_openstack_compute_flavor_v2.go
+++ b/openstack/data_source_openstack_compute_flavor_v2.go
@@ -1,0 +1,186 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceComputeFlavorV2() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceComputeFlavorV2Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"min_ram": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"ram": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"vcpus": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"min_disk": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"disk": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"swap": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"rx_tx_factor": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			// Computed values
+			"is_public": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// dataSourceComputeFlavorV2Read performs the image lookup.
+func dataSourceComputeFlavorV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+
+	listOpts := flavors.ListOpts{
+		MinDisk:    d.Get("min_disk").(int),
+		MinRAM:     d.Get("min_ram").(int),
+		AccessType: flavors.PublicAccess,
+	}
+
+	log.Printf("[DEBUG] List Options: %#v", listOpts)
+
+	var flavor flavors.Flavor
+	allPages, err := flavors.ListDetail(computeClient, listOpts).AllPages()
+	if err != nil {
+		return fmt.Errorf("Unable to query flavors: %s", err)
+	}
+
+	allFlavors, err := flavors.ExtractFlavors(allPages)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve flavors: %s", err)
+	}
+
+	// Loop through all flavors to find a more specific one.
+	if len(allFlavors) > 1 {
+		var filteredFlavors []flavors.Flavor
+		for _, flavor := range allFlavors {
+			if v := d.Get("name").(string); v != "" {
+				if flavor.Name != v {
+					continue
+				}
+			}
+
+			// d.GetOk is used because 0 might be a valid choice.
+			if v, ok := d.GetOk("ram"); ok {
+				if flavor.RAM != v.(int) {
+					continue
+				}
+			}
+
+			if v, ok := d.GetOk("vcpus"); ok {
+				if flavor.VCPUs != v.(int) {
+					continue
+				}
+			}
+
+			if v, ok := d.GetOk("disk"); ok {
+				if flavor.Disk != v.(int) {
+					continue
+				}
+			}
+
+			if v, ok := d.GetOk("swap"); ok {
+				if flavor.Swap != v.(int) {
+					continue
+				}
+			}
+
+			if v, ok := d.GetOk("rx_tx_factor"); ok {
+				if flavor.RxTxFactor != v.(float64) {
+					continue
+				}
+			}
+
+			filteredFlavors = append(filteredFlavors, flavor)
+		}
+
+		allFlavors = filteredFlavors
+	}
+
+	if len(allFlavors) < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	if len(allFlavors) > 1 {
+		log.Printf("[DEBUG] Multiple results found: %#v", allFlavors)
+		return fmt.Errorf("Your query returned more than one result. " +
+			"Please try a more specific search criteria")
+	} else {
+		flavor = allFlavors[0]
+	}
+
+	log.Printf("[DEBUG] Single Flavor found: %s", flavor.ID)
+	return dataSourceComputeFlavorV2Attributes(d, &flavor)
+}
+
+// dataSourceComputeFlavorV2Attributes populates the fields of an Image resource.
+func dataSourceComputeFlavorV2Attributes(d *schema.ResourceData, flavor *flavors.Flavor) error {
+	log.Printf("[DEBUG] openstack_compute_flavor_v2 details: %#v", flavor)
+
+	d.SetId(flavor.ID)
+	d.Set("name", flavor.Name)
+	d.Set("disk", flavor.Disk)
+	d.Set("ram", flavor.RAM)
+	d.Set("rx_tx_factor", flavor.RxTxFactor)
+	d.Set("swap", flavor.Swap)
+	d.Set("vcpus", flavor.VCPUs)
+	d.Set("is_public", flavor.IsPublic)
+
+	return nil
+}

--- a/openstack/data_source_openstack_compute_flavor_v2_test.go
+++ b/openstack/data_source_openstack_compute_flavor_v2_test.go
@@ -1,0 +1,165 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccOpenStackComputeV2FlavorDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOpenStackComputeV2FlavorDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2FlavorDataSourceID("data.openstack_compute_flavor_v2.flavor_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "name", "m1.acctest"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "ram", "512"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "disk", "5"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "vcpus", "1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "rx_tx_factor", "1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "is_public", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOpenStackComputeV2FlavorDataSource_testQueries(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOpenStackComputeV2FlavorDataSource_queryDisk,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2FlavorDataSourceID("data.openstack_compute_flavor_v2.flavor_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "name", "m1.acctest"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "ram", "512"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "disk", "5"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "vcpus", "1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "rx_tx_factor", "1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "is_public", "true"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccOpenStackComputeV2FlavorDataSource_queryMinDisk,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2FlavorDataSourceID("data.openstack_compute_flavor_v2.flavor_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "name", "m1.acctest"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "ram", "512"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "disk", "5"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "vcpus", "1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "rx_tx_factor", "1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "is_public", "true"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccOpenStackComputeV2FlavorDataSource_queryMinRAM,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2FlavorDataSourceID("data.openstack_compute_flavor_v2.flavor_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "name", "m1.acctest"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "ram", "512"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "disk", "5"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "vcpus", "1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "rx_tx_factor", "1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "is_public", "true"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccOpenStackComputeV2FlavorDataSource_queryVCPUs,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2FlavorDataSourceID("data.openstack_compute_flavor_v2.flavor_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "name", "m1.acctest"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "ram", "512"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "disk", "5"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "vcpus", "1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "rx_tx_factor", "1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "is_public", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckComputeV2FlavorDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find flavor data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Flavor data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccOpenStackComputeV2FlavorDataSource_basic = `
+data "openstack_compute_flavor_v2" "flavor_1" {
+  name = "m1.acctest"
+}
+`
+
+const testAccOpenStackComputeV2FlavorDataSource_queryDisk = `
+data "openstack_compute_flavor_v2" "flavor_1" {
+  disk = 5
+}
+`
+
+const testAccOpenStackComputeV2FlavorDataSource_queryMinDisk = `
+data "openstack_compute_flavor_v2" "flavor_1" {
+  name = "m1.acctest"
+  min_disk = 5
+}
+`
+
+const testAccOpenStackComputeV2FlavorDataSource_queryMinRAM = `
+data "openstack_compute_flavor_v2" "flavor_1" {
+  name = "m1.acctest"
+  min_ram = 512
+}
+`
+
+const testAccOpenStackComputeV2FlavorDataSource_queryVCPUs = `
+data "openstack_compute_flavor_v2" "flavor_1" {
+  name = "m1.acctest"
+  vcpus = 1
+}
+`

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -156,6 +156,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"openstack_compute_flavor_v2":      dataSourceComputeFlavorV2(),
 			"openstack_dns_zone_v2":            dataSourceDNSZoneV2(),
 			"openstack_images_image_v2":        dataSourceImagesImageV2(),
 			"openstack_networking_network_v2":  dataSourceNetworkingNetworkV2(),

--- a/website/docs/d/compute_flavor_v2.html.markdown
+++ b/website/docs/d/compute_flavor_v2.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_compute_flavor_v2"
+sidebar_current: "docs-openstack-datasource-compute-flavor-v2"
+description: |-
+  Get information on an OpenStack Flavor.
+---
+
+# openstack\_compute\_flavor\_v2
+
+Use this data source to get the ID of an available OpenStack flavor.
+
+## Example Usage
+
+```hcl
+data "openstack_compute_flavor_v2" "small" {
+  vcpus = 1
+  ram   = 512
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional) The region in which to obtain the V2 Compute client.
+    If omitted, the `region` argument of the provider is used.
+
+* `name` - (Optional) The name of the flavor.
+
+* `min_ram` - (Optional) The minimum amount of RAM (in megabytes).
+
+* `ram` - (Optional) The exact amount of RAM (in megabytes).
+
+* `min_disk` - (Optional) The minimum amount of disk (in gigabytes).
+
+* `disk` - (Optional) The exact amount of disk (in gigabytes).
+
+* `vcpus` - (Optional) The amount of VCPUs.
+
+* `swap` - (Optional) The amount of swap (in gigabytes).
+
+* `rx_tx_factor` - (Optional) The `rx_tx_factor` of the flavor.
+
+
+## Attributes Reference
+
+`id` is set to the ID of the found flavor. In addition, the following attributes
+are exported:
+
+* `is_public` - Whether the flavor is public or private.

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -13,6 +13,9 @@
         <li<%= sidebar_current("docs-openstack-datasource") %>>
           <a href="#">Data Sources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-openstack-datasource-compute-flavor-v2") %>>
+              <a href="/docs/providers/openstack/d/compute_flavor_v2.html">openstack_compute_flavor_v2</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-datasource-dns-zone-v2") %>>
               <a href="/docs/providers/openstack/d/dns_zone_v2.html">openstack_dns_zone_v2</a>
             </li>


### PR DESCRIPTION
This commit adds the `openstack_compute_flavor_v2` data source
which enables querying of OpenStack flavors.

Attributes such as ephemeral and "extra" fields are not yet
supported as they need to be added upstream.

Fixes #187 