### PR TITLE
 Support for availability_zone_hints for networks

### DIFF
--- a/openstack/data_source_openstack_networking_network_v2.go
+++ b/openstack/data_source_openstack_networking_network_v2.go
@@ -57,7 +57,7 @@ func dataSourceNetworkingNetworkV2() *schema.Resource {
 				Computed: true,
 			},
 			"availability_zone_hints": &schema.Schema{
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,

--- a/openstack/data_source_openstack_networking_network_v2.go
+++ b/openstack/data_source_openstack_networking_network_v2.go
@@ -56,6 +56,12 @@ func dataSourceNetworkingNetworkV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"availability_zone_hints": &schema.Schema{
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
 		},
 	}
 }
@@ -111,6 +117,11 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 	}
 
 	network := refinedNetworks[0]
+
+	err = d.Set("availability_zone_hints", network.AvailabilityZoneHints)
+	if err != nil {
+		log.Printf("[DEBUG] Unable to set availability_zone_hints: %s", err)
+	}
 
 	log.Printf("[DEBUG] Retrieved Network %s: %+v", network.ID, network)
 	d.SetId(network.ID)

--- a/openstack/data_source_openstack_networking_network_v2.go
+++ b/openstack/data_source_openstack_networking_network_v2.go
@@ -60,7 +60,6 @@ func dataSourceNetworkingNetworkV2() *schema.Resource {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 			},
 		},
 	}
@@ -118,8 +117,7 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 
 	network := refinedNetworks[0]
 
-	err = d.Set("availability_zone_hints", network.AvailabilityZoneHints)
-	if err != nil {
+	if err = d.Set("availability_zone_hints", network.AvailabilityZoneHints); err != nil {
 		log.Printf("[DEBUG] Unable to set availability_zone_hints: %s", err)
 	}
 

--- a/openstack/resource_openstack_networking_network_v2.go
+++ b/openstack/resource_openstack_networking_network_v2.go
@@ -192,7 +192,10 @@ func resourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{}) e
 	d.Set("shared", strconv.FormatBool(n.Shared))
 	d.Set("tenant_id", n.TenantID)
 	d.Set("region", GetRegion(d, config))
-	d.Set("availability_zone_hints", n.AvailabilityZoneHints)
+
+	if err := d.Set("availability_zone_hints", n.AvailabilityZoneHints); err != nil {
+		log.Printf("[DEBUG] unable to set availability_zone_hints: %s", err)
+	}
 
 	return nil
 }

--- a/openstack/resource_openstack_networking_network_v2.go
+++ b/openstack/resource_openstack_networking_network_v2.go
@@ -89,12 +89,11 @@ func resourceNetworkingNetworkV2() *schema.Resource {
 				ForceNew: true,
 			},
 			"availability_zone_hints": &schema.Schema{
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				ForceNew: true,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 			},
 		},
 	}
@@ -291,9 +290,9 @@ func resourceNetworkingNetworkV2Segments(d *schema.ResourceData) (providerSegmen
 }
 
 func resourceNetworkingNetworkAvailabilityZoneHintsV2(d *schema.ResourceData) []string {
-	rawAZH := d.Get("availability_zone_hints").(*schema.Set)
-	azh := make([]string, rawAZH.Len())
-	for i, raw := range rawAZH.List() {
+	rawAZH := d.Get("availability_zone_hints").([]interface{})
+	azh := make([]string, len(rawAZH))
+	for i, raw := range rawAZH {
 		azh[i] = raw.(string)
 	}
 	return azh

--- a/openstack/resource_openstack_networking_network_v2.go
+++ b/openstack/resource_openstack_networking_network_v2.go
@@ -88,6 +88,14 @@ func resourceNetworkingNetworkV2() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"availability_zone_hints": &schema.Schema{
+				Type:     schema.TypeSet,
+				Computed: true,
+				ForceNew: true,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
 		},
 	}
 }
@@ -101,8 +109,9 @@ func resourceNetworkingNetworkV2Create(d *schema.ResourceData, meta interface{})
 
 	createOpts := NetworkCreateOpts{
 		networks.CreateOpts{
-			Name:     d.Get("name").(string),
-			TenantID: d.Get("tenant_id").(string),
+			Name:                  d.Get("name").(string),
+			TenantID:              d.Get("tenant_id").(string),
+			AvailabilityZoneHints: resourceNetworkingNetworkAvailabilityZoneHintsV2(d),
 		},
 		MapValueSpecs(d),
 	}
@@ -183,6 +192,7 @@ func resourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{}) e
 	d.Set("shared", strconv.FormatBool(n.Shared))
 	d.Set("tenant_id", n.TenantID)
 	d.Set("region", GetRegion(d, config))
+	d.Set("availability_zone_hints", n.AvailabilityZoneHints)
 
 	return nil
 }
