### PR TITLE
Add 'vendor_options' to networking_router_v2 resource.

### DIFF
--- a/openstack/resource_openstack_networking_router_v2_test.go
+++ b/openstack/resource_openstack_networking_router_v2_test.go
@@ -139,6 +139,26 @@ resource "openstack_networking_router_v2" "router_1" {
 }
 `
 
+func TestAccNetworkingV2Router_vendor_opts(t *testing.T) {
+	var router routers.Router
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2RouterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2Router_vendor_opts,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2RouterExists("openstack_networking_router_v2.router_1", &router),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_router_v2.router_1", "external_gateway", OS_EXTGW_ID),
+				),
+			},
+		},
+	})
+}
+
 const testAccNetworkingV2Router_update = `
 resource "openstack_networking_router_v2" "router_1" {
 	name = "router_2"
@@ -146,6 +166,18 @@ resource "openstack_networking_router_v2" "router_1" {
 	distributed = "false"
 }
 `
+
+var testAccNetworkingV2Router_vendor_opts = fmt.Sprintf(`
+resource "openstack_networking_router_v2" "router_1" {
+	name = "router_1"
+	admin_state_up = "true"
+	distributed = "false"
+	external_network_id = "%s"
+	vendor_options {
+		set_router_gateway_on_update = true
+	}
+}
+`, OS_EXTGW_ID)
 
 const testAccNetworkingV2Router_updateExternalGateway1 = `
 resource "openstack_networking_router_v2" "router_1" {

--- a/openstack/resource_openstack_networking_router_v2_test.go
+++ b/openstack/resource_openstack_networking_router_v2_test.go
@@ -174,7 +174,7 @@ resource "openstack_networking_router_v2" "router_1" {
 	distributed = "false"
 	external_network_id = "%s"
 	vendor_options {
-		set_router_gateway_on_update = true
+		set_router_gateway_after_create = true
 	}
 }
 `, OS_EXTGW_ID)

--- a/website/docs/r/networking_router_v2.html.markdown
+++ b/website/docs/r/networking_router_v2.html.markdown
@@ -65,6 +65,9 @@ The following arguments are supported:
 
 * `value_specs` - (Optional) Map of additional driver-specific options.
 
+* `vendor_options` - (Optional) Map of additional vendor-specific options.
+    Supported options are described below.
+
 * `availability_zone_hints` -  (Optional) An availability zone is used to make 
     network resources highly available. Used for resources with high availability so that they are scheduled on different availability zones. Changing
     this creates a new router.
@@ -74,6 +77,11 @@ The `external_fixed_ip` block supports:
 * `subnet_id` - (Optional) Subnet in which the fixed IP belongs to.
 
 * `ip_address` - (Optional) The IP address to set on the router.
+
+The `vendor_options` block supports:
+
+* `set_router_gateway_after_create` - (Optional) Boolean to control whether
+    the Router gateway is assigned during creation or updated after creation.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add a `vendor_options` param to `openstack_networking_router_v2` resource.
This will enable management of 'vendor specific' behaviour in a
sensible, structured manner.

TODO: 
- [x] Documentation
