### PR TITLE
Filter image with  MemberStatus field

### DIFF
--- a/openstack/data_source_openstack_images_image_v2.go
+++ b/openstack/data_source_openstack_images_image_v2.go
@@ -34,6 +34,12 @@ func dataSourceImagesImageV2() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"member_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"owner": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -154,17 +160,19 @@ func dataSourceImagesImageV2Read(d *schema.ResourceData, meta interface{}) error
 	}
 
 	visibility := resourceImagesImageV2VisibilityFromString(d.Get("visibility").(string))
+	member_status := resourceImagesImageV2MemberStatusFromString(d.Get("member_status").(string))
 
 	listOpts := images.ListOpts{
-		Name:       d.Get("name").(string),
-		Visibility: visibility,
-		Owner:      d.Get("owner").(string),
-		Status:     images.ImageStatusActive,
-		SizeMin:    int64(d.Get("size_min").(int)),
-		SizeMax:    int64(d.Get("size_max").(int)),
-		SortKey:    d.Get("sort_key").(string),
-		SortDir:    d.Get("sort_direction").(string),
-		Tag:        d.Get("tag").(string),
+		Name:         d.Get("name").(string),
+		Visibility:   visibility,
+		Owner:        d.Get("owner").(string),
+		Status:       images.ImageStatusActive,
+		SizeMin:      int64(d.Get("size_min").(int)),
+		SizeMax:      int64(d.Get("size_max").(int)),
+		SortKey:      d.Get("sort_key").(string),
+		SortDir:      d.Get("sort_direction").(string),
+		Tag:          d.Get("tag").(string),
+		MemberStatus: member_status,
 	}
 
 	log.Printf("[DEBUG] List Options: %#v", listOpts)

--- a/openstack/resource_openstack_images_image_v2.go
+++ b/openstack/resource_openstack_images_image_v2.go
@@ -403,6 +403,21 @@ func resourceImagesImageV2ValidateContainerFormat(v interface{}, k string) (ws [
 	return
 }
 
+func resourceImagesImageV2MemberStatusFromString(v string) images.ImageMemberStatus {
+	switch v {
+	case "accepted":
+		return images.ImageMemberStatusAccepted
+	case "pending":
+		return images.ImageMemberStatusPending
+	case "rejected":
+		return images.ImageMemberStatusRejected
+	case "all":
+		return images.ImageMemberStatusAll
+	}
+
+	return ""
+}
+
 func resourceImagesImageV2VisibilityFromString(v string) images.ImageVisibility {
 	switch v {
 	case "public":

--- a/website/docs/d/images_image_v2.html.markdown
+++ b/website/docs/d/images_image_v2.html.markdown
@@ -53,6 +53,8 @@ data "openstack_images_image_v2" "ubuntu" {
 * `visibility` - (Optional) The visibility of the image. Must be one of
    "public", "private", "community", or "shared". Defaults to "private".
 
+* `member_status` - (Optional) The status of the image. Must be one of
+   "accepted", "pending", "rejected", or "all".
 
 ## Attributes Reference
 


### PR DESCRIPTION
To get ID of a shared image we need to filter with member_status = all

Documentation:
https://specs.openstack.org/openstack/glance-specs/specs/api/v2/sharing-image-api-v2.html#list-shared-images

```
visibility=shared&member_status=all: show all images shared with me regardless of my member status
```

It's a mandatory feature if image was shared with your tenant and you only know the name.