### PR TITLE
Support acceptance test against OpenStack Queens release in OpenLab

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -16,6 +16,9 @@
     recheck-pike:
       jobs:
         - terraform-provider-openstack-acceptance-test-pike
+    recheck-queens:
+      jobs:
+        - terraform-provider-openstack-acceptance-test-queens
     recheck-trove:
       jobs:
         - terraform-provider-openstack-acceptance-test-trove


### PR DESCRIPTION
Input comment "recheck stable/queens" in pull request comments, that
will trigger acceptance tests against OpenStack Queens release. OpenLab
will report test result in followint comments automatically.

Related-Bug: theopenlab/openlab#38