### PR TITLE
Set region if defined in clouds.yaml

### DIFF
--- a/openstack/config.go
+++ b/openstack/config.go
@@ -76,6 +76,15 @@ func (c *Config) LoadAndValidate() error {
 		if err != nil {
 			return err
 		}
+
+		cloud, err := clientconfig.GetCloudFromYAML(clientOpts)
+		if err != nil {
+			return err
+		}
+
+		if c.Region == "" && cloud.RegionName != "" {
+			c.Region = cloud.RegionName
+		}
 	} else {
 		ao = &gophercloud.AuthOptions{
 			DomainID:         c.DomainID,


### PR DESCRIPTION
This commit will set the region name if one is provided
in the clouds.yaml entry and the user did not specify
one in the provider configuration. If the user set one
in the provider, it will override what is set in
clouds.yaml.

Fixes #215 