### PR TITLE
Image v2: Vendor Update and Logging Fix

### DIFF
--- a/openstack/data_source_openstack_images_image_v2.go
+++ b/openstack/data_source_openstack_images_image_v2.go
@@ -162,6 +162,12 @@ func dataSourceImagesImageV2Read(d *schema.ResourceData, meta interface{}) error
 	visibility := resourceImagesImageV2VisibilityFromString(d.Get("visibility").(string))
 	member_status := resourceImagesImageV2MemberStatusFromString(d.Get("member_status").(string))
 
+	var tags []string
+	tag := d.Get("tag").(string)
+	if tag != "" {
+		tags = append(tags, tag)
+	}
+
 	listOpts := images.ListOpts{
 		Name:         d.Get("name").(string),
 		Visibility:   visibility,
@@ -171,7 +177,7 @@ func dataSourceImagesImageV2Read(d *schema.ResourceData, meta interface{}) error
 		SizeMax:      int64(d.Get("size_max").(int)),
 		SortKey:      d.Get("sort_key").(string),
 		SortDir:      d.Get("sort_direction").(string),
-		Tag:          d.Get("tag").(string),
+		Tags:         tags,
 		MemberStatus: member_status,
 	}
 

--- a/openstack/types.go
+++ b/openstack/types.go
@@ -88,8 +88,6 @@ func (lrt *LogRoundTripper) logRequest(original io.ReadCloser, contentType strin
 	if strings.HasPrefix(contentType, "application/json") {
 		debugInfo := lrt.formatJSON(bs.Bytes())
 		log.Printf("[DEBUG] OpenStack Request Body: %s", debugInfo)
-	} else {
-		log.Printf("[DEBUG] OpenStack Request Body: %s", bs.String())
 	}
 
 	return ioutil.NopCloser(strings.NewReader(bs.String())), nil

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata/doc.go
@@ -1,0 +1,33 @@
+/*
+Package imagedata enables management of image data.
+
+Example to Upload Image Data
+
+	imageID := "da3b75d9-3f4a-40e7-8a2c-bfab23927dea"
+
+	imageData, err := os.Open("/path/to/image/file")
+	if err != nil {
+		panic(err)
+	}
+	defer imageData.Close()
+
+	err = imagedata.Upload(imageClient, imageID, imageData).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Download Image Data
+
+	imageID := "da3b75d9-3f4a-40e7-8a2c-bfab23927dea"
+
+	image, err := imagedata.Download(imageClient, imageID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	imageData, err := ioutil.ReadAll(image)
+	if err != nil {
+		panic(err)
+	}
+*/
+package imagedata

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata/requests.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gophercloud/gophercloud"
 )
 
