### PR TITLE
Networking v2: Fix allowed_address_pairs

### DIFF
--- a/openstack/import_openstack_networking_port_v2_test.go
+++ b/openstack/import_openstack_networking_port_v2_test.go
@@ -29,3 +29,51 @@ func TestAccNetworkingV2Port_importBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccNetworkingV2Port_importAllowedAddressPairs(t *testing.T) {
+	resourceName := "openstack_networking_port_v2.instance_port"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2PortDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2Port_allowedAddressPairs_1,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"fixed_ip",
+				},
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2Port_importAllowedAddressPairsNoMAC(t *testing.T) {
+	resourceName := "openstack_networking_port_v2.instance_port"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2PortDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2Port_allowedAddressPairsNoMAC,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"fixed_ip",
+				},
+			},
+		},
+	})
+}

--- a/openstack/resource_openstack_networking_port_v2.go
+++ b/openstack/resource_openstack_networking_port_v2.go
@@ -119,7 +119,6 @@ func resourceNetworkingPortV2() *schema.Resource {
 						"mac_address": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
 						},
 					},
 				},
@@ -252,7 +251,13 @@ func resourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) erro
 	for _, pairObject := range p.AllowedAddressPairs {
 		pair := make(map[string]interface{})
 		pair["ip_address"] = pairObject.IPAddress
-		pair["mac_address"] = pairObject.MACAddress
+
+		// Only set the MAC address if it is different than the
+		// port's MAC. This means that a specific MAC was set.
+		if p.MACAddress != pairObject.MACAddress {
+			pair["mac_address"] = pairObject.MACAddress
+		}
+
 		pairs = append(pairs, pair)
 	}
 	d.Set("allowed_address_pairs", pairs)


### PR DESCRIPTION
This commit fixes a regression caused in #168.

This fix should now allow a user to both specify and omit a MAC
address when creating an allowed_address_pair and have the state
not require further changes. It should also allow importing of
ports with allowed_address_pairs to continue working.

Fixes #232 