### PR TITLE
Arbitrary Key/Value for Schedule Hints

### DIFF
--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -303,6 +303,11 @@ func resourceComputeInstanceV2() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
+						"additional_properties": &schema.Schema{
+							Type:     schema.TypeMap,
+							Optional: true,
+							ForceNew: true,
+						},
 					},
 				},
 				Set: resourceComputeSchedulerHintsHash,
@@ -898,12 +903,13 @@ func resourceInstanceSchedulerHintsV2(d *schema.ResourceData, schedulerHintsRaw 
 	}
 
 	schedulerHints := schedulerhints.SchedulerHints{
-		Group:           schedulerHintsRaw["group"].(string),
-		DifferentHost:   differentHost,
-		SameHost:        sameHost,
-		Query:           query,
-		TargetCell:      schedulerHintsRaw["target_cell"].(string),
-		BuildNearHostIP: schedulerHintsRaw["build_near_host_ip"].(string),
+		Group:                schedulerHintsRaw["group"].(string),
+		DifferentHost:        differentHost,
+		SameHost:             sameHost,
+		Query:                query,
+		TargetCell:           schedulerHintsRaw["target_cell"].(string),
+		BuildNearHostIP:      schedulerHintsRaw["build_near_host_ip"].(string),
+		AdditionalProperties: schedulerHintsRaw["additional_properties"].(map[string]interface{}),
 	}
 
 	return schedulerHints
@@ -1015,6 +1021,12 @@ func resourceComputeSchedulerHintsHash(v interface{}) int {
 
 	if m["build_host_near_ip"] != nil {
 		buf.WriteString(fmt.Sprintf("%s-", m["build_host_near_ip"].(string)))
+	}
+
+	if m["additional_properties"] != nil {
+		for _, v := range m["additional_properties"].(map[string]interface{}) {
+			buf.WriteString(fmt.Sprintf("%s-", v))
+		}
 	}
 
 	buf.WriteString(fmt.Sprintf("%s-", m["different_host"].([]interface{})))

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints/doc.go
@@ -1,3 +1,76 @@
-// Package schedulerhints enables instances to provide the OpenStack scheduler
-// hints about where they should be placed in the cloud.
+/*
+Package schedulerhints extends the server create request with the ability to
+specify additional parameters which determine where the server will be
+created in the OpenStack cloud.
+
+Example to Add a Server to a Server Group
+
+	schedulerHints := schedulerhints.SchedulerHints{
+		Group: "servergroup-uuid",
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		ImageRef:  "image-uuid",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := schedulerhints.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		SchedulerHints:    schedulerHints,
+	}
+
+	server, err := servers.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Place Server B on a Different Host than Server A
+
+	schedulerHints := schedulerhints.SchedulerHints{
+		DifferentHost: []string{
+			"server-a-uuid",
+		}
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_b",
+		ImageRef:  "image-uuid",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := schedulerhints.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		SchedulerHints:    schedulerHints,
+	}
+
+	server, err := servers.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Place Server B on the Same Host as Server A
+
+	schedulerHints := schedulerhints.SchedulerHints{
+		SameHost: []string{
+			"server-a-uuid",
+		}
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_b",
+		ImageRef:  "image-uuid",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := schedulerhints.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		SchedulerHints:    schedulerHints,
+	}
+
+	server, err := servers.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
 package schedulerhints

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints/requests.go
@@ -10,23 +10,31 @@ import (
 )
 
 // SchedulerHints represents a set of scheduling hints that are passed to the
-// OpenStack scheduler
+// OpenStack scheduler.
 type SchedulerHints struct {
 	// Group specifies a Server Group to place the instance in.
 	Group string
+
 	// DifferentHost will place the instance on a compute node that does not
 	// host the given instances.
 	DifferentHost []string
+
 	// SameHost will place the instance on a compute node that hosts the given
 	// instances.
 	SameHost []string
+
 	// Query is a conditional statement that results in compute nodes able to
 	// host the instance.
 	Query []interface{}
+
 	// TargetCell specifies a cell name where the instance will be placed.
 	TargetCell string `json:"target_cell,omitempty"`
+
 	// BuildNearHostIP specifies a subnet of compute nodes to host the instance.
 	BuildNearHostIP string
+
+	// AdditionalProperies are arbitrary key/values that are not validated by nova.
+	AdditionalProperties map[string]interface{}
 }
 
 // CreateOptsBuilder builds the scheduler hints into a serializable format.
@@ -77,8 +85,9 @@ func (opts SchedulerHints) ToServerSchedulerHintsCreateMap() (map[string]interfa
 		sh["same_host"] = opts.SameHost
 	}
 
-	/* Query can be something simple like:
-	     [">=", "$free_ram_mb", 1024]
+	/*
+		Query can be something simple like:
+			 [">=", "$free_ram_mb", 1024]
 
 			Or more complex like:
 				['and',
@@ -116,12 +125,19 @@ func (opts SchedulerHints) ToServerSchedulerHintsCreateMap() (map[string]interfa
 		sh["cidr"] = "/" + ipParts[1]
 	}
 
+	if opts.AdditionalProperties != nil {
+		for k, v := range opts.AdditionalProperties {
+			sh[k] = v
+		}
+	}
+
 	return sh, nil
 }
 
 // CreateOptsExt adds a SchedulerHints option to the base CreateOpts.
 type CreateOptsExt struct {
 	servers.CreateOptsBuilder
+
 	// SchedulerHints provides a set of hints to the scheduler.
 	SchedulerHints CreateOptsBuilder
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -307,10 +307,10 @@
 			"revisionTime": "2017-03-10T01:59:53Z"
 		},
 		{
-			"checksumSHA1": "tOmntqlmZ/r8aObUChNloddLhwk=",
+			"checksumSHA1": "+hlElX7o8ULWTc0r7oGyDlOnwWM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "3b177406222d4b76d93e90d6ab412e7b7dc160f4",
+			"revisionTime": "2018-02-02T23:12:48Z"
 		},
 		{
 			"checksumSHA1": "jNrUTQf+9dYfaD7YqvKwC+kGvyY=",


### PR DESCRIPTION
This pull request updates the Gophercloud schedulerhints extension to the latest version. The latest version includes the ability to specify arbitrary key/value strings for scheduler hints as specified by this pull request [gophercloud/gophercloud#316]. 

This pull request enables the ability to specify such KV pairs in terraform.