### PR TITLE
Use OS_NETWORK_ID as default network in Acc tests

### DIFF
--- a/openstack/resource_openstack_compute_floatingip_associate_v2_test.go
+++ b/openstack/resource_openstack_compute_floatingip_associate_v2_test.go
@@ -199,10 +199,13 @@ func testAccCheckComputeV2FloatingIPAssociateAssociated(
 	}
 }
 
-const testAccComputeV2FloatingIPAssociate_basic = `
+var testAccComputeV2FloatingIPAssociate_basic = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
+  network {
+    uuid = "%s"
+  }
 }
 
 resource "openstack_networking_floatingip_v2" "fip_1" {
@@ -212,12 +215,15 @@ resource "openstack_compute_floatingip_associate_v2" "fip_1" {
   floating_ip = "${openstack_networking_floatingip_v2.fip_1.address}"
   instance_id = "${openstack_compute_instance_v2.instance_1.id}"
 }
-`
+`, OS_NETWORK_ID)
 
-const testAccComputeV2FloatingIPAssociate_fixedIP = `
+var testAccComputeV2FloatingIPAssociate_fixedIP = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
+  network {
+    uuid = "%s"
+  }
 }
 
 resource "openstack_networking_floatingip_v2" "fip_1" {
@@ -228,7 +234,7 @@ resource "openstack_compute_floatingip_associate_v2" "fip_1" {
   instance_id = "${openstack_compute_instance_v2.instance_1.id}"
   fixed_ip = "${openstack_compute_instance_v2.instance_1.access_ip_v4}"
 }
-`
+`, OS_NETWORK_ID)
 
 var testAccComputeV2FloatingIPAssociate_attachToFirstNetwork = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
@@ -287,10 +293,13 @@ resource "openstack_compute_floatingip_associate_v2" "fip_1" {
 }
 `, OS_NETWORK_ID)
 
-const testAccComputeV2FloatingIPAssociate_attachNew_1 = `
+var testAccComputeV2FloatingIPAssociate_attachNew_1 = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
+  network {
+    uuid = "%s"
+  }
 }
 
 resource "openstack_networking_floatingip_v2" "fip_1" {
@@ -303,12 +312,15 @@ resource "openstack_compute_floatingip_associate_v2" "fip_1" {
   floating_ip = "${openstack_networking_floatingip_v2.fip_1.address}"
   instance_id = "${openstack_compute_instance_v2.instance_1.id}"
 }
-`
+`, OS_NETWORK_ID)
 
-const testAccComputeV2FloatingIPAssociate_attachNew_2 = `
+var testAccComputeV2FloatingIPAssociate_attachNew_2 = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
+  network {
+    uuid = "%s"
+  }
 }
 
 resource "openstack_networking_floatingip_v2" "fip_1" {
@@ -321,4 +333,4 @@ resource "openstack_compute_floatingip_associate_v2" "fip_1" {
   floating_ip = "${openstack_networking_floatingip_v2.fip_2.address}"
   instance_id = "${openstack_compute_instance_v2.instance_1.id}"
 }
-`
+`, OS_NETWORK_ID)

--- a/openstack/resource_openstack_compute_instance_v2_test.go
+++ b/openstack/resource_openstack_compute_instance_v2_test.go
@@ -634,17 +634,20 @@ func testAccCheckComputeV2InstanceInstanceIDsDoNotMatch(
 	}
 }
 
-const testAccComputeV2Instance_basic = `
+var testAccComputeV2Instance_basic = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
   metadata {
     foo = "bar"
   }
+  network {
+    uuid = "%s"
+  }
 }
-`
+`, OS_NETWORK_ID)
 
-const testAccComputeV2Instance_secgroupMulti = `
+var testAccComputeV2Instance_secgroupMulti = fmt.Sprintf(`
 resource "openstack_compute_secgroup_v2" "secgroup_1" {
   name = "secgroup_1"
   description = "a security group"
@@ -659,10 +662,13 @@ resource "openstack_compute_secgroup_v2" "secgroup_1" {
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default", "${openstack_compute_secgroup_v2.secgroup_1.name}"]
+  network {
+    uuid = "%s"
+  }
 }
-`
+`, OS_NETWORK_ID)
 
-const testAccComputeV2Instance_secgroupMultiUpdate_1 = `
+var testAccComputeV2Instance_secgroupMultiUpdate_1 = fmt.Sprintf(`
 resource "openstack_compute_secgroup_v2" "secgroup_1" {
   name = "secgroup_1"
   description = "a security group"
@@ -688,10 +694,13 @@ resource "openstack_compute_secgroup_v2" "secgroup_2" {
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
+  network {
+    uuid = "%s"
+  }
 }
-`
+`, OS_NETWORK_ID)
 
