### PR TITLE
Networking v2: Add disable_snat to router resource

### DIFF
--- a/openstack/resource_openstack_networking_router_v2_test.go
+++ b/openstack/resource_openstack_networking_router_v2_test.go
@@ -60,6 +60,44 @@ func TestAccNetworkingV2Router_updateExternalGateway(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2Router_enableSNAT(t *testing.T) {
+	var router routers.Router
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2RouterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2Router_enableSNAT_1,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2RouterExists("openstack_networking_router_v2.router_1", &router),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_router_v2.router_1", "external_network_id", OS_EXTGW_ID),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_router_v2.router_1", "enable_snat", "true"),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_router_v2.router_1", "disable_snat", "false"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccNetworkingV2Router_enableSNAT_2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"openstack_networking_router_v2.router_1", "external_network_id", OS_EXTGW_ID),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_router_v2.router_1", "enable_snat", "false"),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_router_v2.router_1", "disable_snat", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNetworkingV2Router_timeout(t *testing.T) {
 	var router routers.Router
 
@@ -208,3 +246,23 @@ resource "openstack_networking_router_v2" "router_1" {
   }
 }
 `
+
+var testAccNetworkingV2Router_enableSNAT_1 = fmt.Sprintf(`
+resource "openstack_networking_router_v2" "router_1" {
+	name = "router"
+	admin_state_up = "true"
+	distributed = "false"
+	external_network_id = "%s"
+	enable_snat = true
+}
+`, OS_EXTGW_ID)
+
+var testAccNetworkingV2Router_enableSNAT_2 = fmt.Sprintf(`
+resource "openstack_networking_router_v2" "router_1" {
+	name = "router"
+	admin_state_up = "true"
+	distributed = "false"
+	external_network_id = "%s"
+	disable_snat = true
+}
+`, OS_EXTGW_ID)

--- a/website/docs/r/networking_router_v2.html.markdown
+++ b/website/docs/r/networking_router_v2.html.markdown
@@ -51,9 +51,15 @@ The following arguments are supported:
     compute instances or load balancers will be using floating IPs. Changing
     this updates the external gateway of the router.
 
-* `enable_snat` - (Optional) Enable Source NAT for the router. Valid values are
-    "true" or "false". An `external_network_id` has to be set in order to
-    set this property. Changing this updates the `enable_snat` of the router.
+* `enable_snat` - (Optional - conflicts with `disable_snat`) Enable Source NAT
+    for the router. Valid values are "true" or "false". An `external_network_id`
+    has to be set in order to set this property. Changing this updates
+    the `enable_snat` of the router.
+
+* `disable_snat` - (Optional - conflicts with `enable_snat`) Disables Source NAT
+    for the router. Valid values are "true" or "false". An `external_network_id`
+    has to be set in order to set this property. Changing this updates
+    the `enable_snat` of the router.
 
 * `external_fixed_ip` - (Optional) An external fixed IP for the router. This
     can be repeated. The structure is described below. An `external_network_id`
@@ -68,9 +74,10 @@ The following arguments are supported:
 * `vendor_options` - (Optional) Map of additional vendor-specific options.
     Supported options are described below.
 
-* `availability_zone_hints` -  (Optional) An availability zone is used to make 
-    network resources highly available. Used for resources with high availability so that they are scheduled on different availability zones. Changing
-    this creates a new router.
+* `availability_zone_hints` -  (Optional) An availability zone is used to make
+    network resources highly available. Used for resources with high
+    availability so that they are scheduled on different availability zones.
+    Changing this creates a new router.
 
 The `external_fixed_ip` block supports:
 


### PR DESCRIPTION
This commit adds the disable_snat argument to the openstack_networking_router_v2
resource.

enable_snat is retrieved using d.GetOk because we want to only set it
if the user explicitly enabled it in their Terraform configuration.
However, a value of "false" is not able to be read using this method.

Therefore, we need to add a new argument to reverse the logic and allow
a value of false to be sent in the API request.