### PR TITLE
Add project data source

### DIFF
--- a/openstack/data_source_openstack_identity_project_v3.go
+++ b/openstack/data_source_openstack_identity_project_v3.go
@@ -1,0 +1,117 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceIdentityProjectV3() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceIdentityProjectV3Read,
+
+		Schema: map[string]*schema.Schema{
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"enabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"is_domain": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"parent_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+// dataSourceIdentityProjectV3Read performs the project lookup.
+func dataSourceIdentityProjectV3Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	enabled := d.Get("enabled").(bool)
+	isDomain := d.Get("is_domain").(bool)
+	listOpts := projects.ListOpts{
+		DomainID: d.Get("domain_id").(string),
+		Enabled:  &enabled,
+		IsDomain: &isDomain,
+		Name:     d.Get("name").(string),
+		ParentID: d.Get("parent_id").(string),
+	}
+
+	log.Printf("[DEBUG] List Options: %#v", listOpts)
+
+	var project projects.Project
+	allPages, err := projects.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		return fmt.Errorf("Unable to query projects: %s", err)
+	}
+
+	allProjects, err := projects.ExtractProjects(allPages)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve projects: %s", err)
+	}
+
+	if len(allProjects) < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	if len(allProjects) > 1 {
+		log.Printf("[DEBUG] Multiple results found: %#v", allProjects)
+		return fmt.Errorf("Your query returned more than one result")
+	}
+	project = allProjects[0]
+
+	log.Printf("[DEBUG] Single project found: %s", project.ID)
+	return dataSourceIdentityProjectV3Attributes(d, &project)
+}
+
+// dataSourceIdentityProjectV3Attributes populates the fields of an Project resource.
+func dataSourceIdentityProjectV3Attributes(d *schema.ResourceData, project *projects.Project) error {
+	log.Printf("[DEBUG] openstack_identity_project_v3 details: %#v", project)
+
+	d.SetId(project.ID)
+	d.Set("is_domain", project.IsDomain)
+	d.Set("description", project.Description)
+	d.Set("domain_id", project.DomainID)
+	d.Set("enabled", project.Enabled)
+	d.Set("name", project.Name)
+	d.Set("parent_id", project.ParentID)
+
+	return nil
+}

--- a/openstack/data_source_openstack_identity_project_v3_test.go
+++ b/openstack/data_source_openstack_identity_project_v3_test.go
@@ -1,0 +1,76 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccOpenStackIdentityV3ProjectDataSource_basic(t *testing.T) {
+	projectName := fmt.Sprintf("tf_test_%s", acctest.RandString(5))
+	projectDescription := acctest.RandString(20)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOpenStackIdentityProjectV3DataSource_project(projectName, projectDescription),
+			},
+			resource.TestStep{
+				Config: testAccOpenStackIdentityProjectV3DataSource_basic(projectName, projectDescription),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityV3ProjectDataSourceID("data.openstack_identity_project_v3.project_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_identity_project_v3.project_1", "name", projectName),
+					resource.TestCheckResourceAttr(
+						"openstack_identity_project_v3.project_1", "description", projectDescription),
+					resource.TestCheckResourceAttr(
+						"openstack_identity_project_v3.project_1", "enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"openstack_identity_project_v3.project_1", "is_domain", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIdentityV3ProjectDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find project data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Project data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccOpenStackIdentityProjectV3DataSource_project(name, description string) string {
+	return fmt.Sprintf(`
+	resource "openstack_identity_project_v3" "project_1" {
+	  name = "%s"
+	  description = "%s"
+	}
+`, name, description)
+}
+
+func testAccOpenStackIdentityProjectV3DataSource_basic(name, description string) string {
+	return fmt.Sprintf(`
+	%s
+
+	data "openstack_identity_project_v3" "project_1" {
+      name = "${openstack_identity_project_v3.project_1.name}"
+	}
+`, testAccOpenStackIdentityProjectV3DataSource_project(name, description))
+}

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -159,6 +159,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_compute_flavor_v2":        dataSourceComputeFlavorV2(),
 			"openstack_dns_zone_v2":              dataSourceDNSZoneV2(),
 			"openstack_identity_role_v3":         dataSourceIdentityRoleV3(),
+			"openstack_identity_project_v3":      dataSourceIdentityProjectV3(),
 			"openstack_images_image_v2":          dataSourceImagesImageV2(),
 			"openstack_networking_network_v2":    dataSourceNetworkingNetworkV2(),
 			"openstack_networking_subnet_v2":     dataSourceNetworkingSubnetV2(),

--- a/website/docs/d/identity_project_v3.html.markdown
+++ b/website/docs/d/identity_project_v3.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_identity_project_v3"
+sidebar_current: "docs-openstack-datasource-identity-project-v3"
+description: |-
+  Get information on an OpenStack Project.
+---
+
+# openstack\_identity\_project_v3
+
+Use this data source to get the ID of an OpenStack project.
+
+## Example Usage
+
+```hcl
+data "openstack_identity_project_v3" "project_1" {
+  name = "demo"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_id` - (Optional) The domain this project belongs to.
+
+* `enabled` - (Optional) Whether the project is enabled or disabled. Valid
+  values are `true` and `false`.
+
+* `is_domain` - (Optional) Whether this project is a domain. Valid values
+  are `true` and `false`.
+
+* `name` - (Optional) The name of the project.
+
+* `parent_id` - (Optional) The parent of this project.
+
+## Attributes Reference
+
+`id` is set to the ID of the found project. In addition, the following attributes
+are exported:
+
+* `description` - The description of the project.
+* `domain_id` - See Argument Reference above.
+* `enabled` - See Argument Reference above.
+* `is_domain` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `parent_id` - See Argument Reference above.
+* `region` - The region the project is located in.

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -19,6 +19,9 @@
             <li<%= sidebar_current("docs-openstack-datasource-dns-zone-v2") %>>
               <a href="/docs/providers/openstack/d/dns_zone_v2.html">openstack_dns_zone_v2</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-datasource-identity-project-v3") %>>
+              <a href="/docs/providers/openstack/d/identity_project_v3.html">openstack_identity_project_v3</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-datasource-identity-role-v3") %>>
               <a href="/docs/providers/openstack/d/identity_role_v3.html">openstack_identity_role_v3</a>
             </li>


### PR DESCRIPTION
Adds data source `openstack_identity_project_v3`.

See #248 for more information (this PR contains part of the content that was initially proposed there).

Tests & docs are still missing.