-const testAccComputeV2Instance_secgroupMultiUpdate_2 = `
+var testAccComputeV2Instance_secgroupMultiUpdate_2 = fmt.Sprintf(`
 resource "openstack_compute_secgroup_v2" "secgroup_1" {
   name = "secgroup_1"
   description = "a security group"
@@ -717,8 +726,11 @@ resource "openstack_compute_secgroup_v2" "secgroup_2" {
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default", "${openstack_compute_secgroup_v2.secgroup_1.name}", "${openstack_compute_secgroup_v2.secgroup_2.name}"]
+  network {
+    uuid = "%s"
+  }
 }
-`
+`, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_bootFromVolumeImage = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
@@ -732,8 +744,11 @@ resource "openstack_compute_instance_v2" "instance_1" {
     destination_type = "volume"
     delete_on_termination = true
   }
+  network {
+    uuid = "%s"
+  }
 }
-`, OS_IMAGE_ID)
+`, OS_IMAGE_ID, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_bootFromVolumeVolume = fmt.Sprintf(`
 resource "openstack_blockstorage_volume_v2" "vol_1" {
@@ -752,8 +767,11 @@ resource "openstack_compute_instance_v2" "instance_1" {
     destination_type = "volume"
     delete_on_termination = true
   }
+  network {
+    uuid = "%s"
+  }
 }
-`, OS_IMAGE_ID)
+`, OS_IMAGE_ID, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_bootFromVolumeForceNew_1 = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
@@ -767,8 +785,11 @@ resource "openstack_compute_instance_v2" "instance_1" {
     destination_type = "volume"
     delete_on_termination = true
   }
+  network {
+    uuid = "%s"
+  }
 }
-`, OS_IMAGE_ID)
+`, OS_IMAGE_ID, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_bootFromVolumeForceNew_2 = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
@@ -782,8 +803,11 @@ resource "openstack_compute_instance_v2" "instance_1" {
     destination_type = "volume"
     delete_on_termination = true
   }
+  network {
+    uuid = "%s"
+  }
 }
-`, OS_IMAGE_ID)
+`, OS_IMAGE_ID, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_blockDeviceNewVolume = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
@@ -803,8 +827,11 @@ resource "openstack_compute_instance_v2" "instance_1" {
     boot_index = 1
     delete_on_termination = true
   }
+  network {
+    uuid = "%s"
+  }
 }
-`, OS_IMAGE_ID)
+`, OS_IMAGE_ID, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_blockDeviceExistingVolume = fmt.Sprintf(`
 resource "openstack_blockstorage_volume_v2" "volume_1" {
@@ -829,10 +856,13 @@ resource "openstack_compute_instance_v2" "instance_1" {
     boot_index = 1
     delete_on_termination = true
   }
+  network {
+    uuid = "%s"
+  }
 }
-`, OS_IMAGE_ID)
+`, OS_IMAGE_ID, OS_NETWORK_ID)
 
-const testAccComputeV2Instance_personality = `
+var testAccComputeV2Instance_personality = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
@@ -844,8 +874,11 @@ resource "openstack_compute_instance_v2" "instance_1" {
     file = "/tmp/barfoo.txt"
     content = "angry"
   }
+  network {
+    uuid = "%s"
+  }
 }
-`
+`, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_multiEphemeral = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
@@ -872,8 +905,11 @@ resource "openstack_compute_instance_v2" "instance_1" {
     source_type = "blank"
     volume_size = 1
   }
+  network {
+    uuid = "%s"
+  }
 }
-`, OS_IMAGE_ID)
+`, OS_IMAGE_ID, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_accessIPv4 = fmt.Sprintf(`
 resource "openstack_networking_network_v2" "network_1" {
@@ -929,15 +965,18 @@ resource "openstack_compute_instance_v2" "instance_1" {
 }
 `, OS_NETWORK_ID)
 
-const testAccComputeV2Instance_stopBeforeDestroy = `
+var testAccComputeV2Instance_stopBeforeDestroy = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
   stop_before_destroy = true
+  network {
+    uuid = "%s"
+  }
 }
-`
+`, OS_NETWORK_ID)
 
-const testAccComputeV2Instance_metadataRemove_1 = `
+var testAccComputeV2Instance_metadataRemove_1 = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
@@ -945,10 +984,13 @@ resource "openstack_compute_instance_v2" "instance_1" {
     foo = "bar"
     abc = "def"
   }
+  network {
+    uuid = "%s"
+  }
 }
-`
+`, OS_NETWORK_ID)
 
-const testAccComputeV2Instance_metadataRemove_2 = `
+var testAccComputeV2Instance_metadataRemove_2 = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
@@ -956,18 +998,24 @@ resource "openstack_compute_instance_v2" "instance_1" {
     foo = "bar"
     ghi = "jkl"
   }
