### PR TITLE
Add user data source

### DIFF
--- a/openstack/data_source_openstack_identity_user_v3.go
+++ b/openstack/data_source_openstack_identity_user_v3.go
@@ -1,0 +1,163 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceIdentityUserV3() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceIdentityUserV3Read,
+
+		Schema: map[string]*schema.Schema{
+			"default_project_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"enabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"idp_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"password_expires_at": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validatePasswordExpiresAtQuery,
+			},
+
+			"protocol_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"unique_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+// dataSourceIdentityUserV3Read performs the user lookup.
+func dataSourceIdentityUserV3Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	enabled := d.Get("enabled").(bool)
+	listOpts := users.ListOpts{
+		DomainID:          d.Get("domain_id").(string),
+		Enabled:           &enabled,
+		IdPID:             d.Get("idp_id").(string),
+		Name:              d.Get("name").(string),
+		PasswordExpiresAt: d.Get("password_expires_at").(string),
+		ProtocolID:        d.Get("protocol_id").(string),
+		UniqueID:          d.Get("unique_id").(string),
+	}
+
+	log.Printf("[DEBUG] List Options: %#v", listOpts)
+
+	var user users.User
+	allPages, err := users.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		return fmt.Errorf("Unable to query users: %s", err)
+	}
+
+	allUsers, err := users.ExtractUsers(allPages)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve users: %s", err)
+	}
+
+	if len(allUsers) < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	if len(allUsers) > 1 {
+		log.Printf("[DEBUG] Multiple results found: %#v", allUsers)
+		return fmt.Errorf("Your query returned more than one result")
+	}
+	user = allUsers[0]
+
+	log.Printf("[DEBUG] Single user found: %s", user.ID)
+	return dataSourceIdentityUserV3Attributes(d, &user)
+}
+
+// dataSourceIdentityUserV3Attributes populates the fields of an User resource.
+func dataSourceIdentityUserV3Attributes(d *schema.ResourceData, user *users.User) error {
+	log.Printf("[DEBUG] openstack_identity_user_v3 details: %#v", user)
+
+	d.SetId(user.ID)
+	d.Set("default_project_id", user.DefaultProjectID)
+	d.Set("description", user.Description)
+	d.Set("domain_id", user.DomainID)
+	d.Set("enabled", user.Enabled)
+	d.Set("name", user.Name)
+	d.Set("password_expires_at", user.PasswordExpiresAt.Format(time.RFC3339))
+
+	return nil
+}
+
+// Ensure that password_expires_at query matches format explained in
+// https://developer.openstack.org/api-ref/identity/v3/#list-users
+func validatePasswordExpiresAtQuery(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	values := strings.SplitN(value, ":", 2)
+	if len(values) != 2 {
+		err := fmt.Errorf("%s '%s' does not match expected format: {operator}:{timestamp}", k, value)
+		errors = append(errors, err)
+	}
+	operator, timestamp := values[0], values[1]
+
+	validOperators := map[string]bool{
+		"lt":  true,
+		"lte": true,
+		"gt":  true,
+		"gte": true,
+		"eq":  true,
+		"neq": true,
+	}
+	if !validOperators[operator] {
+		err := fmt.Errorf("'%s' is not a valid operator for %s. Choose one of 'lt', 'lte', 'gt', 'gte', 'eq', 'neq'", operator, k)
+		errors = append(errors, err)
+	}
+
+	_, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		err = fmt.Errorf("'%s' is not a valid timestamp for %s. It should be in the form 'YYYY-MM-DDTHH:mm:ssZ'", timestamp, k)
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/openstack/data_source_openstack_identity_user_v3_test.go
+++ b/openstack/data_source_openstack_identity_user_v3_test.go
@@ -1,0 +1,107 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccOpenStackIdentityV3UserDataSource_basic(t *testing.T) {
+	userName := fmt.Sprintf("tf_test_%s", acctest.RandString(5))
+	userPassword := acctest.RandString(20)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOpenStackIdentityUserV3DataSource_user(userName, userPassword),
+			},
+			resource.TestStep{
+				Config: testAccOpenStackIdentityUserV3DataSource_basic(userName, userPassword),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityUserV3DataSourceID("data.openstack_identity_user_v3.user_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_identity_user_v3.user_1", "name", userName),
+					resource.TestCheckResourceAttr(
+						"data.openstack_identity_user_v3.user_1", "domain_id", "default"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_identity_user_v3.user_1", "enabled", "true"),
+					testAccCheckIdentityUserV3DataSourceDefaultProjectID(
+						"data.openstack_identity_user_v3.user_1", "openstack_identity_project_v3.project_1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIdentityUserV3DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find user data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("User data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckIdentityUserV3DataSourceDefaultProjectID(n1, n2 string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ds1, ok := s.RootModule().Resources[n1]
+		if !ok {
+			return fmt.Errorf("Can't find user data source: %s", n1)
+		}
+
+		if ds1.Primary.ID == "" {
+			return fmt.Errorf("User data source ID not set")
+		}
+
+		rs2, ok := s.RootModule().Resources[n2]
+		if !ok {
+			return fmt.Errorf("Can't find project resource: %s", n2)
+		}
+
+		if rs2.Primary.ID == "" {
+			return fmt.Errorf("Project resource ID not set")
+		}
+
+		if rs2.Primary.ID != ds1.Primary.Attributes["default_project_id"] {
+			return fmt.Errorf("Project id and user default_project_id don't match")
+		}
+
+		return nil
+	}
+}
+
+func testAccOpenStackIdentityUserV3DataSource_user(name, password string) string {
+	return fmt.Sprintf(`
+	%s
+
+	resource "openstack_identity_user_v3" "user_1" {
+	  name = "%s"
+	  password = "%s"
+	  default_project_id = "${openstack_identity_project_v3.project_1.id}"
+	}
+`, testAccOpenStackIdentityProjectV3DataSource_project(fmt.Sprintf("%s_project", name), acctest.RandString(20)), name, password)
+}
+
+func testAccOpenStackIdentityUserV3DataSource_basic(name, password string) string {
+	return fmt.Sprintf(`
+	%s
+
+	data "openstack_identity_user_v3" "user_1" {
+      name = "${openstack_identity_user_v3.user_1.name}"
+	}
+`, testAccOpenStackIdentityUserV3DataSource_user(name, password))
+}

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -163,6 +163,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_dns_zone_v2":              dataSourceDNSZoneV2(),
 			"openstack_identity_role_v3":         dataSourceIdentityRoleV3(),
 			"openstack_identity_project_v3":      dataSourceIdentityProjectV3(),
+			"openstack_identity_user_v3":         dataSourceIdentityUserV3(),
 			"openstack_images_image_v2":          dataSourceImagesImageV2(),
 			"openstack_networking_network_v2":    dataSourceNetworkingNetworkV2(),
 			"openstack_networking_subnet_v2":     dataSourceNetworkingSubnetV2(),

--- a/website/docs/d/identity_user_v3.html.markdown
+++ b/website/docs/d/identity_user_v3.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_identity_user_v3"
+sidebar_current: "docs-openstack-datasource-identity-user-v3"
+description: |-
+  Get information on an OpenStack User.
+---
+
+# openstack\_identity\_user_v3
+
+Use this data source to get the ID of an OpenStack user.
+
+## Example Usage
+
+```hcl
+data "openstack_identity_user_v3" "user_1" {
+  name = "user_1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Optional) A description of the user.
+
+* `default_project_id` - (Optional) The default project this user belongs to.
+
+* `domain_id` - (Optional) The domain this user belongs to.
+
+* `enabled` - (Optional) Whether the user is enabled or disabled. Valid
+  values are `true` and `false`.
+
+* `idp_id` - (Optional) The identity provider ID of the user.
+
+* `name` - (Optional) The name of the user.
+
+* `password_expires_at` - (Optional) Query for expired passwords. See the [https://developer.openstack.org/api-ref/identity/v3/#list-users](OpenStack API docs) for more information on the query format.
+
+* `protocol_id` - (Optional) The protocol ID of the user.
+
+* `unique_id` - (Optional) The unique ID of the user.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `default_project_id` - See Argument Reference above.
+* `domain_id` - See Argument Reference above.
+* `enabled` - See Argument Reference above.
+* `idp_id` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `password_expires_at` - See Argument Reference above.
+* `protocol_id` - See Argument Reference above.
+* `region` - The region the user is located in.
+* `unique_id` - See Argument Reference above.

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -25,6 +25,9 @@
             <li<%= sidebar_current("docs-openstack-datasource-identity-role-v3") %>>
               <a href="/docs/providers/openstack/d/identity_role_v3.html">openstack_identity_role_v3</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-datasource-identity-user-v3") %>>
+              <a href="/docs/providers/openstack/d/identity_user_v3.html">openstack_identity_user_v3</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-datasource-images-image-v2") %>>
               <a href="/docs/providers/openstack/d/images_image_v2.html">openstack_images_image_v2</a>
             </li>


### PR DESCRIPTION
Adds data source `openstack_identity_user_v3`.

See #248 for more information (this PR contains part of the content that was initially proposed there).

Tests & docs are still missing.