### PR TITLE
usable examlpe of compute_flavor_v2

### DIFF
--- a/website/docs/r/compute_flavor_v2.html.markdown
+++ b/website/docs/r/compute_flavor_v2.html.markdown
@@ -15,7 +15,7 @@ Manages a V2 flavor resource within OpenStack.
 ```hcl
 resource "openstack_compute_flavor_v2" "test-flavor" {
   name  = "my-flavor"
-  ram   = "8"
+  ram   = "8096"
   vcpus = "2"
   disk  = "20"
 }


### PR DESCRIPTION
Flavors are properly documented as configuring RAM in megabytes, but the example is not really useful (unless you have an image that can boot with only 8 MB).

I think the intent was to show 8096... but some value of at least 2048 MB should be copy/pasteable for the average user's image.