### PR TITLE
Add data source and resource for roles

### DIFF
--- a/openstack/data_source_openstack_identity_role_v3.go
+++ b/openstack/data_source_openstack_identity_role_v3.go
@@ -1,0 +1,89 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceIdentityRoleV3() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceIdentityRoleV3Read,
+
+		Schema: map[string]*schema.Schema{
+			"domain_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+// dataSourceIdentityRoleV3Read performs the role lookup.
+func dataSourceIdentityRoleV3Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	listOpts := roles.ListOpts{
+		DomainID: d.Get("domain_id").(string),
+		Name:     d.Get("name").(string),
+	}
+
+	log.Printf("[DEBUG] List Options: %#v", listOpts)
+
+	var role roles.Role
+	allPages, err := roles.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		return fmt.Errorf("Unable to query roles: %s", err)
+	}
+
+	allRoles, err := roles.ExtractRoles(allPages)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve roles: %s", err)
+	}
+
+	if len(allRoles) < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	if len(allRoles) > 1 {
+		log.Printf("[DEBUG] Multiple results found: %#v", allRoles)
+		return fmt.Errorf("Your query returned more than one result. Please try a more " +
+			"specific search criteria, or set `most_recent` attribute to true.")
+	}
+	role = allRoles[0]
+
+	log.Printf("[DEBUG] Single Role found: %s", role.ID)
+	return dataSourceIdentityRoleV3Attributes(d, config, &role)
+}
+
+// dataSourceIdentityRoleV3Attributes populates the fields of an Role resource.
+func dataSourceIdentityRoleV3Attributes(d *schema.ResourceData, config *Config, role *roles.Role) error {
+	log.Printf("[DEBUG] openstack_identity_role_v3 details: %#v", role)
+
+	d.SetId(role.ID)
+	d.Set("name", role.Name)
+	d.Set("domain_id", role.DomainID)
+	d.Set("region", GetRegion(d, config))
+
+	return nil
+}

--- a/openstack/data_source_openstack_identity_role_v3_test.go
+++ b/openstack/data_source_openstack_identity_role_v3_test.go
@@ -1,0 +1,50 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccOpenStackIdentityV3RoleDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOpenStackIdentityV3RoleDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityV3DataSourceID("data.openstack_identity_role_v3.role_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_identity_role_v3.role_1", "name", "admin"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIdentityV3DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find role data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Role data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccOpenStackIdentityV3RoleDataSource_basic = `
+data "openstack_identity_role_v3" "role_1" {
+    name = "admin"
+}
+`

--- a/openstack/import_openstack_identity_role_v3_test.go
+++ b/openstack/import_openstack_identity_role_v3_test.go
@@ -1,0 +1,31 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccIdentityV3Role_importBasic(t *testing.T) {
+	resourceName := "openstack_identity_role_v3.role_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIdentityV3UserDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccIdentityV3Role_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -158,6 +158,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"openstack_compute_flavor_v2":        dataSourceComputeFlavorV2(),
 			"openstack_dns_zone_v2":              dataSourceDNSZoneV2(),
+			"openstack_identity_role_v3":         dataSourceIdentityRoleV3(),
 			"openstack_images_image_v2":          dataSourceImagesImageV2(),
 			"openstack_networking_network_v2":    dataSourceNetworkingNetworkV2(),
 			"openstack_networking_subnet_v2":     dataSourceNetworkingSubnetV2(),
@@ -187,6 +188,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_fw_policy_v1":                    resourceFWPolicyV1(),
 			"openstack_fw_rule_v1":                      resourceFWRuleV1(),
 			"openstack_identity_project_v3":             resourceIdentityProjectV3(),
+			"openstack_identity_role_v3":                resourceIdentityRoleV3(),
 			"openstack_identity_user_v3":                resourceIdentityUserV3(),
 			"openstack_images_image_v2":                 resourceImagesImageV2(),
 			"openstack_lb_member_v1":                    resourceLBMemberV1(),

--- a/openstack/resource_openstack_identity_role_v3.go
+++ b/openstack/resource_openstack_identity_role_v3.go
@@ -1,0 +1,125 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceIdentityRoleV3() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceIdentityRoleV3Create,
+		Read:   resourceIdentityRoleV3Read,
+		Update: resourceIdentityRoleV3Update,
+		Delete: resourceIdentityRoleV3Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"domain_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceIdentityRoleV3Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	createOpts := roles.CreateOpts{
+		DomainID: d.Get("domain_id").(string),
+		Name:     d.Get("name").(string),
+	}
+
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	role, err := roles.Create(identityClient, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack role: %s", err)
+	}
+
+	d.SetId(role.ID)
+
+	return resourceIdentityRoleV3Read(d, meta)
+}
+
+func resourceIdentityRoleV3Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	role, err := roles.Get(identityClient, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "role")
+	}
+
+	log.Printf("[DEBUG] Retrieved OpenStack role: %#v", role)
+
+	d.Set("domain_id", role.DomainID)
+	d.Set("name", role.Name)
+	d.Set("region", GetRegion(d, config))
+
+	return nil
+}
+
+func resourceIdentityRoleV3Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	var hasChange bool
+	var updateOpts roles.UpdateOpts
+
+	if d.HasChange("name") {
+		hasChange = true
+		updateOpts.Name = d.Get("name").(string)
+	}
+
+	if hasChange {
+		_, err := roles.Update(identityClient, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("Error updating OpenStack role: %s", err)
+		}
+	}
+
+	return resourceIdentityRoleV3Read(d, meta)
+}
+
+func resourceIdentityRoleV3Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	err = roles.Delete(identityClient, d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("Error deleting OpenStack role: %s", err)
+	}
+
+	return nil
+}

