### PR TITLE
Allow setting availability_zone_hints on router.

### DIFF
--- a/openstack/resource_openstack_networking_network_v2.go
+++ b/openstack/resource_openstack_networking_network_v2.go
@@ -110,7 +110,7 @@ func resourceNetworkingNetworkV2Create(d *schema.ResourceData, meta interface{})
 		networks.CreateOpts{
 			Name:                  d.Get("name").(string),
 			TenantID:              d.Get("tenant_id").(string),
-			AvailabilityZoneHints: resourceNetworkingNetworkAvailabilityZoneHintsV2(d),
+			AvailabilityZoneHints: resourceNetworkingAvailabilityZoneHintsV2(d),
 		},
 		MapValueSpecs(d),
 	}
@@ -287,15 +287,6 @@ func resourceNetworkingNetworkV2Segments(d *schema.ResourceData) (providerSegmen
 		providerSegments = append(providerSegments, segment)
 	}
 	return
-}
-
-func resourceNetworkingNetworkAvailabilityZoneHintsV2(d *schema.ResourceData) []string {
-	rawAZH := d.Get("availability_zone_hints").([]interface{})
-	azh := make([]string, len(rawAZH))
-	for i, raw := range rawAZH {
-		azh[i] = raw.(string)
-	}
-	return azh
 }
 
 func waitForNetworkActive(networkingClient *gophercloud.ServiceClient, networkId string) resource.StateRefreshFunc {

--- a/openstack/resource_openstack_networking_router_v2.go
+++ b/openstack/resource_openstack_networking_router_v2.go
@@ -123,7 +123,7 @@ func resourceNetworkingRouterV2Create(d *schema.ResourceData, meta interface{}) 
 		routers.CreateOpts{
 			Name:                  d.Get("name").(string),
 			TenantID:              d.Get("tenant_id").(string),
-			AvailabilityZoneHints: resourceNetworkingRouterkAvailabilityZoneHintsV2(d),
+			AvailabilityZoneHints: resourceNetworkingAvailabilityZoneHintsV2(d),
 		},
 		MapValueSpecs(d),
 	}
