### PR TITLE
 Networking v2: Add subnet_id to floatingip resource

### DIFF
--- a/openstack/resource_openstack_networking_floatingip_v2.go
+++ b/openstack/resource_openstack_networking_floatingip_v2.go
@@ -62,6 +62,10 @@ func resourceNetworkingFloatingIPV2() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"subnet_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"value_specs": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -91,6 +95,7 @@ func resourceNetworkFloatingIPV2Create(d *schema.ResourceData, meta interface{})
 			PortID:            d.Get("port_id").(string),
 			TenantID:          d.Get("tenant_id").(string),
 			FixedIP:           d.Get("fixed_ip").(string),
+			SubnetID:          d.Get("subnet_id").(string),
 		},
 		MapValueSpecs(d),
 	}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/doc.go
@@ -1,0 +1,71 @@
+/*
+package floatingips enables management and retrieval of Floating IPs from the
+OpenStack Networking service.
+
+Example to List Floating IPs
+
+	listOpts := floatingips.ListOpts{
+		FloatingNetworkID: "a6917946-38ab-4ffd-a55a-26c0980ce5ee",
+	}
+
+	allPages, err := floatingips.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allFIPs, err := floatingips.ExtractFloatingIPs(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, fip := range allFIPs {
+		fmt.Printf("%+v\n", fip)
+	}
+
+Example to Create a Floating IP
+
+	createOpts := floatingips.CreateOpts{
+		FloatingNetworkID: "a6917946-38ab-4ffd-a55a-26c0980ce5ee",
+	}
+
+	fip, err := floatingips.Create(networkingClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Floating IP
+
+	fipID := "2f245a7b-796b-4f26-9cf9-9e82d248fda7"
+	portID := "76d0a61b-b8e5-490c-9892-4cf674f2bec8"
+
+	updateOpts := floatingips.UpdateOpts{
+		PortID: &portID,
+	}
+
+	fip, err := floatingips.Update(networkingClient, fipID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Disassociate a Floating IP with a Port
+
+	fipID := "2f245a7b-796b-4f26-9cf9-9e82d248fda7"
+
+	updateOpts := floatingips.UpdateOpts{
+		PortID: nil,
+	}
+
+	fip, err := floatingips.Update(networkingClient, fipID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Floating IP
+
+	fipID := "2f245a7b-796b-4f26-9cf9-9e82d248fda7"
+	err := floatingips.Delete(networkClient, fipID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package floatingips

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/requests.go
@@ -22,6 +22,7 @@ type ListOpts struct {
 	SortKey           string `q:"sort_key"`
 	SortDir           string `q:"sort_dir"`
 	RouterID          string `q:"router_id"`
+	Status            string `q:"status"`
 }
 
 // List returns a Pager which allows you to iterate over a collection of
@@ -38,8 +39,8 @@ func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
 	})
 }
 
-// CreateOptsBuilder is the interface type must satisfy to be used as Create
-// options.
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToFloatingIPCreateMap() (map[string]interface{}, error)
 }
@@ -52,6 +53,7 @@ type CreateOpts struct {
 	FloatingIP        string `json:"floating_ip_address,omitempty"`
 	PortID            string `json:"port_id,omitempty"`
 	FixedIP           string `json:"fixed_ip_address,omitempty"`
+	SubnetID          string `json:"subnet_id,omitempty"`
 	TenantID          string `json:"tenant_id,omitempty"`
 }
 
@@ -78,10 +80,10 @@ func (opts CreateOpts) ToFloatingIPCreateMap() (map[string]interface{}, error) {
 // return 404 error code.
 //
 // You must also configure an IP address for the port associated with the PortID
-// you have provided - this is what the FixedIP refers to: an IP fixed to a port.
-// Because a port might be associated with multiple IP addresses, you can use
-// the FixedIP field to associate a particular IP address rather than have the
-// API assume for you. If you specify an IP address that is not valid, the
+// you have provided - this is what the FixedIP refers to: an IP fixed to a
+// port. Because a port might be associated with multiple IP addresses, you can
+// use the FixedIP field to associate a particular IP address rather than have
+// the API assume for you. If you specify an IP address that is not valid, the
 // operation will fail and return a 400 error code. If the PortID and FixedIP
 // are already associated with another resource, the operation will fail and
 // returns a 409 error code.
@@ -101,8 +103,8 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
-// UpdateOptsBuilder is the interface type must satisfy to be used as Update
-// options.
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToFloatingIPUpdateMap() (map[string]interface{}, error)
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/results.go
@@ -12,30 +12,32 @@ import (
 // floating IPs can only be defined on networks where the `router:external'
 // attribute (provided by the external network extension) is set to True.
 type FloatingIP struct {
-	// Unique identifier for the floating IP instance.
+	// ID is the unique identifier for the floating IP instance.
 	ID string `json:"id"`
 
-	// UUID of the external network where the floating IP is to be created.
+	// FloatingNetworkID is the UUID of the external network where the floating
+	// IP is to be created.
 	FloatingNetworkID string `json:"floating_network_id"`
 
-	// Address of the floating IP on the external network.
+	// FloatingIP is the address of the floating IP on the external network.
 	FloatingIP string `json:"floating_ip_address"`
 
-	// UUID of the port on an internal network that is associated with the floating IP.
+	// PortID is the UUID of the port on an internal network that is associated
+	// with the floating IP.
 	PortID string `json:"port_id"`
 
-	// The specific IP address of the internal port which should be associated
-	// with the floating IP.
+	// FixedIP is the specific IP address of the internal port which should be
+	// associated with the floating IP.
 	FixedIP string `json:"fixed_ip_address"`
 
-	// Owner of the floating IP. Only admin users can specify a tenant identifier
-	// other than its own.
+	// TenantID is the Owner of the floating IP. Only admin users can specify a
+	// tenant identifier other than its own.
 	TenantID string `json:"tenant_id"`
 
-	// The condition of the API resource.
+	// Status is the condition of the API resource.
 	Status string `json:"status"`
 
-	//The ID of the router used for this Floating-IP
+	// RouterID is the ID of the router used for this floating IP.
 	RouterID string `json:"router_id"`
 }
 
@@ -43,7 +45,7 @@ type commonResult struct {
 	gophercloud.Result
 }
 
-// Extract a result and extracts a FloatingIP resource.
+// Extract will extract a FloatingIP resource from a result.
 func (r commonResult) Extract() (*FloatingIP, error) {
 	var s struct {
 		FloatingIP *FloatingIP `json:"floatingip"`
@@ -52,22 +54,26 @@ func (r commonResult) Extract() (*FloatingIP, error) {
 	return s.FloatingIP, err
 }
 
-// CreateResult represents the result of a create operation.
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a FloatingIP.
 type CreateResult struct {
 	commonResult
 }
 
-// GetResult represents the result of a get operation.
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a FloatingIP.
 type GetResult struct {
 	commonResult
 }
 
-// UpdateResult represents the result of an update operation.
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a FloatingIP.
 type UpdateResult struct {
 	commonResult
 }
 
-// DeleteResult represents the result of an update operation.
+// DeleteResult represents the result of an update operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
@@ -78,9 +84,9 @@ type FloatingIPPage struct {
 	pagination.LinkedPageBase
 }
 
-// NextPageURL is invoked when a paginated collection of floating IPs has reached
-// the end of a page and the pager seeks to traverse over a new one. In order
-// to do this, it needs to construct the next page's URL.
+// NextPageURL is invoked when a paginated collection of floating IPs has
+// reached the end of a page and the pager seeks to traverse over a new one.
+// In order to do this, it needs to construct the next page's URL.
 func (r FloatingIPPage) NextPageURL() (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"floatingips_links"`
@@ -92,15 +98,15 @@ func (r FloatingIPPage) NextPageURL() (string, error) {
 	return gophercloud.ExtractNextURL(s.Links)
 }
 
-// IsEmpty checks whether a NetworkPage struct is empty.
+// IsEmpty checks whether a FloatingIPPage struct is empty.
 func (r FloatingIPPage) IsEmpty() (bool, error) {
 	is, err := ExtractFloatingIPs(r)
 	return len(is) == 0, err
 }
 
-// ExtractFloatingIPs accepts a Page struct, specifically a FloatingIPPage struct,
-// and extracts the elements into a slice of FloatingIP structs. In other words,
-// a generic collection is mapped into a relevant slice.
+// ExtractFloatingIPs accepts a Page struct, specifically a FloatingIPPage
+// struct, and extracts the elements into a slice of FloatingIP structs. In
+// other words, a generic collection is mapped into a relevant slice.
 func ExtractFloatingIPs(r pagination.Page) ([]FloatingIP, error) {
 	var s struct {
 		FloatingIPs []FloatingIP `json:"floatingips"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -463,10 +463,10 @@
 			"revisionTime": "2017-03-10T01:59:53Z"
 		},
 		{
-			"checksumSHA1": "CHmnyRSFPivC+b/ojgfeEIY5ReM=",
+			"checksumSHA1": "w1Mm8OqxEelnDWKtvRf4gsEyjOo=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "6da026c32e2d622cc242d32984259c77237aefe1",
+			"revisionTime": "2018-02-10T02:43:43Z"
 		},
 		{
 			"checksumSHA1": "X2qWZ68Xlfobx/EQR0EEGEpUJBk=",

--- a/website/docs/r/networking_floatingip_v2.html.markdown
+++ b/website/docs/r/networking_floatingip_v2.html.markdown
@@ -43,7 +43,10 @@ The following arguments are supported:
     may or may not have a different address)
 
 * `fixed_ip` - Fixed IP of the port to associate with this floating IP. Required if
-the port has multiple fixed IPs.
+    the port has multiple fixed IPs.
+
+* `subnet_id` - (Optional) The subnet ID of the floating IP pool. Specify this if
+    the floating IP network has multiple subnets.
 
 * `value_specs` - (Optional) Map of additional options.
 


### PR DESCRIPTION
This commit allows the user to specify a subnet_id when creating
a floating IP. This is useful if the floating IP network contains
multiple subnets.

Fixes #229 