+  network {
+    uuid = "%s"
+  }
 }
-`
+`, OS_NETWORK_ID)
 
-const testAccComputeV2Instance_forceDelete = `
+var testAccComputeV2Instance_forceDelete = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
   force_delete = true
+  network {
+    uuid = "%s"
+  }
 }
-`
+`, OS_NETWORK_ID)
 
-const testAccComputeV2Instance_timeout = `
+var testAccComputeV2Instance_timeout = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
@@ -975,8 +1023,11 @@ resource "openstack_compute_instance_v2" "instance_1" {
   timeouts {
     create = "10m"
   }
+  network {
+    uuid = "%s"
+  }
 }
-`
+`, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_networkNameToID = fmt.Sprintf(`
 resource "openstack_networking_network_v2" "network_1" {

--- a/openstack/resource_openstack_compute_servergroup_v2_test.go
+++ b/openstack/resource_openstack_compute_servergroup_v2_test.go
@@ -124,7 +124,7 @@ resource "openstack_compute_servergroup_v2" "sg_1" {
 }
 `
 
-const testAccComputeV2ServerGroup_affinity = `
+var testAccComputeV2ServerGroup_affinity = fmt.Sprintf(`
 resource "openstack_compute_servergroup_v2" "sg_1" {
   name = "sg_1"
   policies = ["affinity"]
@@ -136,5 +136,8 @@ resource "openstack_compute_instance_v2" "instance_1" {
   scheduler_hints {
     group = "${openstack_compute_servergroup_v2.sg_1.id}"
   }
+  network {
+    uuid = "%s"
+  }
 }
-`
+`, OS_NETWORK_ID)

--- a/openstack/resource_openstack_compute_volume_attach_v2_test.go
+++ b/openstack/resource_openstack_compute_volume_attach_v2_test.go
@@ -140,7 +140,7 @@ func testAccCheckComputeV2VolumeAttachDevice(
 	}
 }
 
-const testAccComputeV2VolumeAttach_basic = `
+var testAccComputeV2VolumeAttach_basic = fmt.Sprintf(`
 resource "openstack_blockstorage_volume_v2" "volume_1" {
   name = "volume_1"
   size = 1
@@ -149,15 +149,18 @@ resource "openstack_blockstorage_volume_v2" "volume_1" {
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
+  network {
+    uuid = "%s"
+  }
 }
 
 resource "openstack_compute_volume_attach_v2" "va_1" {
   instance_id = "${openstack_compute_instance_v2.instance_1.id}"
   volume_id = "${openstack_blockstorage_volume_v2.volume_1.id}"
 }
-`
+`, OS_NETWORK_ID)
 
-const testAccComputeV2VolumeAttach_device = `
+var testAccComputeV2VolumeAttach_device = fmt.Sprintf(`
 resource "openstack_blockstorage_volume_v2" "volume_1" {
   name = "volume_1"
   size = 1
@@ -166,6 +169,9 @@ resource "openstack_blockstorage_volume_v2" "volume_1" {
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
+  network {
+    uuid = "%s"
+  }
 }
 
 resource "openstack_compute_volume_attach_v2" "va_1" {
@@ -173,9 +179,9 @@ resource "openstack_compute_volume_attach_v2" "va_1" {
   volume_id = "${openstack_blockstorage_volume_v2.volume_1.id}"
   device = "/dev/vdc"
 }
-`
+`, OS_NETWORK_ID)
 
-const testAccComputeV2VolumeAttach_timeout = `
+var testAccComputeV2VolumeAttach_timeout = fmt.Sprintf(`
 resource "openstack_blockstorage_volume_v2" "volume_1" {
   name = "volume_1"
   size = 1
@@ -184,6 +190,9 @@ resource "openstack_blockstorage_volume_v2" "volume_1" {
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
+  network {
+    uuid = "%s"
+  }
 }
 
 resource "openstack_compute_volume_attach_v2" "va_1" {
@@ -195,4 +204,4 @@ resource "openstack_compute_volume_attach_v2" "va_1" {
     delete = "5m"
   }
 }
-`
+`, OS_NETWORK_ID)


### PR DESCRIPTION
If there are multiple private networks can be used in current tenant,
that cause booting instance failed, because Nova have no idea about
using which network to create instance. Propose to use OS_NETWORK_ID as
default network to create instance in order to avoiding failing in Acc
tests. Only fix Acc tests, no impact to behavior of booting instance,
keep backward compatibility.

Fixes #213