### PR TITLE
Add two jobs for Trove/Designate related tests

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -16,3 +16,9 @@
     recheck-pike:
       jobs:
         - terraform-provider-openstack-acceptance-test-pike
+    recheck-trove:
+      jobs:
+        - terraform-provider-openstack-acceptance-test-trove
+    recheck-designate:
+      jobs:
+        - terraform-provider-openstack-acceptance-test-designate


### PR DESCRIPTION
This change try to add two jobs for Trove and Designate related tests,
which can be run against the Openlab CI. Since the acceptance tests for
database service(Trove) and DNS service(Designate) need some specific
environment configurations, and the tests are time-consuming, we'd better
don't run the tests when every new PR submitted. Insteaded, we use two
separated jobs to run the tests and need to manually triggerred by comment
"recheck trove" or "recheck designate" in PRs.