--- a/openstack/resource_openstack_identity_role_v3_test.go
+++ b/openstack/resource_openstack_identity_role_v3_test.go
@@ -1,0 +1,106 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
+)
+
+func TestAccIdentityV3Role_basic(t *testing.T) {
+	var role roles.Role
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIdentityV3RoleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccIdentityV3Role_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityV3RoleExists("openstack_identity_role_v3.role_1", &role),
+					resource.TestCheckResourceAttr(
+						"openstack_identity_role_v3.role_1", "name", "role_1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccIdentityV3Role_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityV3RoleExists("openstack_identity_role_v3.role_1", &role),
+					resource.TestCheckResourceAttr(
+						"openstack_identity_role_v3.role_1", "name", "role_2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIdentityV3RoleDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	identityClient, err := config.identityV3Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "openstack_identity_role_v3" {
+			continue
+		}
+
+		_, err := roles.Get(identityClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Role still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckIdentityV3RoleExists(n string, role *roles.Role) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		identityClient, err := config.identityV3Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating OpenStack identity client: %s", err)
+		}
+
+		found, err := roles.Get(identityClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("Role not found")
+		}
+
+		*role = *found
+
+		return nil
+	}
+}
+
+const testAccIdentityV3Role_basic = `
+resource "openstack_identity_role_v3" "role_1" {
+  name = "role_1"
+}
+`
+
+const testAccIdentityV3Role_update = `
+resource "openstack_identity_role_v3" "role_1" {
+  name = "role_2"
+}
+`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/doc.go
@@ -1,0 +1,112 @@
+/*
+Package roles provides information and interaction with the roles API
+resource for the OpenStack Identity service.
+
+Example to List Roles
+
+	listOpts := roles.ListOpts{
+		DomainID: "default",
+	}
+
+	allPages, err := roles.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allRoles, err := roles.ExtractRoles(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, role := range allRoles {
+		fmt.Printf("%+v\n", role)
+	}
+
+Example to Create a Role
+
+	createOpts := roles.CreateOpts{
+		Name:             "read-only-admin",
+		DomainID:         "default",
+		Extra: map[string]interface{}{
+			"description": "this role grants read-only privilege cross tenant",
+		}
+	}
+
+	role, err := roles.Create(identityClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Role
+
+	roleID := "0fe36e73809d46aeae6705c39077b1b3"
+
+	updateOpts := roles.UpdateOpts{
+		Name: "read only admin",
+	}
+
+	role, err := roles.Update(identityClient, roleID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Role
+
+	roleID := "0fe36e73809d46aeae6705c39077b1b3"
+	err := roles.Delete(identityClient, roleID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to List Role Assignments
+
+	listOpts := roles.ListAssignmentsOpts{
+		UserID:         "97061de2ed0647b28a393c36ab584f39",
+		ScopeProjectID: "9df1a02f5eb2416a9781e8b0c022d3ae",
+	}
+
+	allPages, err := roles.ListAssignments(identityClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allRoles, err := roles.ExtractRoleAssignments(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, role := range allRoles {
+		fmt.Printf("%+v\n", role)
+	}
+
+Example to Assign a Role to a User in a Project
+
+	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"
+	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
+	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
+
+	err := roles.Assign(identityClient, roleID, roles.AssignOpts{
+		UserID:    userID,
+		ProjectID: projectID,
+	}).ExtractErr()
+
+	if err != nil {
+		panic(err)
+	}
+
+Example to Unassign a Role From a User in a Project
+
+	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"
+	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
+	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
+
+	err := roles.Unassign(identityClient, roleID, roles.UnassignOpts{
+		UserID:    userID,
+		ProjectID: projectID,
+	}).ExtractErr()
+
+	if err != nil {
+		panic(err)
+	}
+*/
+package roles

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/requests.go
@@ -1,0 +1,314 @@
+package roles
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to
+// the List request
+type ListOptsBuilder interface {
+	ToRoleListQuery() (string, error)
+}
+
+// ListOpts provides options to filter the List results.
+type ListOpts struct {
+	// DomainID filters the response by a domain ID.
+	DomainID string `q:"domain_id"`
+
+	// Name filters the response by role name.
+	Name string `q:"name"`
+}
+
+// ToRoleListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToRoleListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List enumerates the roles to which the current token has access.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToRoleListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return RolePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves details on a single role, by ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to
+// the Create request.
+type CreateOptsBuilder interface {
+	ToRoleCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts provides options used to create a role.
+type CreateOpts struct {
+	// Name is the name of the new role.
+	Name string `json:"name" required:"true"`
+
+	// DomainID is the ID of the domain the role belongs to.
+	DomainID string `json:"domain_id,omitempty"`
+
+	// Extra is free-form extra key/value pairs to describe the role.
+	Extra map[string]interface{} `json:"-"`
+}
+
+// ToRoleCreateMap formats a CreateOpts into a create request.
+func (opts CreateOpts) ToRoleCreateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "role")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Extra != nil {
+		if v, ok := b["role"].(map[string]interface{}); ok {
+			for key, value := range opts.Extra {
+				v[key] = value
+			}
+		}
+	}
+
+	return b, nil
+}
+
+// Create creates a new Role.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToRoleCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateOptsBuilder interface {
+	ToRoleUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts provides options for updating a role.
+type UpdateOpts struct {
+	// Name is the name of the new role.
+	Name string `json:"name,omitempty"`
+
+	// Extra is free-form extra key/value pairs to describe the role.
+	Extra map[string]interface{} `json:"-"`
+}
+
+// ToRoleUpdateMap formats a UpdateOpts into an update request.
+func (opts UpdateOpts) ToRoleUpdateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "role")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Extra != nil {
+		if v, ok := b["role"].(map[string]interface{}); ok {
+			for key, value := range opts.Extra {
+				v[key] = value
+			}
+		}
+	}
+
+	return b, nil
+}
+
+// Update updates an existing Role.
+func Update(client *gophercloud.ServiceClient, roleID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToRoleUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Patch(updateURL(client, roleID), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete deletes a role.
+func Delete(client *gophercloud.ServiceClient, roleID string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, roleID), nil)
+	return
+}
+
+// ListAssignmentsOptsBuilder allows extensions to add additional parameters to
+// the ListAssignments request.
+type ListAssignmentsOptsBuilder interface {
+	ToRolesListAssignmentsQuery() (string, error)
+}
+
+// ListAssignmentsOpts allows you to query the ListAssignments method.
+// Specify one of or a combination of GroupId, RoleId, ScopeDomainId,
+// ScopeProjectId, and/or UserId to search for roles assigned to corresponding
+// entities.
+type ListAssignmentsOpts struct {
+	// GroupID is the group ID to query.
+	GroupID string `q:"group.id"`
+
+	// RoleID is the specific role to query assignments to.
+	RoleID string `q:"role.id"`
+
+	// ScopeDomainID filters the results by the given domain ID.
+	ScopeDomainID string `q:"scope.domain.id"`
+
+	// ScopeProjectID filters the results by the given Project ID.
+	ScopeProjectID string `q:"scope.project.id"`
+
+	// UserID filterst he results by the given User ID.
+	UserID string `q:"user.id"`
+
+	// Effective lists effective assignments at the user, project, and domain
+	// level, allowing for the effects of group membership.
+	Effective *bool `q:"effective"`
+}
+
+// ToRolesListAssignmentsQuery formats a ListAssignmentsOpts into a query string.
+func (opts ListAssignmentsOpts) ToRolesListAssignmentsQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// ListAssignments enumerates the roles assigned to a specified resource.
+func ListAssignments(client *gophercloud.ServiceClient, opts ListAssignmentsOptsBuilder) pagination.Pager {
+	url := listAssignmentsURL(client)
+	if opts != nil {
+		query, err := opts.ToRolesListAssignmentsQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return RoleAssignmentPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// AssignOpts provides options to assign a role
+type AssignOpts struct {
+	// UserID is the ID of a user to assign a role
+	// Note: exactly one of UserID or GroupID must be provided
+	UserID string `xor:"GroupID"`
+
+	// GroupID is the ID of a group to assign a role
+	// Note: exactly one of UserID or GroupID must be provided
+	GroupID string `xor:"UserID"`
+
+	// ProjectID is the ID of a project to assign a role on
+	// Note: exactly one of ProjectID or DomainID must be provided
+	ProjectID string `xor:"DomainID"`
+
+	// DomainID is the ID of a domain to assign a role on
+	// Note: exactly one of ProjectID or DomainID must be provided
+	DomainID string `xor:"ProjectID"`
+}
+
+// UnassignOpts provides options to unassign a role
+type UnassignOpts struct {
+	// UserID is the ID of a user to unassign a role
+	// Note: exactly one of UserID or GroupID must be provided
+	UserID string `xor:"GroupID"`
+
+	// GroupID is the ID of a group to unassign a role
+	// Note: exactly one of UserID or GroupID must be provided
+	GroupID string `xor:"UserID"`
+
+	// ProjectID is the ID of a project to unassign a role on
+	// Note: exactly one of ProjectID or DomainID must be provided
+	ProjectID string `xor:"DomainID"`
+
+	// DomainID is the ID of a domain to unassign a role on
+	// Note: exactly one of ProjectID or DomainID must be provided
+	DomainID string `xor:"ProjectID"`
+}
+
+// Assign is the operation responsible for assigning a role
+// to a user/group on a project/domain.
+func Assign(client *gophercloud.ServiceClient, roleID string, opts AssignOpts) (r AssignmentResult) {
+	// Check xor conditions
+	_, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	// Get corresponding URL
+	var targetID string
+	var targetType string
+	if opts.ProjectID != "" {
+		targetID = opts.ProjectID
+		targetType = "projects"
+	} else {
+		targetID = opts.DomainID
+		targetType = "domains"
+	}
+
+	var actorID string
+	var actorType string
+	if opts.UserID != "" {
+		actorID = opts.UserID
+		actorType = "users"
+	} else {
+		actorID = opts.GroupID
+		actorType = "groups"
+	}
+
+	_, r.Err = client.Put(assignURL(client, targetType, targetID, actorType, actorID, roleID), nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}
+
+// Unassign is the operation responsible for unassigning a role
+// from a user/group on a project/domain.
+func Unassign(client *gophercloud.ServiceClient, roleID string, opts UnassignOpts) (r UnassignmentResult) {
+	// Check xor conditions
+	_, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	// Get corresponding URL
+	var targetID string
+	var targetType string
+	if opts.ProjectID != "" {
+		targetID = opts.ProjectID
+		targetType = "projects"
+	} else {
+		targetID = opts.DomainID
+		targetType = "domains"
+	}
+
+	var actorID string
+	var actorType string
+	if opts.UserID != "" {
+		actorID = opts.UserID
+		actorType = "users"
+	} else {
+		actorID = opts.GroupID
+		actorType = "groups"
+	}
+
+	_, r.Err = client.Delete(assignURL(client, targetType, targetID, actorType, actorID, roleID), &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/results.go
@@ -1,0 +1,214 @@
+package roles
+
+import (
+	"encoding/json"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/internal"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Role grants permissions to a user.
+type Role struct {
+	// DomainID is the domain ID the role belongs to.
+	DomainID string `json:"domain_id"`
+
+	// ID is the unique ID of the role.
+	ID string `json:"id"`
+
+	// Links contains referencing links to the role.
+	Links map[string]interface{} `json:"links"`
+
+	// Name is the role name
+	Name string `json:"name"`
+
+	// Extra is a collection of miscellaneous key/values.
+	Extra map[string]interface{} `json:"-"`
+}
+
+func (r *Role) UnmarshalJSON(b []byte) error {
+	type tmp Role
+	var s struct {
+		tmp
+		Extra map[string]interface{} `json:"extra"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Role(s.tmp)
+
+	// Collect other fields and bundle them into Extra
+	// but only if a field titled "extra" wasn't sent.
+	if s.Extra != nil {
+		r.Extra = s.Extra
+	} else {
+		var result interface{}
+		err := json.Unmarshal(b, &result)
+		if err != nil {
+			return err
+		}
+		if resultMap, ok := result.(map[string]interface{}); ok {
+			r.Extra = internal.RemainingKeys(Role{}, resultMap)
+		}
+	}
+
+	return err
+}
+
+type roleResult struct {
+	gophercloud.Result
+}
+
+// GetResult is the response from a Get operation. Call its Extract method
+// to interpret it as a Role.
+type GetResult struct {
+	roleResult
+}
+
+// CreateResult is the response from a Create operation. Call its Extract method
+// to interpret it as a Role
+type CreateResult struct {
+	roleResult
+}
+
+// UpdateResult is the response from an Update operation. Call its Extract
+// method to interpret it as a Role.
+type UpdateResult struct {
+	roleResult
+}
+
+// DeleteResult is the response from a Delete operation. Call its ExtractErr to
+// determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// RolePage is a single page of Role results.
+type RolePage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines whether or not a page of Roles contains any results.
+func (r RolePage) IsEmpty() (bool, error) {
+	roles, err := ExtractRoles(r)
+	return len(roles) == 0, err
+}
+
+// NextPageURL extracts the "next" link from the links section of the result.
+func (r RolePage) NextPageURL() (string, error) {
+	var s struct {
+		Links struct {
+			Next     string `json:"next"`
+			Previous string `json:"previous"`
+		} `json:"links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Links.Next, err
+}
+
+// ExtractProjects returns a slice of Roles contained in a single page of
+// results.
+func ExtractRoles(r pagination.Page) ([]Role, error) {
+	var s struct {
+		Roles []Role `json:"roles"`
+	}
+	err := (r.(RolePage)).ExtractInto(&s)
+	return s.Roles, err
+}
+
+// Extract interprets any roleResults as a Role.
+func (r roleResult) Extract() (*Role, error) {
+	var s struct {
+		Role *Role `json:"role"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Role, err
+}
+
+// RoleAssignment is the result of a role assignments query.
+type RoleAssignment struct {
+	Role  AssignedRole `json:"role,omitempty"`
+	Scope Scope        `json:"scope,omitempty"`
+	User  User         `json:"user,omitempty"`
+	Group Group        `json:"group,omitempty"`
+}
+
+// AssignedRole represents a Role in an assignment.
+type AssignedRole struct {
+	ID string `json:"id,omitempty"`
+}
+
+// Scope represents a scope in a Role assignment.
+type Scope struct {
+	Domain  Domain  `json:"domain,omitempty"`
+	Project Project `json:"project,omitempty"`
+}
+
+// Domain represents a domain in a role assignment scope.
+type Domain struct {
+	ID string `json:"id,omitempty"`
+}
+
+// Project represents a project in a role assignment scope.
+type Project struct {
+	ID string `json:"id,omitempty"`
+}
+
+// User represents a user in a role assignment scope.
+type User struct {
+	ID string `json:"id,omitempty"`
+}
+
+// Group represents a group in a role assignment scope.
+type Group struct {
+	ID string `json:"id,omitempty"`
+}
+
+// RoleAssignmentPage is a single page of RoleAssignments results.
+type RoleAssignmentPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if the RoleAssignmentPage contains no results.
+func (r RoleAssignmentPage) IsEmpty() (bool, error) {
+	roleAssignments, err := ExtractRoleAssignments(r)
+	return len(roleAssignments) == 0, err
+}
+
+// NextPageURL uses the response's embedded link reference to navigate to
+// the next page of results.
+func (r RoleAssignmentPage) NextPageURL() (string, error) {
+	var s struct {
+		Links struct {
+			Next string `json:"next"`
+		} `json:"links"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Links.Next, err
+}
+
+// ExtractRoleAssignments extracts a slice of RoleAssignments from a Collection
+// acquired from List.
+func ExtractRoleAssignments(r pagination.Page) ([]RoleAssignment, error) {
+	var s struct {
+		RoleAssignments []RoleAssignment `json:"role_assignments"`
+	}
+	err := (r.(RoleAssignmentPage)).ExtractInto(&s)
+	return s.RoleAssignments, err
+}
+
+// AssignmentResult represents the result of an assign operation.
+// Call ExtractErr method to determine if the request succeeded or failed.
+type AssignmentResult struct {
+	gophercloud.ErrResult
+}
+
+// UnassignmentResult represents the result of an unassign operation.
+// Call ExtractErr method to determine if the request succeeded or failed.
+type UnassignmentResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/urls.go
@@ -1,0 +1,35 @@
+package roles
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rolePath = "roles"
+)
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL(rolePath)
+}
+
+func getURL(client *gophercloud.ServiceClient, roleID string) string {
+	return client.ServiceURL(rolePath, roleID)
+}
+
+func createURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL(rolePath)
+}
+
+func updateURL(client *gophercloud.ServiceClient, roleID string) string {
+	return client.ServiceURL(rolePath, roleID)
+}
+
+func deleteURL(client *gophercloud.ServiceClient, roleID string) string {
+	return client.ServiceURL(rolePath, roleID)
+}
+
+func listAssignmentsURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("role_assignments")
+}
+
+func assignURL(client *gophercloud.ServiceClient, targetType, targetID, actorType, actorID, roleID string) string {
+	return client.ServiceURL(targetType, targetID, actorType, actorID, rolePath, roleID)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -421,6 +421,12 @@
 			"revisionTime": "2017-07-14T02:05:18Z"
 		},
 		{
+			"checksumSHA1": "KXCCoDbSLSiwN+WCicZxWTBeaRY=",
+			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/roles",
+			"revision": "6da026c32e2d622cc242d32984259c77237aefe1",
+			"revisionTime": "2018-02-10T02:43:43Z"
+		},
+		{
 			"checksumSHA1": "HzVyehPh0jvNZpL5iodoWpUd46k=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
 			"revision": "c7551a666c4fee120cc314dce91ba3d0663a86f3",

--- a/website/docs/d/identity_role_v3.html.markdown
+++ b/website/docs/d/identity_role_v3.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_identity_role_v3"
+sidebar_current: "docs-openstack-datasource-identity-role-v3"
+description: |-
+  Get information on an OpenStack Role.
+---
+
+# openstack\_identity\_role\_v3
+
+Use this data source to get the ID of an OpenStack role.
+
+## Example Usage
+
+```hcl
+data "openstack_identity_role_v3" "admin" {
+  name = "admin"
+}
+```
+
+## Argument Reference
+
+* `name` - The name of the role.
+
+* `domain_id` - (Optional) The domain the role belongs to.
+
+* `region` - (Optional) The region in which to obtain the V3 Keystone client.
+    If omitted, the `region` argument of the provider is used.
+
+
+## Attributes Reference
+
+`id` is set to the ID of the found role. In addition, the following attributes
+are exported:
+
+* `name` - See Argument Reference above.
+* `domain_id` - See Argument Reference above.
+* `region` - See Argument Reference above.

--- a/website/docs/r/identity_role_v3.html.markdown
+++ b/website/docs/r/identity_role_v3.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_identity_role_v3"
+sidebar_current: "docs-openstack-resource-identity-role-v3"
+description: |-
+  Manages a V3 Role resource within OpenStack Keystone.
+---
+
+# openstack\_identity\_role_v3
+
+Manages a V3 Role resource within OpenStack Keystone.
+
+Note: You _must_ have admin privileges in your OpenStack cloud to use
+this resource.
+
+## Example Usage
+
+```hcl
+resource "openstack_identity_role_v3" "role_1" {
+  name = "role_1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - The name of the role.
+
+* `domain_id` - (Optional) The domain the role belongs to.
+
+* `region` - (Optional) The region in which to obtain the V3 Keystone client.
+    If omitted, the `region` argument of the provider is used. Changing this
+    creates a new Role.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - See Argument Reference above.
+* `domain_id` - See Argument Reference above.
+* `region` - See Argument Reference above.
+
+## Import
+
+Roles can be imported using the `id`, e.g.
+
+```
+$ terraform import openstack_identity_role_v3.role_1 89c60255-9bd6-460c-822a-e2b959ede9d2
+```

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -19,6 +19,9 @@
             <li<%= sidebar_current("docs-openstack-datasource-dns-zone-v2") %>>
               <a href="/docs/providers/openstack/d/dns_zone_v2.html">openstack_dns_zone_v2</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-datasource-identity-role-v3") %>>
+              <a href="/docs/providers/openstack/d/identity_role_v3.html">openstack_identity_role_v3</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-datasource-images-image-v2") %>>
               <a href="/docs/providers/openstack/d/images_image_v2.html">openstack_images_image_v2</a>
             </li>
@@ -116,6 +119,9 @@
           <ul class="nav nav-visible">
             <li<%= sidebar_current("docs-openstack-resource-identity-project-v3") %>>
               <a href="/docs/providers/openstack/r/identity_project_v3.html">openstack_identity_project_v3</a>
+            </li>
+            <li<%= sidebar_current("docs-openstack-resource-identity-role-v3") %>>
+              <a href="/docs/providers/openstack/r/identity_role_v3.html">openstack_identity_role_v3</a>
             </li>
             <li<%= sidebar_current("docs-openstack-resource-identity-user-v3") %>>
               <a href="/docs/providers/openstack/r/identity_user_v3.html">openstack_identity_user_v3</a>


### PR DESCRIPTION
Adds `openstack_identity_role_v3` data source & resource.

See #248 for more information (this PR contains part of the content that was initially proposed there).

Docs are still missing.