@@ -275,6 +285,15 @@ func resourceNetworkingNetworkV2Segments(d *schema.ResourceData) (providerSegmen
 		providerSegments = append(providerSegments, segment)
 	}
 	return
+}
+
+func resourceNetworkingNetworkAvailabilityZoneHintsV2(d *schema.ResourceData) []string {
+	rawAZH := d.Get("availability_zone_hints").(*schema.Set)
+	azh := make([]string, rawAZH.Len())
+	for i, raw := range rawAZH.List() {
+		azh[i] = raw.(string)
+	}
+	return azh
 }
 
 func waitForNetworkActive(networkingClient *gophercloud.ServiceClient, networkId string) resource.StateRefreshFunc {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/doc.go
@@ -1,9 +1,65 @@
-// Package networks contains functionality for working with Neutron network
-// resources. A network is an isolated virtual layer-2 broadcast domain that is
-// typically reserved for the tenant who created it (unless you configure the
-// network to be shared). Tenants can create multiple networks until the
-// thresholds per-tenant quota is reached.
-//
-// In the v2.0 Networking API, the network is the main entity. Ports and subnets
-// are always associated with a network.
+/*
+Package networks contains functionality for working with Neutron network
+resources. A network is an isolated virtual layer-2 broadcast domain that is
+typically reserved for the tenant who created it (unless you configure the
+network to be shared). Tenants can create multiple networks until the
+thresholds per-tenant quota is reached.
+
+In the v2.0 Networking API, the network is the main entity. Ports and subnets
+are always associated with a network.
+
+Example to List Networks
+
+	listOpts := networks.ListOpts{
+		TenantID: "a99e9b4e620e4db09a2dfb6e42a01e66",
+	}
+
+	allPages, err := networks.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allNetworks, err := networks.ExtractNetworks(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, network := range allNetworks {
+		fmt.Printf("%+v", network)
+	}
+
+Example to Create a Network
+
+	iTrue := true
+	createOpts := networks.CreateOpts{
+		Name:         "network_1",
+		AdminStateUp: &iTrue,
+	}
+
+	network, err := networks.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Network
+
+	networkID := "484cda0e-106f-4f4b-bb3f-d413710bbe78"
+
+	updateOpts := networks.UpdateOpts{
+		Name: "new_name",
+	}
+
+	network, err := networks.Update(networkClient, networkID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Network
+
+	networkID := "484cda0e-106f-4f4b-bb3f-d413710bbe78"
+	err := networks.Delete(networkClient, networkID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
 package networks

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/requests.go
@@ -58,23 +58,22 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
-// CreateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Create operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToNetworkCreateMap() (map[string]interface{}, error)
 }
 
-// CreateOpts satisfies the CreateOptsBuilder interface
+// CreateOpts represents options used to create a network.
 type CreateOpts struct {
-	AdminStateUp *bool  `json:"admin_state_up,omitempty"`
-	Name         string `json:"name,omitempty"`
-	Shared       *bool  `json:"shared,omitempty"`
-	TenantID     string `json:"tenant_id,omitempty"`
+	AdminStateUp          *bool    `json:"admin_state_up,omitempty"`
+	Name                  string   `json:"name,omitempty"`
+	Shared                *bool    `json:"shared,omitempty"`
+	TenantID              string   `json:"tenant_id,omitempty"`
+	AvailabilityZoneHints []string `json:"availability_zone_hints,omitempty"`
 }
 
-// ToNetworkCreateMap casts a CreateOpts struct to a map.
+// ToNetworkCreateMap builds a request body from CreateOpts.
 func (opts CreateOpts) ToNetworkCreateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "network")
 }
@@ -96,22 +95,20 @@ func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResul
 	return
 }
 
-// UpdateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Update operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToNetworkUpdateMap() (map[string]interface{}, error)
 }
 
-// UpdateOpts satisfies the UpdateOptsBuilder interface
+// UpdateOpts represents options used to update a network.
 type UpdateOpts struct {
 	AdminStateUp *bool  `json:"admin_state_up,omitempty"`
 	Name         string `json:"name,omitempty"`
 	Shared       *bool  `json:"shared,omitempty"`
 }
 
-// ToNetworkUpdateMap casts a UpdateOpts struct to a map.
+// ToNetworkUpdateMap builds a request body from UpdateOpts.
 func (opts UpdateOpts) ToNetworkUpdateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "network")
 }
@@ -136,7 +133,8 @@ func Delete(c *gophercloud.ServiceClient, networkID string) (r DeleteResult) {
 	return
 }
 
-// IDFromName is a convenience function that returns a network's ID given its name.
+// IDFromName is a convenience function that returns a network's ID, given
+// its name.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/results.go
@@ -11,29 +11,35 @@ type commonResult struct {
 
 // Extract is a function that accepts a result and extracts a network resource.
 func (r commonResult) Extract() (*Network, error) {
-	var s struct {
-		Network *Network `json:"network"`
-	}
+	var s Network
 	err := r.ExtractInto(&s)
-	return s.Network, err
+	return &s, err
 }
 
-// CreateResult represents the result of a create operation.
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "network")
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Network.
 type CreateResult struct {
 	commonResult
 }
 
-// GetResult represents the result of a get operation.
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Network.
 type GetResult struct {
 	commonResult
 }
 
-// UpdateResult represents the result of an update operation.
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Network.
 type UpdateResult struct {
 	commonResult
 }
 
-// DeleteResult represents the result of a delete operation.
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
@@ -46,21 +52,27 @@ type Network struct {
 	// Human-readable name for the network. Might not be unique.
 	Name string `json:"name"`
 
-	// The administrative state of network. If false (down), the network does not forward packets.
+	// The administrative state of network. If false (down), the network does not
+	// forward packets.
 	AdminStateUp bool `json:"admin_state_up"`
 
 	// Indicates whether network is currently operational. Possible values include
-	// `ACTIVE', `DOWN', `BUILD', or `ERROR'. Plug-ins might define additional values.
+	// `ACTIVE', `DOWN', `BUILD', or `ERROR'. Plug-ins might define additional
+	// values.
 	Status string `json:"status"`
 
 	// Subnets associated with this network.
 	Subnets []string `json:"subnets"`
 
-	// Owner of network. Only admin users can specify a tenant_id other than its own.
+	// Owner of network.
 	TenantID string `json:"tenant_id"`
 
-	// Specifies whether the network resource can be accessed by any tenant or not.
+	// Specifies whether the network resource can be accessed by any tenant.
 	Shared bool `json:"shared"`
+
+	// Availability zone hints groups network nodes that run services like DHCP, L3, FW, and others.
+	// Used to make network resources highly available.
+	AvailabilityZoneHints []string `json:"availability_zone_hints"`
 }
 
 // NetworkPage is the page returned by a pager when traversing over a
@@ -93,9 +105,11 @@ func (r NetworkPage) IsEmpty() (bool, error) {
 // and extracts the elements into a slice of Network structs. In other words,
 // a generic collection is mapped into a relevant slice.
 func ExtractNetworks(r pagination.Page) ([]Network, error) {
-	var s struct {
-		Networks []Network `json:"networks"`
-	}
-	err := (r.(NetworkPage)).ExtractInto(&s)
-	return s.Networks, err
+	var s []Network
+	err := ExtractNetworksInto(r, &s)
+	return s, err
+}
+
+func ExtractNetworksInto(r pagination.Page, v interface{}) error {
+	return r.(NetworkPage).Result.ExtractIntoSlicePtr(v, "networks")
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -535,10 +535,10 @@
 			"revisionTime": "2017-05-24T13:09:59Z"
 		},
 		{
-			"checksumSHA1": "zKOhFTL5BDZPMC58ZzZkryjskno=",
+			"checksumSHA1": "YnP/P8Tr8hHw+NVZ/KegcGCbK0I=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/networks",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4d2733c962898d8cd68456bd275aee64256cd2a1",
+			"revisionTime": "2017-12-08T16:30:52Z"
 		},
 		{
 			"checksumSHA1": "68RL/R3cHJvkHPNZmu0GW4xd4cY=",

--- a/website/docs/d/networking_network_v2.html.markdown
+++ b/website/docs/d/networking_network_v2.html.markdown
@@ -34,6 +34,9 @@ data "openstack_networking_network_v2" "network" {
 
 * `tenant_id` - (Optional) The owner of the network.
 
+* `availability_zone_hints` - (Optional) The availability zone candidates for the network.
+
+
 ## Attributes Reference
 
 `id` is set to the ID of the found network. In addition, the following attributes
@@ -44,3 +47,4 @@ are exported:
 * `region` - See Argument Reference above.
 * `shared` - (Optional)  Specifies whether the network resource can be accessed
     by any tenant or not.
+* `availability_zone_hints` - (Optional) The availability zone candidates for the network.


### PR DESCRIPTION
This allows users to associate an availability zone with their network 

 * [availability_zone_hints](https://developer.openstack.org/api-ref/network/v2/index.html#networks) (missing in docs but supported by openstack cli and is about to be added to [webui](https://git.openstack.org/cgit/openstack/horizon/commit/?id=b9664a1bf139e6714aa4d507a68ce03d551779aa))

```
resource "openstack_networking_network_v2" "network" {
  name               = "terraform-ipv6"
  admin_state_up = "true"
  shared             = "false"
  availability_zone_hints = ["zone1", "zone2"]
}

```