@@ -348,15 +348,6 @@ func resourceNetworkingRouterV2Delete(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId("")
 	return nil
-}
-
-func resourceNetworkingRouterkAvailabilityZoneHintsV2(d *schema.ResourceData) []string {
-	rawAZH := d.Get("availability_zone_hints").([]interface{})
-	azh := make([]string, len(rawAZH))
-	for i, raw := range rawAZH {
-		azh[i] = raw.(string)
-	}
-	return azh
 }
 
 func waitForRouterActive(networkingClient *gophercloud.ServiceClient, routerId string) resource.StateRefreshFunc {

--- a/openstack/resource_openstack_networking_router_v2.go
+++ b/openstack/resource_openstack_networking_router_v2.go
@@ -101,6 +101,13 @@ func resourceNetworkingRouterV2() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"availability_zone_hints": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				ForceNew: true,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -114,8 +121,9 @@ func resourceNetworkingRouterV2Create(d *schema.ResourceData, meta interface{}) 
 
 	createOpts := RouterCreateOpts{
 		routers.CreateOpts{
-			Name:     d.Get("name").(string),
-			TenantID: d.Get("tenant_id").(string),
+			Name:                  d.Get("name").(string),
+			TenantID:              d.Get("tenant_id").(string),
+			AvailabilityZoneHints: resourceNetworkingRouterkAvailabilityZoneHintsV2(d),
 		},
 		MapValueSpecs(d),
 	}
@@ -211,6 +219,10 @@ func resourceNetworkingRouterV2Read(d *schema.ResourceData, meta interface{}) er
 	d.Set("distributed", n.Distributed)
 	d.Set("tenant_id", n.TenantID)
 	d.Set("region", GetRegion(d, config))
+
+	if err := d.Set("availability_zone_hints", n.AvailabilityZoneHints); err != nil {
+		log.Printf("[DEBUG] unable to set availability_zone_hints: %s", err)
+	}
 
 	// Gateway settings
 	d.Set("external_gateway", n.GatewayInfo.NetworkID)
@@ -336,6 +348,15 @@ func resourceNetworkingRouterV2Delete(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId("")
 	return nil
+}
+
+func resourceNetworkingRouterkAvailabilityZoneHintsV2(d *schema.ResourceData) []string {
+	rawAZH := d.Get("availability_zone_hints").([]interface{})
+	azh := make([]string, len(rawAZH))
+	for i, raw := range rawAZH {
+		azh[i] = raw.(string)
+	}
+	return azh
 }
 
 func waitForRouterActive(networkingClient *gophercloud.ServiceClient, routerId string) resource.StateRefreshFunc {

--- a/openstack/util.go
+++ b/openstack/util.go
@@ -136,3 +136,12 @@ func validateSubnetV2IPv6Mode(v interface{}, k string) (ws []string, errors []er
 	}
 	return
 }
+
+func resourceNetworkingAvailabilityZoneHintsV2(d *schema.ResourceData) []string {
+	rawAZH := d.Get("availability_zone_hints").([]interface{})
+	azh := make([]string, len(rawAZH))
+	for i, raw := range rawAZH {
+		azh[i] = raw.(string)
+	}
+	return azh
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/requests.go
@@ -49,11 +49,12 @@ type CreateOptsBuilder interface {
 // CreateOpts contains all the values needed to create a new router. There are
 // no required values.
 type CreateOpts struct {
-	Name         string       `json:"name,omitempty"`
-	AdminStateUp *bool        `json:"admin_state_up,omitempty"`
-	Distributed  *bool        `json:"distributed,omitempty"`
-	TenantID     string       `json:"tenant_id,omitempty"`
-	GatewayInfo  *GatewayInfo `json:"external_gateway_info,omitempty"`
+	Name                  string       `json:"name,omitempty"`
+	AdminStateUp          *bool        `json:"admin_state_up,omitempty"`
+	Distributed           *bool        `json:"distributed,omitempty"`
+	TenantID              string       `json:"tenant_id,omitempty"`
+	GatewayInfo           *GatewayInfo `json:"external_gateway_info,omitempty"`
+	AvailabilityZoneHints []string     `json:"availability_zone_hints,omitempty"`
 }
 
 // ToRouterCreateMap builds a create request body from CreateOpts.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/results.go
@@ -60,6 +60,10 @@ type Router struct {
 
 	// Routes are a collection of static routes that the router will host.
 	Routes []Route `json:"routes"`
+
+	// Availability zone hints groups network nodes that run services like DHCP, L3, FW, and others.
+	// Used to make network resources highly available.
+	AvailabilityZoneHints []string `json:"availability_zone_hints"`
 }
 
 // RouterPage is the page returned by a pager when traversing over a

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,6 +3,10 @@
 	"ignore": "appengine test github.com/hashicorp/nomad/ github.com/hashicorp/terraform/backend",
 	"package": [
 		{
+			"path": "fetch",
+			"revision": ""
+		},
+		{
 			"checksumSHA1": "ly9VLPE9GKo2U7mnbZyjb2LDQ3w=",
 			"path": "github.com/Unknwon/com",
 			"revision": "28b053d5a2923b87ce8c5a08f3af779894a72758",
@@ -463,10 +467,10 @@
 			"revisionTime": "2017-03-10T01:59:53Z"
 		},
 		{
-			"checksumSHA1": "MwH3GAr/ULiw/D2slN4vxYjQDjI=",
+			"checksumSHA1": "X2qWZ68Xlfobx/EQR0EEGEpUJBk=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers",
-			"revision": "d6667ee368f58dfeeb69ae9c11ba37f9fc7e0c58",
-			"revisionTime": "2017-10-27T02:34:43Z"
+			"revision": "92fb632e86f730790c3d240e468617c6f8d4a3bf",
+			"revisionTime": "2017-12-14T02:21:50Z"
 		},
 		{
 			"checksumSHA1": "mCTz2rnyVfhjJ+AD/WihCNcYWiY=",
@@ -1022,6 +1026,10 @@
 			"path": "gopkg.in/yaml.v2",
 			"revision": "eb3733d160e74a9c7e442f435eb3bea458e1d19f",
 			"revisionTime": "2017-08-12T16:00:11Z"
+		},
+		{
+			"path": "govendor",
+			"revision": ""
 		},
 		{
 			"checksumSHA1": "wICWAGQfZcHD2y0dHesz9R2YSiw=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,6 @@
 	"ignore": "appengine test github.com/hashicorp/nomad/ github.com/hashicorp/terraform/backend",
 	"package": [
 		{
-			"path": "fetch",
-			"revision": ""
-		},
-		{
 			"checksumSHA1": "ly9VLPE9GKo2U7mnbZyjb2LDQ3w=",
 			"path": "github.com/Unknwon/com",
 			"revision": "28b053d5a2923b87ce8c5a08f3af779894a72758",
@@ -1026,10 +1022,6 @@
 			"path": "gopkg.in/yaml.v2",
 			"revision": "eb3733d160e74a9c7e442f435eb3bea458e1d19f",
 			"revisionTime": "2017-08-12T16:00:11Z"
-		},
-		{
-			"path": "govendor",
-			"revision": ""
 		},
 		{
 			"checksumSHA1": "wICWAGQfZcHD2y0dHesz9R2YSiw=",

--- a/website/docs/r/networking_network_v2.html.markdown
+++ b/website/docs/r/networking_network_v2.html.markdown
@@ -86,6 +86,11 @@ The following arguments are supported:
 
 * `value_specs` - (Optional) Map of additional options.
 
+* `availability_zone_hints` -  (Optional) An availability zone is used to make
+    network resources highly available. Used for resources with high availability
+    so that they are scheduled on different availability zones. Changing this 
+    creates a new network.
+
 The `segments` block supports:
 
 * `physical_network` - The phisical network where this network is implemented.
@@ -101,6 +106,7 @@ The following attributes are exported:
 * `shared` - See Argument Reference above.
 * `tenant_id` - See Argument Reference above.
 * `admin_state_up` - See Argument Reference above.
+* `availability_zone_hints` - See Argument Reference above.
 
 ## Import
 

--- a/website/docs/r/networking_router_v2.html.markdown
+++ b/website/docs/r/networking_router_v2.html.markdown
@@ -65,6 +65,10 @@ The following arguments are supported:
 
 * `value_specs` - (Optional) Map of additional driver-specific options.
 
+* `availability_zone_hints` -  (Optional) An availability zone is used to make 
+    network resources highly available. Used for resources with high availability so that they are scheduled on different availability zones. Changing
+    this creates a new router.
+
 The `external_fixed_ip` block supports:
 
 * `subnet_id` - (Optional) Subnet in which the fixed IP belongs to.
@@ -85,6 +89,7 @@ The following attributes are exported:
 * `external_fixed_ip` - See Argument Reference above.
 * `tenant_id` - See Argument Reference above.
 * `value_specs` - See Argument Reference above.
+* `availability_zone_hints` - See Argument Reference above.
 
 ## Import
 


### PR DESCRIPTION
This allows users to associate an availability zone with their
resources.

```
resource "openstack_networking_router_v2" "testrouter" {
    name                      = "testrouter"
    availability_zone_hints   = ["zone1", "zone3"]
}
```

When/if #196 is accepted, one improvement would be to break out  resourceNetworkingRouterkAvailabilityZoneHintsV2_ into util.go and 
use it from borth networks and router.