-// Upload uploads image file
+// Upload uploads an image file.
 func Upload(client *gophercloud.ServiceClient, id string, data io.Reader) (r UploadResult) {
 	_, r.Err = client.Put(uploadURL(client, id), data, nil, &gophercloud.RequestOpts{
 		MoreHeaders: map[string]string{"Content-Type": "application/octet-stream"},
@@ -16,7 +16,7 @@ func Upload(client *gophercloud.ServiceClient, id string, data io.Reader) (r Upl
 	return
 }
 
-// Download retrieves file
+// Download retrieves an image.
 func Download(client *gophercloud.ServiceClient, id string) (r DownloadResult) {
 	var resp *http.Response
 	resp, r.Err = client.Get(downloadURL(client, id), nil, nil)

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata/results.go
@@ -7,12 +7,14 @@ import (
 	"github.com/gophercloud/gophercloud"
 )
 
-// UploadResult is the result of an upload image operation
+// UploadResult is the result of an upload image operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
 type UploadResult struct {
 	gophercloud.ErrResult
 }
 
-// DownloadResult is the result of a download image operation
+// DownloadResult is the result of a download image operation. Call its Extract
+// method to gain access to the image data.
 type DownloadResult struct {
 	gophercloud.Result
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/requests.go
@@ -1,6 +1,10 @@
 package images
 
 import (
+	"fmt"
+	"net/url"
+	"time"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -18,6 +22,11 @@ type ListOptsBuilder interface {
 //
 // http://developer.openstack.org/api-ref-image-v2.html
 type ListOpts struct {
+	// ID is the ID of the image.
+	// Multiple IDs can be specified by constructing a string
+	// such as "in:uuid1,uuid2,uuid3".
+	ID string `q:"id"`
+
 	// Integer value for the limit of values to return.
 	Limit int `q:"limit"`
 
@@ -25,6 +34,8 @@ type ListOpts struct {
 	Marker string `q:"marker"`
 
 	// Name filters on the name of the image.
+	// Multiple names can be specified by constructing a string
+	// such as "in:name1,name2,name3".
 	Name string `q:"name"`
 
 	// Visibility filters on the visibility of the image.
@@ -37,6 +48,8 @@ type ListOpts struct {
 	Owner string `q:"owner"`
 
 	// Status filters on the status of the image.
+	// Multiple statuses can be specified by constructing a string
+	// such as "in:saving,queued".
 	Status ImageStatus `q:"status"`
 
 	// SizeMin filters on the size_min image property.
@@ -45,17 +58,63 @@ type ListOpts struct {
 	// SizeMax filters on the size_max image property.
 	SizeMax int64 `q:"size_max"`
 
+	// Sort sorts the results using the new style of sorting. See the OpenStack
+	// Image API reference for the exact syntax.
+	//
+	// Sort cannot be used with the classic sort options (sort_key and sort_dir).
+	Sort string `q:"sort"`
+
 	// SortKey will sort the results based on a specified image property.
 	SortKey string `q:"sort_key"`
 
 	// SortDir will sort the list results either ascending or decending.
 	SortDir string `q:"sort_dir"`
-	Tag     string `q:"tag"`
+
+	// Tags filters on specific image tags.
+	Tags []string `q:"tag"`
+
+	// CreatedAtQuery filters images based on their creation date.
+	CreatedAtQuery *ImageDateQuery
+
+	// UpdatedAtQuery filters images based on their updated date.
+	UpdatedAtQuery *ImageDateQuery
+
+	// ContainerFormat filters images based on the container_format.
+	// Multiple container formats can be specified by constructing a
+	// string such as "in:bare,ami".
+	ContainerFormat string `q:"container_format"`
+
+	// DiskFormat filters images based on the disk_format.
+	// Multiple disk formats can be specified by constructing a string
+	// such as "in:qcow2,iso".
+	DiskFormat string `q:"disk_format"`
 }
 
 // ToImageListQuery formats a ListOpts into a query string.
 func (opts ListOpts) ToImageListQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
+	params := q.Query()
+
+	if opts.CreatedAtQuery != nil {
+		createdAt := opts.CreatedAtQuery.Date.Format(time.RFC3339)
+		if v := opts.CreatedAtQuery.Filter; v != "" {
+			createdAt = fmt.Sprintf("%s:%s", v, createdAt)
+		}
+
+		params.Add("created_at", createdAt)
+	}
+
+	if opts.UpdatedAtQuery != nil {
+		updatedAt := opts.UpdatedAtQuery.Date.Format(time.RFC3339)
+		if v := opts.UpdatedAtQuery.Filter; v != "" {
+			updatedAt = fmt.Sprintf("%s:%s", v, updatedAt)
+		}
+
+		params.Add("updated_at", updatedAt)
+	}
+
+	q = &url.URL{RawQuery: params.Encode()}
+
 	return q.String(), err
 }
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/results.go
@@ -102,7 +102,7 @@ func (r *Image) UnmarshalJSON(b []byte) error {
 
 	switch t := s.SizeBytes.(type) {
 	case nil:
-		return nil
+		r.SizeBytes = 0
 	case float32:
 		r.SizeBytes = int64(t)
 	case float64:

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/types.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/types.go
@@ -1,5 +1,9 @@
 package images
 
+import (
+	"time"
+)
+
 // ImageStatus image statuses
 // http://docs.openstack.org/developer/glance/statuses.html
 type ImageStatus string
@@ -77,3 +81,24 @@ const (
 	// ImageMemberStatusAll
 	ImageMemberStatusAll ImageMemberStatus = "all"
 )
+
+// ImageDateFilter represents a valid filter to use for filtering
+// images by their date during a List.
+type ImageDateFilter string
+
+const (
+	FilterGT  ImageDateFilter = "gt"
+	FilterGTE ImageDateFilter = "gte"
+	FilterLT  ImageDateFilter = "lt"
+	FilterLTE ImageDateFilter = "lte"
+	FilterNEQ ImageDateFilter = "neq"
+	FilterEQ  ImageDateFilter = "eq"
+)
+
+// ImageDateQuery represents a date field to be used for listing images.
+// If no filter is specified, the query will act as though FilterEQ was
+// set.
+type ImageDateQuery struct {
+	Date   time.Time
+	Filter ImageDateFilter
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -433,16 +433,16 @@
 			"revisionTime": "2017-10-29T05:30:20Z"
 		},
 		{
-			"checksumSHA1": "5+wNKnxGvSGV8lHS+7km0ZiNEts=",
+			"checksumSHA1": "I7QtHxTYPCZybsi+u/J5AQaNxxQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "e02a6935a9a628ff8694e6072b9d0aac22623abd",
+			"revisionTime": "2018-04-17T21:29:20Z"
 		},
 		{
-			"checksumSHA1": "gnDqkD2hdbV0ek3m2eNgsc4opdg=",
+			"checksumSHA1": "Pop8rylL583hCZ0RjO+9TkrScCo=",
 			"path": "github.com/gophercloud/gophercloud/openstack/imageservice/v2/images",
-			"revision": "e764e6cf0316a135851b56f8eea946b906988707",
-			"revisionTime": "2017-09-08T04:14:34Z"
+			"revision": "e02a6935a9a628ff8694e6072b9d0aac22623abd",
+			"revisionTime": "2018-04-17T21:29:20Z"
 		},
 		{
 			"checksumSHA1": "YqqqrMdOCKY2xwFkwxskkx8XtTQ=",


### PR DESCRIPTION
This PR updates the Gophercloud library for handling images. This might help #289, but I'm not sure yet.

If it doesn't, I have modified the debug logger to not print non-JSON requests. This will prevent the binary output from being logged when uploading images which will help with debugging this issue further.