### PR TITLE
Networking v2: Make Subnet CIDR Optional

### DIFF
--- a/openstack/resource_openstack_networking_secgroup_rule_v2.go
+++ b/openstack/resource_openstack_networking_secgroup_rule_v2.go
@@ -116,7 +116,7 @@ func resourceNetworkingSecGroupRuleV2Create(d *schema.ResourceData, meta interfa
 		PortRangeMax:   d.Get("port_range_max").(int),
 		RemoteGroupID:  d.Get("remote_group_id").(string),
 		RemoteIPPrefix: d.Get("remote_ip_prefix").(string),
-		TenantID:       d.Get("tenant_id").(string),
+		ProjectID:      d.Get("tenant_id").(string),
 	}
 
 	if v, ok := d.GetOk("direction"); ok {

--- a/openstack/resource_openstack_networking_subnet_v2.go
+++ b/openstack/resource_openstack_networking_subnet_v2.go
@@ -41,7 +41,8 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 			},
 			"cidr": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"name": &schema.Schema{
@@ -163,7 +164,6 @@ func resourceNetworkingSubnetV2Create(d *schema.ResourceData, meta interface{}) 
 	createOpts := SubnetCreateOpts{
 		subnets.CreateOpts{
 			NetworkID:       d.Get("network_id").(string),
-			CIDR:            d.Get("cidr").(string),
 			Name:            d.Get("name").(string),
 			TenantID:        d.Get("tenant_id").(string),
 			IPv6AddressMode: d.Get("ipv6_address_mode").(string),
@@ -175,6 +175,11 @@ func resourceNetworkingSubnetV2Create(d *schema.ResourceData, meta interface{}) 
 			EnableDHCP:      nil,
 		},
 		MapValueSpecs(d),
+	}
+
+	if v, ok := d.GetOk("cidr"); ok {
+		cidr := v.(string)
+		createOpts.CIDR = cidr
 	}
 
 	if v, ok := d.GetOk("gateway_ip"); ok {

--- a/openstack/resource_openstack_networking_subnet_v2_test.go
+++ b/openstack/resource_openstack_networking_subnet_v2_test.go
@@ -160,6 +160,24 @@ func TestAccNetworkingV2Subnet_subnetPool(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2Subnet_subnetPoolNoCIDR(t *testing.T) {
+	var subnet subnets.Subnet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2SubnetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2Subnet_subnetPoolNoCIDR,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2SubnetExists("openstack_networking_subnet_v2.subnet_1", &subnet),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingV2SubnetDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
@@ -366,6 +384,25 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
   name = "subnet_1"
   cidr = "10.11.12.0/25"
   no_gateway = true
+	network_id = "${openstack_networking_network_v2.network_1.id}"
+	subnetpool_id = "${openstack_networking_subnetpool_v2.subnetpool_1.id}"
+}
+`
+
+const testAccNetworkingV2Subnet_subnetPoolNoCIDR = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnetpool_v2" "subnetpool_1" {
+  name = "my_ipv4_pool"
+  prefixes = ["10.11.12.0/24"]
+  min_prefixlen = "24"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name = "subnet_1"
 	network_id = "${openstack_networking_network_v2.network_1.id}"
 	subnetpool_id = "${openstack_networking_subnetpool_v2.subnetpool_1.id}"
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls/doc.go
@@ -1,0 +1,60 @@
+/*
+Package firewalls allows management and retrieval of firewalls from the
+OpenStack Networking Service.
+
+Example to List Firewalls
+
+	listOpts := firewalls.ListOpts{
+		TenantID: "tenant-id",
+	}
+
+	allPages, err := firewalls.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allFirewalls, err := firewalls.ExtractFirewalls(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, fw := range allFirewalls {
+		fmt.Printf("%+v\n", fw)
+	}
+
+Example to Create a Firewall
+
+	createOpts := firewalls.CreateOpts{
+		Name:        "firewall_1",
+		Description: "A firewall",
+		PolicyID:    "19ab8c87-4a32-4e6a-a74e-b77fffb89a0c",
+		AdminStateUp: gophercloud.Enabled,
+	}
+
+	firewall, err := firewalls.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Firewall
+
+	firewallID := "a6917946-38ab-4ffd-a55a-26c0980ce5ee"
+
+	updateOpts := firewalls.UpdateOpts{
+		AdminStateUp: gophercloud.Disabled,
+	}
+
+	firewall, err := firewalls.Update(networkClient, firewallID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Firewall
+
+	firewallID := "a6917946-38ab-4ffd-a55a-26c0980ce5ee"
+	err := firewalls.Delete(networkClient, firewallID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package firewalls

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls/requests.go
@@ -18,6 +18,7 @@ type ListOptsBuilder interface {
 // `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
 	TenantID     string `q:"tenant_id"`
+	ProjectID    string `q:"project_id"`
 	Name         string `q:"name"`
 	Description  string `q:"description"`
 	AdminStateUp bool   `q:"admin_state_up"`
@@ -56,10 +57,8 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	})
 }
 
-// CreateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Create operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToFirewallCreateMap() (map[string]interface{}, error)
 }
@@ -67,9 +66,11 @@ type CreateOptsBuilder interface {
 // CreateOpts contains all the values needed to create a new firewall.
 type CreateOpts struct {
 	PolicyID string `json:"firewall_policy_id" required:"true"`
-	// Only required if the caller has an admin role and wants to create a firewall
-	// for another tenant.
+	// TenantID specifies a tenant to own the firewall. The caller must have
+	// an admin role in order to set this. Otherwise, this field is left unset
+	// and the caller will be the owner.
 	TenantID     string `json:"tenant_id,omitempty"`
+	ProjectID    string `json:"project_id,omitempty"`
 	Name         string `json:"name,omitempty"`
 	Description  string `json:"description,omitempty"`
 	AdminStateUp *bool  `json:"admin_state_up,omitempty"`
@@ -81,7 +82,7 @@ func (opts CreateOpts) ToFirewallCreateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "firewall")
 }
 
-// Create accepts a CreateOpts struct and uses the values to create a new firewall
+// Create accepts a CreateOpts struct and uses the values to create a new firewall.
 func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToFirewallCreateMap()
 	if err != nil {
@@ -98,10 +99,8 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
-// UpdateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Update operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToFirewallUpdateMap() (map[string]interface{}, error)
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls/results.go
@@ -14,6 +14,7 @@ type Firewall struct {
 	Status       string `json:"status"`
 	PolicyID     string `json:"firewall_policy_id"`
 	TenantID     string `json:"tenant_id"`
+	ProjectID    string `json:"project_id"`
 }
 
 type commonResult struct {
@@ -61,8 +62,8 @@ func (r FirewallPage) IsEmpty() (bool, error) {
 	return len(is) == 0, err
 }
 
-// ExtractFirewalls accepts a Page struct, specifically a RouterPage struct,
-// and extracts the elements into a slice of Router structs. In other words,
+// ExtractFirewalls accepts a Page struct, specifically a FirewallPage struct,
+// and extracts the elements into a slice of Firewall structs. In other words,
 // a generic collection is mapped into a relevant slice.
 func ExtractFirewalls(r pagination.Page) ([]Firewall, error) {
 	var s []Firewall
@@ -70,22 +71,26 @@ func ExtractFirewalls(r pagination.Page) ([]Firewall, error) {
 	return s, err
 }
 
-// GetResult represents the result of a get operation.
+// GetResult represents the result of a Get operation. Call its Extract
+// method to interpret it as a Firewall.
 type GetResult struct {
 	commonResult
 }
 
-// UpdateResult represents the result of an update operation.
+// UpdateResult represents the result of an Update operation. Call its Extract
+// method to interpret it as a Firewall.
 type UpdateResult struct {
 	commonResult
 }
 
-// DeleteResult represents the result of a delete operation.
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the operation succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
-// CreateResult represents the result of a create operation.
+// CreateResult represents the result of a Create operation. Call its Extract
+// method to interpret it as a Firewall.
 type CreateResult struct {
 	commonResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies/doc.go
@@ -1,0 +1,84 @@
+/*
+Package policies allows management and retrieval of Firewall Policies in the
+OpenStack Networking Service.
+
+Example to List Policies
+
+	listOpts := policies.ListOpts{
+		TenantID: "966b3c7d36a24facaf20b7e458bf2192",
+	}
+
+	allPages, err := policies.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allPolicies, err := policies.ExtractPolicies(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, policy := range allPolicies {
+		fmt.Printf("%+v\n", policy)
+	}
+
+Example to Create a Policy
+
+	createOpts := policies.CreateOpts{
+		Name:        "policy_1",
+		Description: "A policy",
+		Rules: []string{
+			"98a58c87-76be-ae7c-a74e-b77fffb88d95",
+			"7c4f087a-ed46-4ea8-8040-11ca460a61c0",
+		}
+	}
+
+	policy, err := policies.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Policy
+
+	policyID := "38aee955-6283-4279-b091-8b9c828000ec"
+
+	updateOpts := policies.UpdateOpts{
+		Description: "New Description",
+	}
+
+	policy, err := policies.Update(networkClient, policyID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Policy
+
+	policyID := "38aee955-6283-4279-b091-8b9c828000ec"
+	err := policies.Delete(networkClient, policyID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Add a Rule to a Policy
+
+	policyID := "38aee955-6283-4279-b091-8b9c828000ec"
+	ruleOpts := policies.InsertRuleOpts{
+		ID: "98a58c87-76be-ae7c-a74e-b77fffb88d95",
+	}
+
+	policy, err := policies.AddRule(networkClient, policyID, ruleOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Rule from a Policy
+
+	policyID := "38aee955-6283-4279-b091-8b9c828000ec"
+	ruleID := "98a58c87-76be-ae7c-a74e-b77fffb88d95",
+
+	policy, err := policies.RemoveRule(networkClient, policyID, ruleID).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
+package policies

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies/requests.go
@@ -18,6 +18,7 @@ type ListOptsBuilder interface {
 // and is either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
 	TenantID    string `q:"tenant_id"`
+	ProjectID   string `q:"project_id"`
 	Name        string `q:"name"`
 	Description string `q:"description"`
 	Shared      *bool  `q:"shared"`
@@ -39,8 +40,8 @@ func (opts ListOpts) ToPolicyListQuery() (string, error) {
 // firewall policies. It accepts a ListOpts struct, which allows you to filter
 // and sort the returned collection for greater efficiency.
 //
-// Default policy settings return only those firewall policies that are owned by the
-// tenant who submits the request, unless an admin user submits the request.
+// Default policy settings return only those firewall policies that are owned by
+// the tenant who submits the request, unless an admin user submits the request.
 func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
@@ -55,19 +56,19 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	})
 }
 
-// CreateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Create operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToFirewallPolicyCreateMap() (map[string]interface{}, error)
 }
 
 // CreateOpts contains all the values needed to create a new firewall policy.
 type CreateOpts struct {
-	// Only required if the caller has an admin role and wants to create a firewall policy
-	// for another tenant.
+	// TenantID specifies a tenant to own the firewall. The caller must have
+	// an admin role in order to set this. Otherwise, this field is left unset
+	// and the caller will be the owner.
 	TenantID    string   `json:"tenant_id,omitempty"`
+	ProjectID   string   `json:"project_id,omitempty"`
 	Name        string   `json:"name,omitempty"`
 	Description string   `json:"description,omitempty"`
 	Shared      *bool    `json:"shared,omitempty"`
@@ -80,7 +81,8 @@ func (opts CreateOpts) ToFirewallPolicyCreateMap() (map[string]interface{}, erro
 	return gophercloud.BuildRequestBody(opts, "firewall_policy")
 }
 
-// Create accepts a CreateOpts struct and uses the values to create a new firewall policy
+// Create accepts a CreateOpts struct and uses the values to create a new
+// firewall policy.
 func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToFirewallPolicyCreateMap()
 	if err != nil {
@@ -97,10 +99,8 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
-// UpdateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Update operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToFirewallPolicyUpdateMap() (map[string]interface{}, error)
 }
@@ -132,16 +132,20 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r 
 	return
 }
 
-// Delete will permanently delete a particular firewall policy based on its unique ID.
+// Delete will permanently delete a particular firewall policy based on its
+// unique ID.
 func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = c.Delete(resourceURL(c, id), nil)
 	return
 }
 
+// InsertRuleOptsBuilder allows extensions to add additional parameters to the
+// InsertRule request.
 type InsertRuleOptsBuilder interface {
 	ToFirewallPolicyInsertRuleMap() (map[string]interface{}, error)
 }
 
+// InsertRuleOpts contains the values used when updating a policy's rules.
 type InsertRuleOpts struct {
 	ID           string `json:"firewall_rule_id" required:"true"`
 	BeforeRuleID string `json:"insert_before,omitempty"`
@@ -152,6 +156,7 @@ func (opts InsertRuleOpts) ToFirewallPolicyInsertRuleMap() (map[string]interface
 	return gophercloud.BuildRequestBody(opts, "")
 }
 
+// AddRule will add a rule to a policy.
 func AddRule(c *gophercloud.ServiceClient, id string, opts InsertRuleOptsBuilder) (r InsertRuleResult) {
 	b, err := opts.ToFirewallPolicyInsertRuleMap()
 	if err != nil {
@@ -164,6 +169,7 @@ func AddRule(c *gophercloud.ServiceClient, id string, opts InsertRuleOptsBuilder
 	return
 }
 
+// RemoveRule will add a rule to a policy.
 func RemoveRule(c *gophercloud.ServiceClient, id, ruleID string) (r RemoveRuleResult) {
 	b := map[string]interface{}{"firewall_rule_id": ruleID}
 	_, r.Err = c.Put(removeURL(c, id), b, &r.Body, &gophercloud.RequestOpts{

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies/results.go
@@ -11,6 +11,7 @@ type Policy struct {
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
 	TenantID    string   `json:"tenant_id"`
+	ProjectID   string   `json:"project_id"`
 	Audited     bool     `json:"audited"`
 	Shared      bool     `json:"shared"`
 	Rules       []string `json:"firewall_rules,omitempty"`
@@ -55,8 +56,8 @@ func (r PolicyPage) IsEmpty() (bool, error) {
 	return len(is) == 0, err
 }
 
-// ExtractPolicies accepts a Page struct, specifically a RouterPage struct,
-// and extracts the elements into a slice of Router structs. In other words,
+// ExtractPolicies accepts a Page struct, specifically a Policy struct,
+// and extracts the elements into a slice of Policy structs. In other words,
 // a generic collection is mapped into a relevant slice.
 func ExtractPolicies(r pagination.Page) ([]Policy, error) {
 	var s struct {
@@ -66,32 +67,38 @@ func ExtractPolicies(r pagination.Page) ([]Policy, error) {
 	return s.Policies, err
 }
 
-// GetResult represents the result of a get operation.
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Policy.
 type GetResult struct {
 	commonResult
 }
 
-// UpdateResult represents the result of an update operation.
+// UpdateResult represents the result of an update operation. Call its
+// Extract method to interpret it as a Policy.
 type UpdateResult struct {
 	commonResult
 }
 
-// DeleteResult represents the result of a delete operation.
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the operation succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
-// CreateResult represents the result of a create operation.
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Policy.
 type CreateResult struct {
 	commonResult
 }
 
-// InsertRuleResult represents the result of an InsertRule operation.
+// InsertRuleResult represents the result of an InsertRule operation. Call its
+// Extract method to interpret it as a Policy.
 type InsertRuleResult struct {
 	commonResult
 }
 
-// RemoveRuleResult represents the result of a RemoveRule operation.
+// RemoveRuleResult represents the result of a RemoveRule operation. Call its
+// Extract method to interpret it as a Policy.
 type RemoveRuleResult struct {
 	commonResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/routerinsertion/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/routerinsertion/doc.go
@@ -1,2 +1,68 @@
-// Package routerinsertion implements the fwaasrouterinsertion FWaaS extension.
+/*
+Package routerinsertion implements the fwaasrouterinsertion Firewall extension.
+It is used to manage the router information of a firewall.
+
+Example to List Firewalls with Router Information
+
+	type FirewallsWithRouters struct {
+		firewalls.Firewall
+		routerinsertion.FirewallExt
+	}
+
+	var allFirewalls []FirewallsWithRouters
+
+	allPages, err := firewalls.List(networkClient, nil).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	err = firewalls.ExtractFirewallsInto(allPages, &allFirewalls)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, fw := range allFirewalls {
+		fmt.Printf("%+v\n", fw)
+	}
+
+Example to Create a Firewall with a Router
+
+	firewallCreateOpts := firewalls.CreateOpts{
+		Name:     "firewall_1",
+		PolicyID: "19ab8c87-4a32-4e6a-a74e-b77fffb89a0c",
+	}
+
+	createOpts := routerinsertion.CreateOptsExt{
+		CreateOptsBuilder: firewallCreateOpts,
+		RouterIDs: []string{
+			"8a3a0d6a-34b5-4a92-b65d-6375a4c1e9e8",
+		},
+	}
+
+	firewall, err := firewalls.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Firewall with a Router
+
+	firewallID := "a6917946-38ab-4ffd-a55a-26c0980ce5ee"
+
+	firewallUpdateOpts := firewalls.UpdateOpts{
+		Description: "updated firewall",
+		PolicyID:    "19ab8c87-4a32-4e6a-a74e-b77fffb89a0c",
+	}
+
+	updateOpts := routerinsertion.UpdateOptsExt{
+		UpdateOptsBuilder: firewallUpdateOpts,
+		RouterIDs: []string{
+			"8a3a0d6a-34b5-4a92-b65d-6375a4c1e9e8",
+		},
+	}
+
+	firewall, err := firewalls.Update(networkClient, firewallID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
 package routerinsertion

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/routerinsertion/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/routerinsertion/requests.go
@@ -4,7 +4,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls"
 )
 
-// CreateOptsExt adds a RouterIDs option to the base CreateOpts.
+// CreateOptsExt adds the RouterIDs option to the base CreateOpts.
 type CreateOptsExt struct {
 	firewalls.CreateOptsBuilder
 	RouterIDs []string `json:"router_ids"`
@@ -23,7 +23,7 @@ func (opts CreateOptsExt) ToFirewallCreateMap() (map[string]interface{}, error) 
 	return base, nil
 }
 
-// UpdateOptsExt updates a RouterIDs option to the base UpdateOpts.
+// UpdateOptsExt adds the RouterIDs option to the base UpdateOpts.
 type UpdateOptsExt struct {
 	firewalls.UpdateOptsBuilder
 	RouterIDs []string `json:"router_ids"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules/doc.go
@@ -1,0 +1,64 @@
+/*
+Package rules enables management and retrieval of Firewall Rules in the
+OpenStack Networking Service.
+
+Example to List Rules
+
+	listOpts := rules.ListOpts{
+		Protocol: rules.ProtocolAny,
+	}
+
+	allPages, err := rules.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allRules, err := rules.ExtractRules(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, rule := range allRules {
+		fmt.Printf("%+v\n", rule)
+	}
+
+Example to Create a Rule
+
+	createOpts := rules.CreateOpts{
+		Action:               "allow",
+		Protocol:             rules.ProtocolTCP,
+		Description:          "ssh",
+		DestinationPort:      22,
+		DestinationIPAddress: "192.168.1.0/24",
+	}
+
+	rule, err := rules.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Rule
+
+	ruleID := "f03bd950-6c56-4f5e-a307-45967078f507"
+	newPort := 80
+	newDescription := "http"
+
+	updateOpts := rules.UpdateOpts{
+		Description: &newDescription,
+		port:        &newPort,
+	}
+
+	rule, err := rules.Update(networkClient, ruleID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Rule
+
+	ruleID := "f03bd950-6c56-4f5e-a307-45967078f507"
+	err := rules.Delete(networkClient, ruleID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package rules

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules/requests.go
@@ -6,21 +6,21 @@ import (
 )
 
 type (
-	// Protocol represents a valid rule protocol
+	// Protocol represents a valid rule protocol.
 	Protocol string
 )
 
 const (
-	// ProtocolAny is to allow any protocol
+	// ProtocolAny is to allow any protocol.
 	ProtocolAny Protocol = "any"
 
-	// ProtocolICMP is to allow the ICMP protocol
+	// ProtocolICMP is to allow the ICMP protocol.
 	ProtocolICMP Protocol = "icmp"
 
-	// ProtocolTCP is to allow the TCP protocol
+	// ProtocolTCP is to allow the TCP protocol.
 	ProtocolTCP Protocol = "tcp"
 
-	// ProtocolUDP is to allow the UDP protocol
+	// ProtocolUDP is to allow the UDP protocol.
 	ProtocolUDP Protocol = "udp"
 )
 
@@ -33,10 +33,11 @@ type ListOptsBuilder interface {
 // ListOpts allows the filtering and sorting of paginated collections through
 // the API. Filtering is achieved by passing in struct field values that map to
 // the Firewall rule attributes you want to see returned. SortKey allows you to
-// sort by a particular firewall rule attribute. SortDir sets the direction, and is
-// either `asc' or `desc'. Marker and Limit are used for pagination.
+// sort by a particular firewall rule attribute. SortDir sets the direction, and
+// is either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
 	TenantID             string `q:"tenant_id"`
+	ProjectID            string `q:"project_id"`
 	Name                 string `q:"name"`
 	Description          string `q:"description"`
 	Protocol             string `q:"protocol"`
@@ -67,8 +68,8 @@ func (opts ListOpts) ToRuleListQuery() (string, error) {
 // firewall rules. It accepts a ListOpts struct, which allows you to filter
 // and sort the returned collection for greater efficiency.
 //
-// Default policy settings return only those firewall rules that are owned by the
-// tenant who submits the request, unless an admin user submits the request.
+// Default policy settings return only those firewall rules that are owned by
+// the tenant who submits the request, unless an admin user submits the request.
 func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 
@@ -85,10 +86,8 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	})
 }
 
-// CreateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Create operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToRuleCreateMap() (map[string]interface{}, error)
 }
@@ -98,6 +97,7 @@ type CreateOpts struct {
 	Protocol             Protocol              `json:"protocol" required:"true"`
 	Action               string                `json:"action" required:"true"`
 	TenantID             string                `json:"tenant_id,omitempty"`
+	ProjectID            string                `json:"project_id,omitempty"`
 	Name                 string                `json:"name,omitempty"`
 	Description          string                `json:"description,omitempty"`
 	IPVersion            gophercloud.IPVersion `json:"ip_version,omitempty"`
@@ -123,7 +123,8 @@ func (opts CreateOpts) ToRuleCreateMap() (map[string]interface{}, error) {
 	return b, nil
 }
 
-// Create accepts a CreateOpts struct and uses the values to create a new firewall rule
+// Create accepts a CreateOpts struct and uses the values to create a new
+// firewall rule.
 func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToRuleCreateMap()
 	if err != nil {
@@ -140,15 +141,15 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
-// UpdateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Update operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToRuleUpdateMap() (map[string]interface{}, error)
 }
 
 // UpdateOpts contains the values used when updating a firewall rule.
+// These fields are all pointers so that unset fields will not cause the
+// existing Rule attribute to be removed.
 type UpdateOpts struct {
 	Protocol             *string                `json:"protocol,omitempty"`
 	Action               *string                `json:"action,omitempty"`
@@ -181,7 +182,8 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r 
 	return
 }
 
-// Delete will permanently delete a particular firewall rule based on its unique ID.
+// Delete will permanently delete a particular firewall rule based on its
+// unique ID.
 func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = c.Delete(resourceURL(c, id), nil)
 	return

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules/results.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// Rule represents a firewall rule
+// Rule represents a firewall rule.
 type Rule struct {
 	ID                   string `json:"id"`
 	Name                 string `json:"name,omitempty"`
@@ -22,6 +22,7 @@ type Rule struct {
 	PolicyID             string `json:"firewall_policy_id"`
 	Position             int    `json:"position"`
 	TenantID             string `json:"tenant_id"`
+	ProjectID            string `json:"project_id"`
 }
 
 // RulePage is the page returned by a pager when traversing over a
@@ -50,8 +51,8 @@ func (r RulePage) IsEmpty() (bool, error) {
 	return len(is) == 0, err
 }
 
-// ExtractRules accepts a Page struct, specifically a RouterPage struct,
-// and extracts the elements into a slice of Router structs. In other words,
+// ExtractRules accepts a Page struct, specifically a RulePage struct,
+// and extracts the elements into a slice of Rule structs. In other words,
 // a generic collection is mapped into a relevant slice.
 func ExtractRules(r pagination.Page) ([]Rule, error) {
 	var s struct {
@@ -74,22 +75,26 @@ func (r commonResult) Extract() (*Rule, error) {
 	return s.Rule, err
 }
 
-// GetResult represents the result of a get operation.
+// GetResult represents the result of a get operation. Call its Extract method
+// to interpret it as a Rule.
 type GetResult struct {
 	commonResult
 }
 
-// UpdateResult represents the result of an update operation.
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Rule.
 type UpdateResult struct {
 	commonResult
 }
 
-// DeleteResult represents the result of a delete operation.
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
-// CreateResult represents the result of a create operation.
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Rule.
 type CreateResult struct {
 	commonResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/requests.go
@@ -17,6 +17,7 @@ type ListOpts struct {
 	FixedIP           string `q:"fixed_ip_address"`
 	FloatingIP        string `q:"floating_ip_address"`
 	TenantID          string `q:"tenant_id"`
+	ProjectID         string `q:"project_id"`
 	Limit             int    `q:"limit"`
 	Marker            string `q:"marker"`
 	SortKey           string `q:"sort_key"`
@@ -55,6 +56,7 @@ type CreateOpts struct {
 	FixedIP           string `json:"fixed_ip_address,omitempty"`
 	SubnetID          string `json:"subnet_id,omitempty"`
 	TenantID          string `json:"tenant_id,omitempty"`
+	ProjectID         string `json:"project_id,omitempty"`
 }
 
 // ToFloatingIPCreateMap allows CreateOpts to satisfy the CreateOptsBuilder

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/results.go
@@ -30,9 +30,12 @@ type FloatingIP struct {
 	// associated with the floating IP.
 	FixedIP string `json:"fixed_ip_address"`
 
-	// TenantID is the Owner of the floating IP. Only admin users can specify a
-	// tenant identifier other than its own.
+	// TenantID is the project owner of the floating IP. Only admin users can
+	// specify a project identifier other than its own.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the floating IP.
+	ProjectID string `json:"project_id"`
 
 	// Status is the condition of the API resource.
 	Status string `json:"status"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/requests.go
@@ -17,6 +17,7 @@ type ListOpts struct {
 	Distributed  *bool  `q:"distributed"`
 	Status       string `q:"status"`
 	TenantID     string `q:"tenant_id"`
+	ProjectID    string `q:"project_id"`
 	Limit        int    `q:"limit"`
 	Marker       string `q:"marker"`
 	SortKey      string `q:"sort_key"`
@@ -53,6 +54,7 @@ type CreateOpts struct {
 	AdminStateUp          *bool        `json:"admin_state_up,omitempty"`
 	Distributed           *bool        `json:"distributed,omitempty"`
 	TenantID              string       `json:"tenant_id,omitempty"`
+	ProjectID             string       `json:"project_id,omitempty"`
 	GatewayInfo           *GatewayInfo `json:"external_gateway_info,omitempty"`
 	AvailabilityZoneHints []string     `json:"availability_zone_hints,omitempty"`
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/results.go
@@ -54,9 +54,12 @@ type Router struct {
 	// ID is the unique identifier for the router.
 	ID string `json:"id"`
 
-	// TenantID is the owner of the router. Only admin users can specify a tenant
-	// identifier other than its own.
+	// TenantID is the project owner of the router. Only admin users can
+	// specify a project identifier other than its own.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the router.
+	ProjectID string `json:"project_id"`
 
 	// Routes are a collection of static routes that the router will host.
 	Routes []Route `json:"routes"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/members/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/members/doc.go
@@ -1,0 +1,59 @@
+/*
+Package members provides information and interaction with Members of the
+Load Balancer as a Service extension for the OpenStack Networking service.
+
+Example to List Members
+
+	listOpts := members.ListOpts{
+		ProtocolPort: 80,
+	}
+
+	allPages, err := members.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allMembers, err := members.ExtractMembers(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, member := range allMembers {
+		fmt.Printf("%+v\n", member)
+	}
+
+Example to Create a Member
+
+	createOpts := members.CreateOpts{
+		Address:      "192.168.2.14",
+		ProtocolPort: 80,
+		PoolID:       "0b266a12-0fdf-4434-bd11-649d84e54bd5"
+	}
+
+	member, err := members.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Member
+
+	memberID := "46592c54-03f7-40ef-9cdf-b1fcf2775ddf"
+
+	updateOpts := members.UpdateOpts{
+		AdminStateUp: gophercloud.Disabled,
+	}
+
+	member, err := members.Update(networkClient, memberID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Member
+
+	memberID := "46592c54-03f7-40ef-9cdf-b1fcf2775ddf"
+	err := members.Delete(networkClient, memberID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package members

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/members/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/members/requests.go
@@ -26,10 +26,10 @@ type ListOpts struct {
 }
 
 // List returns a Pager which allows you to iterate over a collection of
-// pools. It accepts a ListOpts struct, which allows you to filter and sort
+// members. It accepts a ListOpts struct, which allows you to filter and sort
 // the returned collection for greater efficiency.
 //
-// Default policy settings return only those pools that are owned by the
+// Default policy settings return only those members that are owned by the
 // tenant who submits the request, unless an admin user submits the request.
 func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
 	q, err := gophercloud.BuildQueryString(&opts)
@@ -42,23 +42,29 @@ func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
 	})
 }
 
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToLBMemberCreateMap() (map[string]interface{}, error)
 }
 
 // CreateOpts contains all the values needed to create a new pool member.
 type CreateOpts struct {
-	// The IP address of the member.
+	// Address is the IP address of the member.
 	Address string `json:"address" required:"true"`
-	// The port on which the application is hosted.
+
+	// ProtocolPort is the port on which the application is hosted.
 	ProtocolPort int `json:"protocol_port" required:"true"`
-	// The pool to which this member will belong.
+
+	// PoolID is the pool to which this member will belong.
 	PoolID string `json:"pool_id" required:"true"`
-	// Only required if the caller has an admin role and wants to create a pool
-	// for another tenant.
+
+	// TenantID is only required if the caller has an admin role and wants
+	// to create a pool for another tenant.
 	TenantID string `json:"tenant_id,omitempty"`
 }
 
+// ToLBMemberCreateMap builds a request body from CreateOpts.
 func (opts CreateOpts) ToLBMemberCreateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "member")
 }
@@ -81,6 +87,8 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToLBMemberUpdateMap() (map[string]interface{}, error)
 }
@@ -91,6 +99,7 @@ type UpdateOpts struct {
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 }
 
+// ToLBMemberUpdateMap builds a request body from UpdateOpts.
 func (opts UpdateOpts) ToLBMemberUpdateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "member")
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/members/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/members/results.go
@@ -7,29 +7,30 @@ import (
 
 // Member represents the application running on a backend server.
 type Member struct {
-	// The status of the member. Indicates whether the member is operational.
+	// Status is the status of the member. Indicates whether the member
+	// is operational.
 	Status string
 
-	// Weight of member.
+	// Weight is the weight of member.
 	Weight int
 
-	// The administrative state of the member, which is up (true) or down (false).
+	// AdminStateUp is the administrative state of the member, which is up
+	// (true) or down (false).
 	AdminStateUp bool `json:"admin_state_up"`
 
-	// Owner of the member. Only an administrative user can specify a tenant ID
-	// other than its own.
+	// TenantID is the owner of the member.
 	TenantID string `json:"tenant_id"`
 
-	// The pool to which the member belongs.
+	// PoolID is the pool to which the member belongs.
 	PoolID string `json:"pool_id"`
 
-	// The IP address of the member.
+	// Address is the IP address of the member.
 	Address string
 
-	// The port on which the application is hosted.
+	// ProtocolPort is the port on which the application is hosted.
 	ProtocolPort int `json:"protocol_port"`
 
-	// The unique ID for the member.
+	// ID is the unique ID for the member.
 	ID string
 }
 
@@ -74,7 +75,7 @@ type commonResult struct {
 	gophercloud.Result
 }
 
-// Extract is a function that accepts a result and extracts a router.
+// Extract is a function that accepts a result and extracts a member.
 func (r commonResult) Extract() (*Member, error) {
 	var s struct {
 		Member *Member `json:"member"`
@@ -83,22 +84,26 @@ func (r commonResult) Extract() (*Member, error) {
 	return s.Member, err
 }
 
-// CreateResult represents the result of a create operation.
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Member.
 type CreateResult struct {
 	commonResult
 }
 
-// GetResult represents the result of a get operation.
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Member.
 type GetResult struct {
 	commonResult
 }
 
-// UpdateResult represents the result of an update operation.
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Member.
 type UpdateResult struct {
 	commonResult
 }
 
-// DeleteResult represents the result of a delete operation.
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the result succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/monitors/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/monitors/doc.go
@@ -1,0 +1,63 @@
+/*
+Package monitors provides information and interaction with the Monitors
+of the Load Balancer as a Service extension for the OpenStack Networking
+Service.
+
+Example to List Monitors
+
+	listOpts: monitors.ListOpts{
+		Type: "HTTP",
+	}
+
+	allPages, err := monitors.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allMonitors, err := monitors.ExtractMonitors(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, monitor := range allMonitors {
+		fmt.Printf("%+v\n", monitor)
+	}
+
+Example to Create a Monitor
+
+	createOpts := monitors.CreateOpts{
+		Type:          "HTTP",
+		Delay:         20,
+		Timeout:       20,
+		MaxRetries:    5,
+		URLPath:       "/check",
+		ExpectedCodes: "200-299",
+	}
+
+	monitor, err := monitors.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Monitor
+
+	monitorID := "681aed03-aadb-43ae-aead-b9016375650a"
+
+	updateOpts := monitors.UpdateOpts{
+		Timeout: 30,
+	}
+
+	monitor, err := monitors.Update(networkClient, monitorID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Member
+
+	monitorID := "681aed03-aadb-43ae-aead-b9016375650a"
+	err := monitors.Delete(networkClient, monitorID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package monitors

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/monitors/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/monitors/requests.go
@@ -31,10 +31,10 @@ type ListOpts struct {
 }
 
 // List returns a Pager which allows you to iterate over a collection of
-// routers. It accepts a ListOpts struct, which allows you to filter and sort
+// monitors. It accepts a ListOpts struct, which allows you to filter and sort
 // the returned collection for greater efficiency.
 //
-// Default policy settings return only those routers that are owned by the
+// Default policy settings return only those monitors that are owned by the
 // tenant who submits the request, unless an admin user submits the request.
 func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
 	q, err := gophercloud.BuildQueryString(&opts)
@@ -47,7 +47,7 @@ func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
 	})
 }
 
-// MonitorType is the type for all the types of LB monitors
+// MonitorType is the type for all the types of LB monitors.
 type MonitorType string
 
 // Constants that represent approved monitoring types.
@@ -58,42 +58,52 @@ const (
 	TypeHTTPS MonitorType = "HTTPS"
 )
 
-// CreateOptsBuilder is what types must satisfy to be used as Create
-// options.
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToLBMonitorCreateMap() (map[string]interface{}, error)
 }
 
 // CreateOpts contains all the values needed to create a new health monitor.
 type CreateOpts struct {
-	// Required. The type of probe, which is PING, TCP, HTTP, or HTTPS, that is
-	// sent by the load balancer to verify the member state.
+	// MonitorType is the type of probe, which is PING, TCP, HTTP, or HTTPS,
+	// that is sent by the load balancer to verify the member state.
 	Type MonitorType `json:"type" required:"true"`
-	// Required. The time, in seconds, between sending probes to members.
+
+	// Delay is the time, in seconds, between sending probes to members.
 	Delay int `json:"delay" required:"true"`
-	// Required. Maximum number of seconds for a monitor to wait for a ping reply
-	// before it times out. The value must be less than the delay value.
+
+	// Timeout is the maximum number of seconds for a monitor to wait for a ping
+	// reply before it times out. The value must be less than the delay value.
 	Timeout int `json:"timeout" required:"true"`
-	// Required. Number of permissible ping failures before changing the member's
-	// status to INACTIVE. Must be a number between 1 and 10.
+
+	// MaxRetries is the number of permissible ping failures before changing the
+	// member's status to INACTIVE. Must be a number between 1 and 10.
 	MaxRetries int `json:"max_retries" required:"true"`
-	// Required for HTTP(S) types. URI path that will be accessed if monitor type
-	// is HTTP or HTTPS.
+
+	// URLPath is the URI path that will be accessed if monitor type
+	// is HTTP or HTTPS. Required for HTTP(S) types.
 	URLPath string `json:"url_path,omitempty"`
-	// Required for HTTP(S) types. The HTTP method used for requests by the
-	// monitor. If this attribute is not specified, it defaults to "GET".
+
+	// HTTPMethod is the HTTP method used for requests by the monitor. If this
+	// attribute is not specified, it defaults to "GET". Required for HTTP(S)
+	// types.
 	HTTPMethod string `json:"http_method,omitempty"`
-	// Required for HTTP(S) types. Expected HTTP codes for a passing HTTP(S)
-	// monitor. You can either specify a single status like "200", or a range
-	// like "200-202".
+
+	// ExpectedCodes is the expected HTTP codes for a passing HTTP(S) monitor
+	// You can either specify a single status like "200", or a range like
+	// "200-202". Required for HTTP(S) types.
 	ExpectedCodes string `json:"expected_codes,omitempty"`
-	// Required for admins. Indicates the owner of the VIP.
-	TenantID     string `json:"tenant_id,omitempty"`
-	AdminStateUp *bool  `json:"admin_state_up,omitempty"`
+
+	// TenantID is only required if the caller has an admin role and wants
+	// to create a pool for another tenant.
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// AdminStateUp denotes whether the monitor is administratively up or down.
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 }
 
-// ToLBMonitorCreateMap allows CreateOpts to satisfy the CreateOptsBuilder
-// interface
+// ToLBMonitorCreateMap builds a request body from CreateOpts.
 func (opts CreateOpts) ToLBMonitorCreateMap() (map[string]interface{}, error) {
 	if opts.Type == TypeHTTP || opts.Type == TypeHTTPS {
 		if opts.URLPath == "" {
@@ -146,39 +156,45 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
-// UpdateOptsBuilder is what types must satisfy to be used as Update
-// options.
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToLBMonitorUpdateMap() (map[string]interface{}, error)
 }
 
-// UpdateOpts contains all the values needed to update an existing virtual IP.
+// UpdateOpts contains all the values needed to update an existing monitor.
 // Attributes not listed here but appear in CreateOpts are immutable and cannot
 // be updated.
 type UpdateOpts struct {
-	// The time, in seconds, between sending probes to members.
+	// Delay is the time, in seconds, between sending probes to members.
 	Delay int `json:"delay,omitempty"`
-	// Maximum number of seconds for a monitor to wait for a ping reply
-	// before it times out. The value must be less than the delay value.
+
+	// Timeout is the maximum number of seconds for a monitor to wait for a ping
+	// reply before it times out. The value must be less than the delay value.
 	Timeout int `json:"timeout,omitempty"`
-	// Number of permissible ping failures before changing the member's
-	// status to INACTIVE. Must be a number between 1 and 10.
+
+	// MaxRetries is the number of permissible ping failures before changing the
+	// member's status to INACTIVE. Must be a number between 1 and 10.
 	MaxRetries int `json:"max_retries,omitempty"`
-	// URI path that will be accessed if monitor type
+
+	// URLPath is the URI path that will be accessed if monitor type
 	// is HTTP or HTTPS.
 	URLPath string `json:"url_path,omitempty"`
-	// The HTTP method used for requests by the
-	// monitor. If this attribute is not specified, it defaults to "GET".
+
+	// HTTPMethod is the HTTP method used for requests by the monitor. If this
+	// attribute is not specified, it defaults to "GET".
 	HTTPMethod string `json:"http_method,omitempty"`
-	// Expected HTTP codes for a passing HTTP(S)
-	// monitor. You can either specify a single status like "200", or a range
-	// like "200-202".
+
+	// ExpectedCodes is the expected HTTP codes for a passing HTTP(S) monitor
+	// You can either specify a single status like "200", or a range like
+	// "200-202".
 	ExpectedCodes string `json:"expected_codes,omitempty"`
-	AdminStateUp  *bool  `json:"admin_state_up,omitempty"`
+
+	// AdminStateUp denotes whether the monitor is administratively up or down.
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 }
 
-// ToLBMonitorUpdateMap allows UpdateOpts to satisfy the UpdateOptsBuilder
-// interface
+// ToLBMonitorUpdateMap builds a request body from UpdateOpts.
 func (opts UpdateOpts) ToLBMonitorUpdateMap() (map[string]interface{}, error) {
 	if opts.Delay > 0 && opts.Timeout > 0 && opts.Delay < opts.Timeout {
 		err := gophercloud.ErrInvalidInput{}
@@ -190,7 +206,8 @@ func (opts UpdateOpts) ToLBMonitorUpdateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "health_monitor")
 }
 
-// Update is an operation which modifies the attributes of the specified monitor.
+// Update is an operation which modifies the attributes of the specified
+// monitor.
 func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToLBMonitorUpdateMap()
 	if err != nil {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/monitors/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/monitors/results.go
@@ -21,46 +21,47 @@ import (
 // won't participate in its pool's load balancing. In other words, ALL monitors
 // must declare the member to be healthy for it to stay ACTIVE.
 type Monitor struct {
-	// The unique ID for the VIP.
+	// ID is the unique ID for the Monitor.
 	ID string
 
-	// Monitor name. Does not have to be unique.
+	// Name is the monitor name. Does not have to be unique.
 	Name string
 
-	// Owner of the VIP. Only an administrative user can specify a tenant ID
-	// other than its own.
+	// TenantID is the owner of the Monitor.
 	TenantID string `json:"tenant_id"`
 
-	// The type of probe sent by the load balancer to verify the member state,
-	// which is PING, TCP, HTTP, or HTTPS.
+	// Type is the type of probe sent by the load balancer to verify the member
+	// state, which is PING, TCP, HTTP, or HTTPS.
 	Type string
 
-	// The time, in seconds, between sending probes to members.
+	// Delay is the time, in seconds, between sending probes to members.
 	Delay int
 
-	// The maximum number of seconds for a monitor to wait for a connection to be
-	// established before it times out. This value must be less than the delay value.
+	// Timeout is the maximum number of seconds for a monitor to wait for a
+	// connection to be established before it times out. This value must be less
+	// than the delay value.
 	Timeout int
 
-	// Number of allowed connection failures before changing the status of the
-	// member to INACTIVE. A valid value is from 1 to 10.
+	// MaxRetries is the number of allowed connection failures before changing the
+	// status of the member to INACTIVE. A valid value is from 1 to 10.
 	MaxRetries int `json:"max_retries"`
 
-	// The HTTP method that the monitor uses for requests.
+	// HTTPMethod is the HTTP method that the monitor uses for requests.
 	HTTPMethod string `json:"http_method"`
 
-	// The HTTP path of the request sent by the monitor to test the health of a
-	// member. Must be a string beginning with a forward slash (/).
+	// URLPath is the HTTP path of the request sent by the monitor to test the
+	// health of a member. Must be a string beginning with a forward slash (/).
 	URLPath string `json:"url_path"`
 
-	// Expected HTTP codes for a passing HTTP(S) monitor.
+	// ExpectedCodes is the expected HTTP codes for a passing HTTP(S) monitor.
 	ExpectedCodes string `json:"expected_codes"`
 
-	// The administrative state of the health monitor, which is up (true) or down (false).
+	// AdminStateUp is the administrative state of the health monitor, which is up
+	// (true) or down (false).
 	AdminStateUp bool `json:"admin_state_up"`
 
-	// The status of the health monitor. Indicates whether the health monitor is
-	// operational.
+	// Status is the status of the health monitor. Indicates whether the health
+	// monitor is operational.
 	Status string
 }
 
@@ -115,22 +116,26 @@ func (r commonResult) Extract() (*Monitor, error) {
 	return s.Monitor, err
 }
 
-// CreateResult represents the result of a create operation.
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Monitor.
 type CreateResult struct {
 	commonResult
 }
 
-// GetResult represents the result of a get operation.
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Monitor.
 type GetResult struct {
 	commonResult
 }
 
-// UpdateResult represents the result of an update operation.
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Monitor.
 type UpdateResult struct {
 	commonResult
 }
 
-// DeleteResult represents the result of a delete operation.
+// DeleteResult represents the result of a delete operation. Call its Extract
+// method to determine if the request succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/pools/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/pools/doc.go
@@ -1,0 +1,81 @@
+/*
+Package pools provides information and interaction with the Pools of the
+Load Balancing as a Service extension for the OpenStack Networking service.
+
+Example to List Pools
+
+	listOpts := pools.ListOpts{
+		SubnetID: "d9bd223b-f1a9-4f98-953b-df977b0f902d",
+	}
+
+	allPages, err := pools.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allPools, err := pools.ExtractPools(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, pool := range allPools {
+		fmt.Printf("%+v\n", pool)
+	}
+
+Example to Create a Pool
+
+	createOpts := pools.CreateOpts{
+		LBMethod: pools.LBMethodRoundRobin,
+		Protocol: "HTTP",
+		Name:     "Example pool",
+		SubnetID: "1981f108-3c48-48d2-b908-30f7d28532c9",
+		Provider: "haproxy",
+	}
+
+	pool, err := pools.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Pool
+
+	poolID := "166db5e6-c72a-4d77-8776-3573e27ae271"
+
+	updateOpts := pools.UpdateOpts{
+		LBMethod: pools.LBMethodLeastConnections,
+	}
+
+	pool, err := pools.Update(networkClient, poolID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Pool
+
+	poolID := "166db5e6-c72a-4d77-8776-3573e27ae271"
+	err := pools.Delete(networkClient, poolID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Associate a Monitor to a Pool
+
+	poolID := "166db5e6-c72a-4d77-8776-3573e27ae271"
+	monitorID := "8bbfbe1c-6faa-4d97-abdb-0df6c90df70b"
+
+	pool, err := pools.AssociateMonitor(networkClient, poolID, monitorID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Disassociate a Monitor from a Pool
+
+	poolID := "166db5e6-c72a-4d77-8776-3573e27ae271"
+	monitorID := "8bbfbe1c-6faa-4d97-abdb-0df6c90df70b"
+
+	pool, err := pools.DisassociateMonitor(networkClient, poolID, monitorID).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
+package pools

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/pools/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/pools/requests.go
@@ -43,10 +43,10 @@ func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
 	})
 }
 
-// LBMethod is a type used for possible load balancing methods
+// LBMethod is a type used for possible load balancing methods.
 type LBMethod string
 
-// LBProtocol is a type used for possible load balancing protocols
+// LBProtocol is a type used for possible load balancing protocols.
 type LBProtocol string
 
 // Supported attributes for create/update operations.
@@ -59,8 +59,8 @@ const (
 	ProtocolHTTPS LBProtocol = "HTTPS"
 )
 
-// CreateOptsBuilder is the interface types must satisfy to be used as options
-// for the Create function
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToLBPoolCreateMap() (map[string]interface{}, error)
 }
@@ -69,25 +69,29 @@ type CreateOptsBuilder interface {
 type CreateOpts struct {
 	// Name of the pool.
 	Name string `json:"name" required:"true"`
-	// The protocol used by the pool members, you can use either
+
+	// Protocol used by the pool members, you can use either
 	// ProtocolTCP, ProtocolHTTP, or ProtocolHTTPS.
 	Protocol LBProtocol `json:"protocol" required:"true"`
-	// Only required if the caller has an admin role and wants to create a pool
-	// for another tenant.
+
+	// TenantID is only required if the caller has an admin role and wants
+	// to create a pool for another tenant.
 	TenantID string `json:"tenant_id,omitempty"`
-	// The network on which the members of the pool will be located. Only members
-	// that are on this network can be added to the pool.
+
+	// SubnetID is the network on which the members of the pool will be located.
+	// Only members that are on this network can be added to the pool.
 	SubnetID string `json:"subnet_id,omitempty"`
-	// The algorithm used to distribute load between the members of the pool. The
-	// current specification supports LBMethodRoundRobin and
+
+	// LBMethod is the algorithm used to distribute load between the members of
+	// the pool. The current specification supports LBMethodRoundRobin and
 	// LBMethodLeastConnections as valid values for this attribute.
 	LBMethod LBMethod `json:"lb_method" required:"true"`
 
-	// The provider of the pool
+	// Provider of the pool.
 	Provider string `json:"provider,omitempty"`
 }
 
-// ToLBPoolCreateMap allows CreateOpts to satisfy the CreateOptsBuilder interface
+// ToLBPoolCreateMap builds a request body based on CreateOpts.
 func (opts CreateOpts) ToLBPoolCreateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "pool")
 }
@@ -110,8 +114,8 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
-// UpdateOptsBuilder is the interface types must satisfy to be used as options
-// for the Update function
+// UpdateOptsBuilder allows extensions to add additional parameters ot the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToLBPoolUpdateMap() (map[string]interface{}, error)
 }
@@ -120,13 +124,14 @@ type UpdateOptsBuilder interface {
 type UpdateOpts struct {
 	// Name of the pool.
 	Name string `json:"name,omitempty"`
-	// The algorithm used to distribute load between the members of the pool. The
-	// current specification supports LBMethodRoundRobin and
+
+	// LBMethod is the algorithm used to distribute load between the members of
+	// the pool. The current specification supports LBMethodRoundRobin and
 	// LBMethodLeastConnections as valid values for this attribute.
 	LBMethod LBMethod `json:"lb_method,omitempty"`
 }
 
-// ToLBPoolUpdateMap allows UpdateOpts to satisfy the UpdateOptsBuilder interface
+// ToLBPoolUpdateMap builds a request body based on UpdateOpts.
 func (opts UpdateOpts) ToLBPoolUpdateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "pool")
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/pools/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/pools/results.go
@@ -11,47 +11,48 @@ import (
 // method to handle the new requests or connections received on the VIP address.
 // There is only one pool per virtual IP.
 type Pool struct {
-	// The status of the pool. Indicates whether the pool is operational.
+	// Status of the pool. Indicates whether the pool is operational.
 	Status string
 
-	// The load-balancer algorithm, which is round-robin, least-connections, and
-	// so on. This value, which must be supported, is dependent on the provider.
-	// Round-robin must be supported.
+	// LBMethod is the load-balancer algorithm, which is round-robin,
+	// least-connections, and so on. This value, which must be supported, is
+	// dependent on the provider.
 	LBMethod string `json:"lb_method"`
 
-	// The protocol of the pool, which is TCP, HTTP, or HTTPS.
+	// Protocol of the pool, which is TCP, HTTP, or HTTPS.
 	Protocol string
 
 	// Description for the pool.
 	Description string
 
-	// The IDs of associated monitors which check the health of the pool members.
+	// MonitorIDs are the IDs of associated monitors which check the health of
+	// the pool members.
 	MonitorIDs []string `json:"health_monitors"`
 
-	// The network on which the members of the pool will be located. Only members
-	// that are on this network can be added to the pool.
+	// SubnetID is the network on which the members of the pool will be located.
+	// Only members that are on this network can be added to the pool.
 	SubnetID string `json:"subnet_id"`
 
-	// Owner of the pool. Only an administrative user can specify a tenant ID
-	// other than its own.
+	// TenantID is the owner of the pool.
 	TenantID string `json:"tenant_id"`
 
-	// The administrative state of the pool, which is up (true) or down (false).
+	// AdminStateUp is the administrative state of the pool, which is up
+	// (true) or down (false).
 	AdminStateUp bool `json:"admin_state_up"`
 
-	// Pool name. Does not have to be unique.
+	// Name of the pool.
 	Name string
 
-	// List of member IDs that belong to the pool.
+	// MemberIDs is the list of member IDs that belong to the pool.
 	MemberIDs []string `json:"members"`
 
-	// The unique ID for the pool.
+	// ID is the unique ID for the pool.
 	ID string
 
-	// The ID of the virtual IP associated with this pool
+	// VIPID is the ID of the virtual IP associated with this pool.
 	VIPID string `json:"vip_id"`
 
-	// The provider
+	// The provider.
 	Provider string
 }
 
@@ -81,7 +82,7 @@ func (r PoolPage) IsEmpty() (bool, error) {
 	return len(is) == 0, err
 }
 
-// ExtractPools accepts a Page struct, specifically a RouterPage struct,
+// ExtractPools accepts a Page struct, specifically a PoolPage struct,
 // and extracts the elements into a slice of Router structs. In other words,
 // a generic collection is mapped into a relevant slice.
 func ExtractPools(r pagination.Page) ([]Pool, error) {
@@ -105,27 +106,32 @@ func (r commonResult) Extract() (*Pool, error) {
 	return s.Pool, err
 }
 
-// CreateResult represents the result of a create operation.
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Pool.
 type CreateResult struct {
 	commonResult
 }
 
-// GetResult represents the result of a get operation.
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Pool.
 type GetResult struct {
 	commonResult
 }
 
-// UpdateResult represents the result of an update operation.
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Pool.
 type UpdateResult struct {
 	commonResult
 }
 
-// DeleteResult represents the result of a delete operation.
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to interpret it as a Pool.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
-// AssociateResult represents the result of an association operation.
+// AssociateResult represents the result of an association operation. Call its Extract
+// method to interpret it as a Pool.
 type AssociateResult struct {
 	commonResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/vips/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/vips/doc.go
@@ -1,0 +1,65 @@
+/*
+Package vips provides information and interaction with the Virtual IPs of the
+Load Balancing as a Service extension for the OpenStack Networking service.
+
+Example to List Virtual IPs
+
+	listOpts := vips.ListOpts{
+		SubnetID: "d9bd223b-f1a9-4f98-953b-df977b0f902d",
+	}
+
+	allPages, err := vips.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allVIPs, err := vips.ExtractVIPs(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, vip := range allVIPs {
+		fmt.Printf("%+v\n", vip)
+	}
+
+Example to Create a Virtual IP
+
+	createOpts := vips.CreateOpts{
+		Protocol:     "HTTP",
+		Name:         "NewVip",
+		AdminStateUp: gophercloud.Enabled,
+		SubnetID:     "8032909d-47a1-4715-90af-5153ffe39861",
+		PoolID:       "61b1f87a-7a21-4ad3-9dda-7f81d249944f",
+		ProtocolPort: 80,
+		Persistence:  &vips.SessionPersistence{Type: "SOURCE_IP"},
+	}
+
+	vip, err := vips.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Virtual IP
+
+	vipID := "93f1bad4-0423-40a8-afac-3fc541839912"
+
+	i1000 := 1000
+	updateOpts := vips.UpdateOpts{
+		ConnLimit:   &i1000,
+		Persistence: &vips.SessionPersistence{Type: "SOURCE_IP"},
+	}
+
+	vip, err := vips.Update(networkClient, vipID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Virtual IP
+
+	vipID := "93f1bad4-0423-40a8-afac-3fc541839912"
+	err := vips.Delete(networkClient, vipID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package vips

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/vips/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/vips/requests.go
@@ -29,10 +29,10 @@ type ListOpts struct {
 }
 
 // List returns a Pager which allows you to iterate over a collection of
-// routers. It accepts a ListOpts struct, which allows you to filter and sort
-// the returned collection for greater efficiency.
+// Virtual IPs. It accepts a ListOpts struct, which allows you to filter and
+// sort the returned collection for greater efficiency.
 //
-// Default policy settings return only those routers that are owned by the
+// Default policy settings return only those virtual IPs that are owned by the
 // tenant who submits the request, unless an admin user submits the request.
 func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
 	q, err := gophercloud.BuildQueryString(&opts)
@@ -45,43 +45,54 @@ func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
 	})
 }
 
-// CreateOptsBuilder is what types must satisfy to be used as Create
-// options.
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create Request.
 type CreateOptsBuilder interface {
 	ToVIPCreateMap() (map[string]interface{}, error)
 }
 
 // CreateOpts contains all the values needed to create a new virtual IP.
 type CreateOpts struct {
-	// Human-readable name for the VIP. Does not have to be unique.
+	// Name is the human-readable name for the VIP. Does not have to be unique.
 	Name string `json:"name" required:"true"`
-	// The network on which to allocate the VIP's address. A tenant can
-	// only create VIPs on networks authorized by policy (e.g. networks that
+
+	// SubnetID is the network on which to allocate the VIP's address. A tenant
+	// can only create VIPs on networks authorized by policy (e.g. networks that
 	// belong to them or networks that are shared).
 	SubnetID string `json:"subnet_id" required:"true"`
-	// The protocol - can either be TCP, HTTP or HTTPS.
+
+	// Protocol - can either be TCP, HTTP or HTTPS.
 	Protocol string `json:"protocol" required:"true"`
-	// The port on which to listen for client traffic.
+
+	// ProtocolPort is the port on which to listen for client traffic.
 	ProtocolPort int `json:"protocol_port" required:"true"`
-	// The ID of the pool with which the VIP is associated.
+
+	// PoolID is the ID of the pool with which the VIP is associated.
 	PoolID string `json:"pool_id" required:"true"`
-	// Required for admins. Indicates the owner of the VIP.
+
+	// TenantID is only required if the caller has an admin role and wants
+	// to create a pool for another tenant.
 	TenantID string `json:"tenant_id,omitempty"`
-	// The IP address of the VIP.
+
+	// Address is the IP address of the VIP.
 	Address string `json:"address,omitempty"`
-	// Human-readable description for the VIP.
+
+	// Description is the human-readable description for the VIP.
 	Description string `json:"description,omitempty"`
+
+	// Persistence is the the of session persistence to use.
 	// Omit this field to prevent session persistence.
 	Persistence *SessionPersistence `json:"session_persistence,omitempty"`
-	// The maximum number of connections allowed for the VIP.
+
+	// ConnLimit is the maximum number of connections allowed for the VIP.
 	ConnLimit *int `json:"connection_limit,omitempty"`
-	// The administrative state of the VIP. A valid value is true (UP)
-	// or false (DOWN).
+
+	// AdminStateUp is the administrative state of the VIP. A valid value is
+	// true (UP) or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 }
 
-// ToVIPCreateMap allows CreateOpts to satisfy the CreateOptsBuilder
-// interface
+// ToVIPCreateMap builds a request body from CreateOpts.
 func (opts CreateOpts) ToVIPCreateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "vip")
 }
@@ -113,8 +124,8 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
-// UpdateOptsBuilder is what types must satisfy to be used as Update
-// options.
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToVIPUpdateMap() (map[string]interface{}, error)
 }
@@ -123,22 +134,28 @@ type UpdateOptsBuilder interface {
 // Attributes not listed here but appear in CreateOpts are immutable and cannot
 // be updated.
 type UpdateOpts struct {
-	// Human-readable name for the VIP. Does not have to be unique.
+	// Name is the human-readable name for the VIP. Does not have to be unique.
 	Name *string `json:"name,omitempty"`
-	// The ID of the pool with which the VIP is associated.
+
+	// PoolID is the ID of the pool with which the VIP is associated.
 	PoolID *string `json:"pool_id,omitempty"`
-	// Human-readable description for the VIP.
+
+	// Description is the human-readable description for the VIP.
 	Description *string `json:"description,omitempty"`
+
+	// Persistence is the the of session persistence to use.
 	// Omit this field to prevent session persistence.
 	Persistence *SessionPersistence `json:"session_persistence,omitempty"`
-	// The maximum number of connections allowed for the VIP.
+
+	// ConnLimit is the maximum number of connections allowed for the VIP.
 	ConnLimit *int `json:"connection_limit,omitempty"`
-	// The administrative state of the VIP. A valid value is true (UP)
-	// or false (DOWN).
+
+	// AdminStateUp is the administrative state of the VIP. A valid value is
+	// true (UP) or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 }
 
-// ToVIPUpdateMap allows UpdateOpts to satisfy the UpdateOptsBuilder interface
+// ToVIPUpdateMap builds a request body based on UpdateOpts.
 func (opts UpdateOpts) ToVIPUpdateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "vip")
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/vips/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/vips/results.go
@@ -21,10 +21,10 @@ import (
 //              requests carrying the same cookie value will be handled by the
 //              same member of the pool.
 type SessionPersistence struct {
-	// The type of persistence mode
+	// Type is the type of persistence mode.
 	Type string `json:"type"`
 
-	// Name of cookie if persistence mode is set appropriately
+	// CookieName is the name of cookie if persistence mode is set appropriately.
 	CookieName string `json:"cookie_name,omitempty"`
 }
 
@@ -34,54 +34,55 @@ type SessionPersistence struct {
 // This entity is sometimes known in LB products under the name of a "virtual
 // server", a "vserver" or a "listener".
 type VirtualIP struct {
-	// The unique ID for the VIP.
+	// ID is the unique ID for the VIP.
 	ID string `json:"id"`
 
-	// Owner of the VIP. Only an admin user can specify a tenant ID other than its own.
+	// TenantID is the owner of the VIP.
 	TenantID string `json:"tenant_id"`
 
-	// Human-readable name for the VIP. Does not have to be unique.
+	// Name is the human-readable name for the VIP. Does not have to be unique.
 	Name string `json:"name"`
 
-	// Human-readable description for the VIP.
+	// Description is the human-readable description for the VIP.
 	Description string `json:"description"`
 
-	// The ID of the subnet on which to allocate the VIP address.
+	// SubnetID is the ID of the subnet on which to allocate the VIP address.
 	SubnetID string `json:"subnet_id"`
 
-	// The IP address of the VIP.
+	// Address is the IP address of the VIP.
 	Address string `json:"address"`
 
-	// The protocol of the VIP address. A valid value is TCP, HTTP, or HTTPS.
+	// Protocol of the VIP address. A valid value is TCP, HTTP, or HTTPS.
 	Protocol string `json:"protocol"`
 
-	// The port on which to listen to client traffic that is associated with the
-	// VIP address. A valid value is from 0 to 65535.
+	// ProtocolPort is the port on which to listen to client traffic that is
+	// associated with the VIP address. A valid value is from 0 to 65535.
 	ProtocolPort int `json:"protocol_port"`
 
-	// The ID of the pool with which the VIP is associated.
+	// PoolID is the ID of the pool with which the VIP is associated.
 	PoolID string `json:"pool_id"`
 
-	// The ID of the port which belongs to the load balancer
+	// PortID is the ID of the port which belongs to the load balancer.
 	PortID string `json:"port_id"`
 
-	// Indicates whether connections in the same session will be processed by the
-	// same pool member or not.
+	// Persistence indicates whether connections in the same session will be
+	// processed by the same pool member or not.
 	Persistence SessionPersistence `json:"session_persistence"`
 
-	// The maximum number of connections allowed for the VIP. Default is -1,
-	// meaning no limit.
+	// ConnLimit is the maximum number of connections allowed for the VIP.
+	// Default is -1, meaning no limit.
 	ConnLimit int `json:"connection_limit"`
 
-	// The administrative state of the VIP. A valid value is true (UP) or false (DOWN).
+	// AdminStateUp is the administrative state of the VIP. A valid value is
+	// true (UP) or false (DOWN).
 	AdminStateUp bool `json:"admin_state_up"`
 
-	// The status of the VIP. Indicates whether the VIP is operational.
+	// Status is the status of the VIP. Indicates whether the VIP is operational.
 	Status string `json:"status"`
 }
 
 // VIPPage is the page returned by a pager when traversing over a
-// collection of routers.
+// collection of virtual IPs.
 type VIPPage struct {
 	pagination.LinkedPageBase
 }
@@ -121,7 +122,7 @@ type commonResult struct {
 	gophercloud.Result
 }
 
-// Extract is a function that accepts a result and extracts a router.
+// Extract is a function that accepts a result and extracts a VirtualIP.
 func (r commonResult) Extract() (*VirtualIP, error) {
 	var s struct {
 		VirtualIP *VirtualIP `json:"vip" json:"vip"`
@@ -130,22 +131,26 @@ func (r commonResult) Extract() (*VirtualIP, error) {
 	return s.VirtualIP, err
 }
 
-// CreateResult represents the result of a create operation.
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a VirtualIP
 type CreateResult struct {
 	commonResult
 }
 
-// GetResult represents the result of a get operation.
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a VirtualIP
 type GetResult struct {
 	commonResult
 }
 
-// UpdateResult represents the result of an update operation.
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a VirtualIP
 type UpdateResult struct {
 	commonResult
 }
 
-// DeleteResult represents the result of a delete operation.
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners/doc.go
@@ -1,0 +1,63 @@
+/*
+Package listeners provides information and interaction with Listeners of the
+LBaaS v2 extension for the OpenStack Networking service.
+
+Example to List Listeners
+
+	listOpts := listeners.ListOpts{
+		LoadbalancerID : "ca430f80-1737-4712-8dc6-3f640d55594b",
+	}
+
+	allPages, err := listeners.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allListeners, err := listeners.ExtractListeners(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, listener := range allListeners {
+		fmt.Printf("%+v\n", listener)
+	}
+
+Example to Create a Listener
+
+	createOpts := listeners.CreateOpts{
+		Protocol:               "TCP",
+		Name:                   "db",
+		LoadbalancerID:         "79e05663-7f03-45d2-a092-8b94062f22ab",
+		AdminStateUp:           gophercloud.Enabled,
+		DefaultPoolID:          "41efe233-7591-43c5-9cf7-923964759f9e",
+		ProtocolPort:           3306,
+	}
+
+	listener, err := listeners.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Listener
+
+	listenerID := "d67d56a6-4a86-4688-a282-f46444705c64"
+
+	i1001 := 1001
+	updateOpts := listeners.UpdateOpts{
+		ConnLimit: &i1001,
+	}
+
+	listener, err := listeners.Update(networkClient, listenerID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Listener
+
+	listenerID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	err := listeners.Delete(networkClient, listenerID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package listeners

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
+// Type Protocol represents a listener protocol.
 type Protocol string
 
 // Supported attributes for create/update operations.
@@ -30,6 +31,7 @@ type ListOpts struct {
 	Name            string `q:"name"`
 	AdminStateUp    *bool  `q:"admin_state_up"`
 	TenantID        string `q:"tenant_id"`
+	ProjectID       string `q:"project_id"`
 	LoadbalancerID  string `q:"loadbalancer_id"`
 	DefaultPoolID   string `q:"default_pool_id"`
 	Protocol        string `q:"protocol"`
@@ -48,10 +50,10 @@ func (opts ListOpts) ToListenerListQuery() (string, error) {
 }
 
 // List returns a Pager which allows you to iterate over a collection of
-// routers. It accepts a ListOpts struct, which allows you to filter and sort
+// listeners. It accepts a ListOpts struct, which allows you to filter and sort
 // the returned collection for greater efficiency.
 //
-// Default policy settings return only those routers that are owned by the
+// Default policy settings return only those listeners that are owned by the
 // tenant who submits the request, unless an admin user submits the request.
 func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
@@ -67,43 +69,55 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	})
 }
 
-// CreateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Create operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToListenerCreateMap() (map[string]interface{}, error)
 }
 
-// CreateOpts is the common options struct used in this package's Create
-// operation.
+// CreateOpts represents options for creating a listener.
 type CreateOpts struct {
 	// The load balancer on which to provision this listener.
 	LoadbalancerID string `json:"loadbalancer_id" required:"true"`
+
 	// The protocol - can either be TCP, HTTP or HTTPS.
 	Protocol Protocol `json:"protocol" required:"true"`
+
 	// The port on which to listen for client traffic.
 	ProtocolPort int `json:"protocol_port" required:"true"`
-	// Indicates the owner of the Listener. Required for admins.
+
+	// TenantID is only required if the caller has an admin role and wants
+	// to create a pool for another project.
 	TenantID string `json:"tenant_id,omitempty"`
+
+	// ProjectID is only required if the caller has an admin role and wants
+	// to create a pool for another project.
+	ProjectID string `json:"project_id,omitempty"`
+
 	// Human-readable name for the Listener. Does not have to be unique.
 	Name string `json:"name,omitempty"`
+
 	// The ID of the default pool with which the Listener is associated.
 	DefaultPoolID string `json:"default_pool_id,omitempty"`
+
 	// Human-readable description for the Listener.
 	Description string `json:"description,omitempty"`
+
 	// The maximum number of connections allowed for the Listener.
 	ConnLimit *int `json:"connection_limit,omitempty"`
-	// A reference to a container of TLS secrets.
+
+	// A reference to a Barbican container of TLS secrets.
 	DefaultTlsContainerRef string `json:"default_tls_container_ref,omitempty"`
+
 	// A list of references to TLS secrets.
 	SniContainerRefs []string `json:"sni_container_refs,omitempty"`
+
 	// The administrative state of the Listener. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 }
 
-// ToListenerCreateMap casts a CreateOpts struct to a map.
+// ToListenerCreateMap builds a request body from CreateOpts.
 func (opts CreateOpts) ToListenerCreateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "listener")
 }
@@ -131,38 +145,41 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
-// UpdateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Update operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToListenerUpdateMap() (map[string]interface{}, error)
 }
 
-// UpdateOpts is the common options struct used in this package's Update
-// operation.
+// UpdateOpts represents options for updating a Listener.
 type UpdateOpts struct {
 	// Human-readable name for the Listener. Does not have to be unique.
 	Name string `json:"name,omitempty"`
+
 	// Human-readable description for the Listener.
 	Description string `json:"description,omitempty"`
+
 	// The maximum number of connections allowed for the Listener.
 	ConnLimit *int `json:"connection_limit,omitempty"`
-	// A reference to a container of TLS secrets.
+
+	// A reference to a Barbican container of TLS secrets.
 	DefaultTlsContainerRef string `json:"default_tls_container_ref,omitempty"`
-	//  A list of references to TLS secrets.
+
+	// A list of references to TLS secrets.
 	SniContainerRefs []string `json:"sni_container_refs,omitempty"`
+
 	// The administrative state of the Listener. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 }
 
-// ToListenerUpdateMap casts a UpdateOpts struct to a map.
+// ToListenerUpdateMap builds a request body from UpdateOpts.
 func (opts UpdateOpts) ToListenerUpdateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "listener")
 }
 
-// Update is an operation which modifies the attributes of the specified Listener.
+// Update is an operation which modifies the attributes of the specified
+// Listener.
 func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
 	b, err := opts.ToListenerUpdateMap()
 	if err != nil {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners/results.go
@@ -16,40 +16,53 @@ type LoadBalancerID struct {
 type Listener struct {
 	// The unique ID for the Listener.
 	ID string `json:"id"`
-	// Owner of the Listener. Only an admin user can specify a tenant ID other than its own.
+
+	// Owner of the Listener.
 	TenantID string `json:"tenant_id"`
+
 	// Human-readable name for the Listener. Does not have to be unique.
 	Name string `json:"name"`
+
 	// Human-readable description for the Listener.
 	Description string `json:"description"`
+
 	// The protocol to loadbalance. A valid value is TCP, HTTP, or HTTPS.
 	Protocol string `json:"protocol"`
+
 	// The port on which to listen to client traffic that is associated with the
 	// Loadbalancer. A valid value is from 0 to 65535.
 	ProtocolPort int `json:"protocol_port"`
+
 	// The UUID of default pool. Must have compatible protocol with listener.
 	DefaultPoolID string `json:"default_pool_id"`
+
 	// A list of load balancer IDs.
 	Loadbalancers []LoadBalancerID `json:"loadbalancers"`
-	// The maximum number of connections allowed for the Loadbalancer. Default is -1,
-	// meaning no limit.
+
+	// The maximum number of connections allowed for the Loadbalancer.
+	// Default is -1, meaning no limit.
 	ConnLimit int `json:"connection_limit"`
+
 	// The list of references to TLS secrets.
 	SniContainerRefs []string `json:"sni_container_refs"`
-	// Optional. A reference to a container of TLS secrets.
+
+	// A reference to a Barbican container of TLS secrets.
 	DefaultTlsContainerRef string `json:"default_tls_container_ref"`
+
 	// The administrative state of the Listener. A valid value is true (UP) or false (DOWN).
-	AdminStateUp bool         `json:"admin_state_up"`
-	Pools        []pools.Pool `json:"pools"`
+	AdminStateUp bool `json:"admin_state_up"`
+
+	// Pools are the pools which are part of this listener.
+	Pools []pools.Pool `json:"pools"`
 }
 
 // ListenerPage is the page returned by a pager when traversing over a
-// collection of routers.
+// collection of listeners.
 type ListenerPage struct {
 	pagination.LinkedPageBase
 }
 
-// NextPageURL is invoked when a paginated collection of routers has reached
+// NextPageURL is invoked when a paginated collection of listeners has reached
 // the end of a page and the pager seeks to traverse over a new one. In order
 // to do this, it needs to construct the next page's URL.
 func (r ListenerPage) NextPageURL() (string, error) {
@@ -63,7 +76,7 @@ func (r ListenerPage) NextPageURL() (string, error) {
 	return gophercloud.ExtractNextURL(s.Links)
 }
 
-// IsEmpty checks whether a RouterPage struct is empty.
+// IsEmpty checks whether a ListenerPage struct is empty.
 func (r ListenerPage) IsEmpty() (bool, error) {
 	is, err := ExtractListeners(r)
 	return len(is) == 0, err
@@ -84,7 +97,7 @@ type commonResult struct {
 	gophercloud.Result
 }
 
-// Extract is a function that accepts a result and extracts a router.
+// Extract is a function that accepts a result and extracts a listener.
 func (r commonResult) Extract() (*Listener, error) {
 	var s struct {
 		Listener *Listener `json:"listener"`
@@ -93,22 +106,26 @@ func (r commonResult) Extract() (*Listener, error) {
 	return s.Listener, err
 }
 
-// CreateResult represents the result of a create operation.
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Listener.
 type CreateResult struct {
 	commonResult
 }
 
-// GetResult represents the result of a get operation.
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Listener.
 type GetResult struct {
 	commonResult
 }
 
-// UpdateResult represents the result of an update operation.
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Listener.
 type UpdateResult struct {
 	commonResult
 }
 
-// DeleteResult represents the result of a delete operation.
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/doc.go
@@ -1,0 +1,71 @@
+/*
+Package loadbalancers provides information and interaction with Load Balancers
+of the LBaaS v2 extension for the OpenStack Networking service.
+
+Example to List Load Balancers
+
+	listOpts := loadbalancers.ListOpts{
+		Provider: "haproxy",
+	}
+
+	allPages, err := loadbalancers.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allLoadbalancers, err := loadbalancers.ExtractLoadBalancers(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, lb := range allLoadbalancers {
+		fmt.Printf("%+v\n", lb)
+	}
+
+Example to Create a Load Balancer
+
+	createOpts := loadbalancers.CreateOpts{
+		Name:         "db_lb",
+		AdminStateUp: gophercloud.Enabled,
+		VipSubnetID:  "9cedb85d-0759-4898-8a4b-fa5a5ea10086",
+		VipAddress:   "10.30.176.48",
+		Flavor:       "medium",
+		Provider:     "haproxy",
+	}
+
+	lb, err := loadbalancers.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Load Balancer
+
+	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"
+
+	i1001 := 1001
+	updateOpts := loadbalancers.UpdateOpts{
+		Name: "new-name",
+	}
+
+	lb, err := loadbalancers.Update(networkClient, lbID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Load Balancers
+
+	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	err := loadbalancers.Delete(networkClient, lbID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Get the Status of a Load Balancer
+
+	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	status, err := loadbalancers.GetStatuses(networkClient, LBID).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
+package loadbalancers

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/requests.go
@@ -1,6 +1,8 @@
 package loadbalancers
 
 import (
+	"fmt"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -20,6 +22,7 @@ type ListOpts struct {
 	Description        string `q:"description"`
 	AdminStateUp       *bool  `q:"admin_state_up"`
 	TenantID           string `q:"tenant_id"`
+	ProjectID          string `q:"project_id"`
 	ProvisioningStatus string `q:"provisioning_status"`
 	VipAddress         string `q:"vip_address"`
 	VipPortID          string `q:"vip_port_id"`
@@ -35,18 +38,18 @@ type ListOpts struct {
 	SortDir            string `q:"sort_dir"`
 }
 
-// ToLoadbalancerListQuery formats a ListOpts into a query string.
+// ToLoadBalancerListQuery formats a ListOpts into a query string.
 func (opts ListOpts) ToLoadBalancerListQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
 	return q.String(), err
 }
 
 // List returns a Pager which allows you to iterate over a collection of
-// routers. It accepts a ListOpts struct, which allows you to filter and sort
-// the returned collection for greater efficiency.
+// load balancers. It accepts a ListOpts struct, which allows you to filter
+// and sort the returned collection for greater efficiency.
 //
-// Default policy settings return only those routers that are owned by the
-// tenant who submits the request, unless an admin user submits the request.
+// Default policy settings return only those load balancers that are owned by
+// the tenant who submits the request, unless an admin user submits the request.
 func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
@@ -61,10 +64,8 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	})
 }
 
-// CreateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Create operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToLoadBalancerCreateMap() (map[string]interface{}, error)
 }
@@ -72,29 +73,40 @@ type CreateOptsBuilder interface {
 // CreateOpts is the common options struct used in this package's Create
 // operation.
 type CreateOpts struct {
-	// Optional. Human-readable name for the Loadbalancer. Does not have to be unique.
+	// Human-readable name for the Loadbalancer. Does not have to be unique.
 	Name string `json:"name,omitempty"`
-	// Optional. Human-readable description for the Loadbalancer.
+
+	// Human-readable description for the Loadbalancer.
 	Description string `json:"description,omitempty"`
-	// Required. The network on which to allocate the Loadbalancer's address. A tenant can
-	// only create Loadbalancers on networks authorized by policy (e.g. networks that
-	// belong to them or networks that are shared).
+
+	// The network on which to allocate the Loadbalancer's address. A tenant can
+	// only create Loadbalancers on networks authorized by policy (e.g. networks
+	// that belong to them or networks that are shared).
 	VipSubnetID string `json:"vip_subnet_id" required:"true"`
-	// Required for admins. The UUID of the tenant who owns the Loadbalancer.
-	// Only administrative users can specify a tenant UUID other than their own.
+
+	// TenantID is the UUID of the project who owns the Loadbalancer.
+	// Only administrative users can specify a project UUID other than their own.
 	TenantID string `json:"tenant_id,omitempty"`
-	// Optional. The IP address of the Loadbalancer.
+
+	// ProjectID is the UUID of the project who owns the Loadbalancer.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// The IP address of the Loadbalancer.
 	VipAddress string `json:"vip_address,omitempty"`
-	// Optional. The administrative state of the Loadbalancer. A valid value is true (UP)
+
+	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
-	// Optional. The UUID of a flavor.
+
+	// The UUID of a flavor.
 	Flavor string `json:"flavor,omitempty"`
-	// Optional. The name of the provider.
+
+	// The name of the provider.
 	Provider string `json:"provider,omitempty"`
 }
 
-// ToLoadBalancerCreateMap casts a CreateOpts struct to a map.
+// ToLoadBalancerCreateMap builds a request body from CreateOpts.
 func (opts CreateOpts) ToLoadBalancerCreateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "loadbalancer")
 }
@@ -103,9 +115,6 @@ func (opts CreateOpts) ToLoadBalancerCreateMap() (map[string]interface{}, error)
 // configuration defined in the CreateOpts struct. Once the request is
 // validated and progress has started on the provisioning process, a
 // CreateResult will be returned.
-//
-// Users with an admin role can create loadbalancers on behalf of other tenants by
-// specifying a TenantID attribute different than their own.
 func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToLoadBalancerCreateMap()
 	if err != nil {
@@ -122,10 +131,8 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
-// UpdateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Update operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToLoadBalancerUpdateMap() (map[string]interface{}, error)
 }
@@ -133,21 +140,24 @@ type UpdateOptsBuilder interface {
 // UpdateOpts is the common options struct used in this package's Update
 // operation.
 type UpdateOpts struct {
-	// Optional. Human-readable name for the Loadbalancer. Does not have to be unique.
+	// Human-readable name for the Loadbalancer. Does not have to be unique.
 	Name string `json:"name,omitempty"`
-	// Optional. Human-readable description for the Loadbalancer.
+
+	// Human-readable description for the Loadbalancer.
 	Description string `json:"description,omitempty"`
-	// Optional. The administrative state of the Loadbalancer. A valid value is true (UP)
+
+	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 }
 
-// ToLoadBalancerUpdateMap casts a UpdateOpts struct to a map.
+// ToLoadBalancerUpdateMap builds a request body from UpdateOpts.
 func (opts UpdateOpts) ToLoadBalancerUpdateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "loadbalancer")
 }
 
-// Update is an operation which modifies the attributes of the specified LoadBalancer.
+// Update is an operation which modifies the attributes of the specified
+// LoadBalancer.
 func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
 	b, err := opts.ToLoadBalancerUpdateMap()
 	if err != nil {
@@ -160,12 +170,28 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateR
 	return
 }
 
-// Delete will permanently delete a particular LoadBalancer based on its unique ID.
+// Delete will permanently delete a particular LoadBalancer based on its
+// unique ID.
 func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = c.Delete(resourceURL(c, id), nil)
 	return
 }
 
+// CascadingDelete is like `Delete`, but will also delete any of the load balancer's
+// children (listener, monitor, etc).
+// NOTE: This function will only work with Octavia load balancers; Neutron does not
+// support this.
+func CascadingDelete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	if c.Type != "load-balancer" {
+		r.Err = fmt.Errorf("error prior to running cascade delete: only Octavia LBs supported")
+		return
+	}
+	u := fmt.Sprintf("%s?cascade=true", resourceURL(c, id))
+	_, r.Err = c.Delete(u, nil)
+	return
+}
+
+// GetStatuses will return the status of a particular LoadBalancer.
 func GetStatuses(c *gophercloud.ServiceClient, id string) (r GetStatusesResult) {
 	_, r.Err = c.Get(statusRootURL(c, id), &r.Body, nil)
 	return

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/results.go
@@ -6,50 +6,67 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// LoadBalancer is the primary load balancing configuration object that specifies
-// the virtual IP address on which client traffic is received, as well
+// LoadBalancer is the primary load balancing configuration object that
+// specifies the virtual IP address on which client traffic is received, as well
 // as other details such as the load balancing method to be use, protocol, etc.
 type LoadBalancer struct {
 	// Human-readable description for the Loadbalancer.
 	Description string `json:"description"`
-	// The administrative state of the Loadbalancer. A valid value is true (UP) or false (DOWN).
+
+	// The administrative state of the Loadbalancer.
+	// A valid value is true (UP) or false (DOWN).
 	AdminStateUp bool `json:"admin_state_up"`
-	// Owner of the LoadBalancer. Only an admin user can specify a tenant ID other than its own.
+
+	// Owner of the LoadBalancer.
 	TenantID string `json:"tenant_id"`
-	// The provisioning status of the LoadBalancer. This value is ACTIVE, PENDING_CREATE or ERROR.
+
+	// The provisioning status of the LoadBalancer.
+	// This value is ACTIVE, PENDING_CREATE or ERROR.
 	ProvisioningStatus string `json:"provisioning_status"`
+
 	// The IP address of the Loadbalancer.
 	VipAddress string `json:"vip_address"`
+
 	// The UUID of the port associated with the IP address.
 	VipPortID string `json:"vip_port_id"`
-	// The UUID of the subnet on which to allocate the virtual IP for the Loadbalancer address.
+
+	// The UUID of the subnet on which to allocate the virtual IP for the
+	// Loadbalancer address.
 	VipSubnetID string `json:"vip_subnet_id"`
+
 	// The unique ID for the LoadBalancer.
 	ID string `json:"id"`
+
 	// The operating status of the LoadBalancer. This value is ONLINE or OFFLINE.
 	OperatingStatus string `json:"operating_status"`
+
 	// Human-readable name for the LoadBalancer. Does not have to be unique.
 	Name string `json:"name"`
+
 	// The UUID of a flavor if set.
 	Flavor string `json:"flavor"`
+
 	// The name of the provider.
-	Provider  string               `json:"provider"`
+	Provider string `json:"provider"`
+
+	// Listeners are the listeners related to this Loadbalancer.
 	Listeners []listeners.Listener `json:"listeners"`
 }
 
+// StatusTree represents the status of a loadbalancer.
 type StatusTree struct {
 	Loadbalancer *LoadBalancer `json:"loadbalancer"`
 }
 
 // LoadBalancerPage is the page returned by a pager when traversing over a
-// collection of routers.
+// collection of load balancers.
 type LoadBalancerPage struct {
 	pagination.LinkedPageBase
 }
 
-// NextPageURL is invoked when a paginated collection of routers has reached
-// the end of a page and the pager seeks to traverse over a new one. In order
-// to do this, it needs to construct the next page's URL.
+// NextPageURL is invoked when a paginated collection of load balancers has
+// reached the end of a page and the pager seeks to traverse over a new one.
+// In order to do this, it needs to construct the next page's URL.
 func (r LoadBalancerPage) NextPageURL() (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"loadbalancers_links"`
@@ -62,14 +79,14 @@ func (r LoadBalancerPage) NextPageURL() (string, error) {
 }
 
 // IsEmpty checks whether a LoadBalancerPage struct is empty.
-func (p LoadBalancerPage) IsEmpty() (bool, error) {
-	is, err := ExtractLoadBalancers(p)
+func (r LoadBalancerPage) IsEmpty() (bool, error) {
+	is, err := ExtractLoadBalancers(r)
 	return len(is) == 0, err
 }
 
-// ExtractLoadBalancers accepts a Page struct, specifically a LoadbalancerPage struct,
-// and extracts the elements into a slice of LoadBalancer structs. In other words,
-// a generic collection is mapped into a relevant slice.
+// ExtractLoadBalancers accepts a Page struct, specifically a LoadbalancerPage
+// struct, and extracts the elements into a slice of LoadBalancer structs. In
+// other words, a generic collection is mapped into a relevant slice.
 func ExtractLoadBalancers(r pagination.Page) ([]LoadBalancer, error) {
 	var s struct {
 		LoadBalancers []LoadBalancer `json:"loadbalancers"`
@@ -82,7 +99,7 @@ type commonResult struct {
 	gophercloud.Result
 }
 
-// Extract is a function that accepts a result and extracts a router.
+// Extract is a function that accepts a result and extracts a loadbalancer.
 func (r commonResult) Extract() (*LoadBalancer, error) {
 	var s struct {
 		LoadBalancer *LoadBalancer `json:"loadbalancer"`
@@ -91,11 +108,14 @@ func (r commonResult) Extract() (*LoadBalancer, error) {
 	return s.LoadBalancer, err
 }
 
+// GetStatusesResult represents the result of a GetStatuses operation.
+// Call its Extract method to interpret it as a StatusTree.
 type GetStatusesResult struct {
 	gophercloud.Result
 }
 
-// Extract is a function that accepts a result and extracts a Loadbalancer.
+// Extract is a function that accepts a result and extracts the status of
+// a Loadbalancer.
 func (r GetStatusesResult) Extract() (*StatusTree, error) {
 	var s struct {
 		Statuses *StatusTree `json:"statuses"`
@@ -104,22 +124,26 @@ func (r GetStatusesResult) Extract() (*StatusTree, error) {
 	return s.Statuses, err
 }
 
-// CreateResult represents the result of a create operation.
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a LoadBalancer.
 type CreateResult struct {
 	commonResult
 }
 
-// GetResult represents the result of a get operation.
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a LoadBalancer.
 type GetResult struct {
 	commonResult
 }
 
-// UpdateResult represents the result of an update operation.
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a LoadBalancer.
 type UpdateResult struct {
 	commonResult
 }
 
-// DeleteResult represents the result of a delete operation.
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/monitors/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/monitors/doc.go
@@ -1,0 +1,69 @@
+/*
+Package monitors provides information and interaction with Monitors
+of the LBaaS v2 extension for the OpenStack Networking service.
+
+Example to List Monitors
+
+	listOpts := monitors.ListOpts{
+		PoolID: "c79a4468-d788-410c-bf79-9a8ef6354852",
+	}
+
+	allPages, err := monitors.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allMonitors, err := monitors.ExtractMonitors(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, monitor := range allMonitors {
+		fmt.Printf("%+v\n", monitor)
+	}
+
+Example to Create a Monitor
+
+	createOpts := monitors.CreateOpts{
+		Type:          "HTTP",
+		Name:          "db",
+		PoolID:        "84f1b61f-58c4-45bf-a8a9-2dafb9e5214d",
+		Delay:         20,
+		Timeout:       10,
+		MaxRetries:    5,
+		URLPath:       "/check",
+		ExpectedCodes: "200-299",
+	}
+
+	monitor, err := monitors.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Monitor
+
+	monitorID := "d67d56a6-4a86-4688-a282-f46444705c64"
+
+	updateOpts := monitors.UpdateOpts{
+		Name:          "NewHealthmonitorName",
+		Delay:         3,
+		Timeout:       20,
+		MaxRetries:    10,
+		URLPath:       "/another_check",
+		ExpectedCodes: "301",
+	}
+
+	monitor, err := monitors.Update(networkClient, monitorID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Monitor
+
+	monitorID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	err := monitors.Delete(networkClient, monitorID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package monitors

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/monitors/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/monitors/requests.go
@@ -22,6 +22,7 @@ type ListOpts struct {
 	ID            string `q:"id"`
 	Name          string `q:"name"`
 	TenantID      string `q:"tenant_id"`
+	ProjectID     string `q:"project_id"`
 	PoolID        string `q:"pool_id"`
 	Type          string `q:"type"`
 	Delay         int    `q:"delay"`
@@ -79,10 +80,8 @@ var (
 	errDelayMustGETimeout = fmt.Errorf("Delay must be greater than or equal to timeout")
 )
 
-// CreateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Create operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// List request.
 type CreateOptsBuilder interface {
 	ToMonitorCreateMap() (map[string]interface{}, error)
 }
@@ -90,37 +89,54 @@ type CreateOptsBuilder interface {
 // CreateOpts is the common options struct used in this package's Create
 // operation.
 type CreateOpts struct {
-	// Required. The Pool to Monitor.
+	// The Pool to Monitor.
 	PoolID string `json:"pool_id" required:"true"`
-	// Required. The type of probe, which is PING, TCP, HTTP, or HTTPS, that is
+
+	// The type of probe, which is PING, TCP, HTTP, or HTTPS, that is
 	// sent by the load balancer to verify the member state.
 	Type string `json:"type" required:"true"`
-	// Required. The time, in seconds, between sending probes to members.
+
+	// The time, in seconds, between sending probes to members.
 	Delay int `json:"delay" required:"true"`
-	// Required. Maximum number of seconds for a Monitor to wait for a ping reply
+
+	// Maximum number of seconds for a Monitor to wait for a ping reply
 	// before it times out. The value must be less than the delay value.
 	Timeout int `json:"timeout" required:"true"`
-	// Required. Number of permissible ping failures before changing the member's
+
+	// Number of permissible ping failures before changing the member's
 	// status to INACTIVE. Must be a number between 1 and 10.
 	MaxRetries int `json:"max_retries" required:"true"`
-	// Required for HTTP(S) types. URI path that will be accessed if Monitor type
-	// is HTTP or HTTPS.
+
+	// URI path that will be accessed if Monitor type is HTTP or HTTPS.
+	// Required for HTTP(S) types.
 	URLPath string `json:"url_path,omitempty"`
-	// Required for HTTP(S) types. The HTTP method used for requests by the
-	// Monitor. If this attribute is not specified, it defaults to "GET".
+
+	// The HTTP method used for requests by the Monitor. If this attribute
+	// is not specified, it defaults to "GET". Required for HTTP(S) types.
 	HTTPMethod string `json:"http_method,omitempty"`
-	// Required for HTTP(S) types. Expected HTTP codes for a passing HTTP(S)
-	// Monitor. You can either specify a single status like "200", or a range
-	// like "200-202".
+
+	// Expected HTTP codes for a passing HTTP(S) Monitor. You can either specify
+	// a single status like "200", or a range like "200-202". Required for HTTP(S)
+	// types.
 	ExpectedCodes string `json:"expected_codes,omitempty"`
-	// Indicates the owner of the Loadbalancer. Required for admins.
+
+	// TenantID is the UUID of the project who owns the Monitor.
+	// Only administrative users can specify a project UUID other than their own.
 	TenantID string `json:"tenant_id,omitempty"`
-	// Optional. The Name of the Monitor.
-	Name         string `json:"name,omitempty"`
-	AdminStateUp *bool  `json:"admin_state_up,omitempty"`
+
+	// ProjectID is the UUID of the project who owns the Monitor.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// The Name of the Monitor.
+	Name string `json:"name,omitempty"`
+
+	// The administrative state of the Monitor. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 }
 
-// ToMonitorCreateMap casts a CreateOpts struct to a map.
+// ToMonitorCreateMap builds a request body from CreateOpts.
 func (opts CreateOpts) ToMonitorCreateMap() (map[string]interface{}, error) {
 	b, err := gophercloud.BuildRequestBody(opts, "healthmonitor")
 	if err != nil {
@@ -173,10 +189,8 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
-// UpdateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Update operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToMonitorUpdateMap() (map[string]interface{}, error)
 }
@@ -184,35 +198,45 @@ type UpdateOptsBuilder interface {
 // UpdateOpts is the common options struct used in this package's Update
 // operation.
 type UpdateOpts struct {
-	// Required. The time, in seconds, between sending probes to members.
+	// The time, in seconds, between sending probes to members.
 	Delay int `json:"delay,omitempty"`
-	// Required. Maximum number of seconds for a Monitor to wait for a ping reply
+
+	// Maximum number of seconds for a Monitor to wait for a ping reply
 	// before it times out. The value must be less than the delay value.
 	Timeout int `json:"timeout,omitempty"`
-	// Required. Number of permissible ping failures before changing the member's
+
+	// Number of permissible ping failures before changing the member's
 	// status to INACTIVE. Must be a number between 1 and 10.
 	MaxRetries int `json:"max_retries,omitempty"`
-	// Required for HTTP(S) types. URI path that will be accessed if Monitor type
-	// is HTTP or HTTPS.
+
+	// URI path that will be accessed if Monitor type is HTTP or HTTPS.
+	// Required for HTTP(S) types.
 	URLPath string `json:"url_path,omitempty"`
-	// Required for HTTP(S) types. The HTTP method used for requests by the
-	// Monitor. If this attribute is not specified, it defaults to "GET".
+
+	// The HTTP method used for requests by the Monitor. If this attribute
+	// is not specified, it defaults to "GET". Required for HTTP(S) types.
 	HTTPMethod string `json:"http_method,omitempty"`
-	// Required for HTTP(S) types. Expected HTTP codes for a passing HTTP(S)
-	// Monitor. You can either specify a single status like "200", or a range
-	// like "200-202".
+
+	// Expected HTTP codes for a passing HTTP(S) Monitor. You can either specify
+	// a single status like "200", or a range like "200-202". Required for HTTP(S)
+	// types.
 	ExpectedCodes string `json:"expected_codes,omitempty"`
-	// Optional. The Name of the Monitor.
-	Name         string `json:"name,omitempty"`
-	AdminStateUp *bool  `json:"admin_state_up,omitempty"`
+
+	// The Name of the Monitor.
+	Name string `json:"name,omitempty"`
+
+	// The administrative state of the Monitor. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 }
 
-// ToMonitorUpdateMap casts a UpdateOpts struct to a map.
+// ToMonitorUpdateMap builds a request body from UpdateOpts.
 func (opts UpdateOpts) ToMonitorUpdateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "healthmonitor")
 }
 
-// Update is an operation which modifies the attributes of the specified Monitor.
+// Update is an operation which modifies the attributes of the specified
+// Monitor.
 func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToMonitorUpdateMap()
 	if err != nil {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/monitors/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/monitors/results.go
@@ -31,8 +31,7 @@ type Monitor struct {
 	// The Name of the Monitor.
 	Name string `json:"name"`
 
-	// Only an administrative user can specify a tenant ID
-	// other than its own.
+	// TenantID is the owner of the Monitor.
 	TenantID string `json:"tenant_id"`
 
 	// The type of probe sent by the load balancer to verify the member state,
@@ -43,7 +42,8 @@ type Monitor struct {
 	Delay int `json:"delay"`
 
 	// The maximum number of seconds for a monitor to wait for a connection to be
-	// established before it times out. This value must be less than the delay value.
+	// established before it times out. This value must be less than the delay
+	// value.
 	Timeout int `json:"timeout"`
 
 	// Number of allowed connection failures before changing the status of the
@@ -60,7 +60,8 @@ type Monitor struct {
 	// Expected HTTP codes for a passing HTTP(S) monitor.
 	ExpectedCodes string `json:"expected_codes"`
 
-	// The administrative state of the health monitor, which is up (true) or down (false).
+	// The administrative state of the health monitor, which is up (true) or
+	// down (false).
 	AdminStateUp bool `json:"admin_state_up"`
 
 	// The status of the health monitor. Indicates whether the health monitor is
@@ -123,22 +124,26 @@ func (r commonResult) Extract() (*Monitor, error) {
 	return s.Monitor, err
 }
 
-// CreateResult represents the result of a create operation.
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Monitor.
 type CreateResult struct {
 	commonResult
 }
 
-// GetResult represents the result of a get operation.
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Monitor.
 type GetResult struct {
 	commonResult
 }
 
-// UpdateResult represents the result of an update operation.
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Monitor.
 type UpdateResult struct {
 	commonResult
 }
 
-// DeleteResult represents the result of a delete operation.
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the result succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools/doc.go
@@ -1,0 +1,124 @@
+/*
+Package pools provides information and interaction with Pools and
+Members of the LBaaS v2 extension for the OpenStack Networking service.
+
+Example to List Pools
+
+	listOpts := pools.ListOpts{
+		LoadbalancerID: "c79a4468-d788-410c-bf79-9a8ef6354852",
+	}
+
+	allPages, err := pools.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allPools, err := pools.ExtractMonitors(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, pools := range allPools {
+		fmt.Printf("%+v\n", pool)
+	}
+
+Example to Create a Pool
+
+	createOpts := pools.CreateOpts{
+		LBMethod:       pools.LBMethodRoundRobin,
+		Protocol:       "HTTP",
+		Name:           "Example pool",
+		LoadbalancerID: "79e05663-7f03-45d2-a092-8b94062f22ab",
+	}
+
+	pool, err := pools.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Pool
+
+	poolID := "d67d56a6-4a86-4688-a282-f46444705c64"
+
+	updateOpts := pools.UpdateOpts{
+		Name: "new-name",
+	}
+
+	pool, err := pools.Update(networkClient, poolID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Pool
+
+	poolID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	err := pools.Delete(networkClient, poolID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to List Pool Members
+
+	poolID := "d67d56a6-4a86-4688-a282-f46444705c64"
+
+	listOpts := pools.ListMemberOpts{
+		ProtocolPort: 80,
+	}
+
+	allPages, err := pools.ListMembers(networkClient, poolID, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allMembers, err := pools.ExtractMembers(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, member := allMembers {
+		fmt.Printf("%+v\n", member)
+	}
+
+Example to Create a Member
+
+	poolID := "d67d56a6-4a86-4688-a282-f46444705c64"
+
+	createOpts := pools.CreateMemberOpts{
+		Name:         "db",
+		SubnetID:     "1981f108-3c48-48d2-b908-30f7d28532c9",
+		Address:      "10.0.2.11",
+		ProtocolPort: 80,
+		Weight:       10,
+	}
+
+	member, err := pools.CreateMember(networkClient, poolID, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Member
+
+	poolID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	memberID := "64dba99f-8af8-4200-8882-e32a0660f23e"
+
+	updateOpts := pools.UpdateMemberOpts{
+		Name:   "new-name",
+		Weight: 4,
+	}
+
+	member, err := pools.UpdateMember(networkClient, poolID, memberID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Member
+
+	poolID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	memberID := "64dba99f-8af8-4200-8882-e32a0660f23e"
+
+	err := pools.DeleteMember(networkClient, poolID, memberID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package pools

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools/requests.go
@@ -20,6 +20,7 @@ type ListOpts struct {
 	LBMethod       string `q:"lb_algorithm"`
 	Protocol       string `q:"protocol"`
 	TenantID       string `q:"tenant_id"`
+	ProjectID      string `q:"project_id"`
 	AdminStateUp   *bool  `q:"admin_state_up"`
 	Name           string `q:"name"`
 	ID             string `q:"id"`
@@ -71,10 +72,8 @@ const (
 	ProtocolHTTPS Protocol = "HTTPS"
 )
 
-// CreateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Create operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToPoolCreateMap() (map[string]interface{}, error)
 }
@@ -86,30 +85,43 @@ type CreateOpts struct {
 	// current specification supports LBMethodRoundRobin, LBMethodLeastConnections
 	// and LBMethodSourceIp as valid values for this attribute.
 	LBMethod LBMethod `json:"lb_algorithm" required:"true"`
+
 	// The protocol used by the pool members, you can use either
 	// ProtocolTCP, ProtocolHTTP, or ProtocolHTTPS.
 	Protocol Protocol `json:"protocol" required:"true"`
+
 	// The Loadbalancer on which the members of the pool will be associated with.
-	// Note:  one of LoadbalancerID or ListenerID must be provided.
+	// Note: one of LoadbalancerID or ListenerID must be provided.
 	LoadbalancerID string `json:"loadbalancer_id,omitempty" xor:"ListenerID"`
+
 	// The Listener on which the members of the pool will be associated with.
-	// Note:  one of LoadbalancerID or ListenerID must be provided.
+	// Note: one of LoadbalancerID or ListenerID must be provided.
 	ListenerID string `json:"listener_id,omitempty" xor:"LoadbalancerID"`
-	// Only required if the caller has an admin role and wants to create a pool
-	// for another tenant.
+
+	// TenantID is the UUID of the project who owns the Pool.
+	// Only administrative users can specify a project UUID other than their own.
 	TenantID string `json:"tenant_id,omitempty"`
+
+	// ProjectID is the UUID of the project who owns the Pool.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
 	// Name of the pool.
 	Name string `json:"name,omitempty"`
+
 	// Human-readable description for the pool.
 	Description string `json:"description,omitempty"`
+
+	// Persistence is the session persistence of the pool.
 	// Omit this field to prevent session persistence.
 	Persistence *SessionPersistence `json:"session_persistence,omitempty"`
+
 	// The administrative state of the Pool. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 }
 
-// ToPoolCreateMap casts a CreateOpts struct to a map.
+// ToPoolCreateMap builds a request body from CreateOpts.
 func (opts CreateOpts) ToPoolCreateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "pool")
 }
@@ -132,10 +144,8 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
-// UpdateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Update operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToPoolUpdateMap() (map[string]interface{}, error)
 }
@@ -145,18 +155,21 @@ type UpdateOptsBuilder interface {
 type UpdateOpts struct {
 	// Name of the pool.
 	Name string `json:"name,omitempty"`
+
 	// Human-readable description for the pool.
 	Description string `json:"description,omitempty"`
+
 	// The algorithm used to distribute load between the members of the pool. The
 	// current specification supports LBMethodRoundRobin, LBMethodLeastConnections
 	// and LBMethodSourceIp as valid values for this attribute.
 	LBMethod LBMethod `json:"lb_algorithm,omitempty"`
+
 	// The administrative state of the Pool. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 }
 
-// ToPoolUpdateMap casts a UpdateOpts struct to a map.
+// ToPoolUpdateMap builds a request body from UpdateOpts.
 func (opts UpdateOpts) ToPoolUpdateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "pool")
 }
@@ -186,11 +199,11 @@ type ListMembersOptsBuilder interface {
 	ToMembersListQuery() (string, error)
 }
 
-// ListMembersOpts allows the filtering and sorting of paginated collections through
-// the API. Filtering is achieved by passing in struct field values that map to
-// the Member attributes you want to see returned. SortKey allows you to
-// sort by a particular Member attribute. SortDir sets the direction, and is
-// either `asc' or `desc'. Marker and Limit are used for pagination.
+// ListMembersOpts allows the filtering and sorting of paginated collections
+// through the API. Filtering is achieved by passing in struct field values
+// that map to the Member attributes you want to see returned. SortKey allows
+// you to sort by a particular Member attribute. SortDir sets the direction,
+// and is either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListMembersOpts struct {
 	Name         string `q:"name"`
 	Weight       int    `q:"weight"`
@@ -212,8 +225,8 @@ func (opts ListMembersOpts) ToMembersListQuery() (string, error) {
 }
 
 // ListMembers returns a Pager which allows you to iterate over a collection of
-// members. It accepts a ListMembersOptsBuilder, which allows you to filter and sort
-// the returned collection for greater efficiency.
+// members. It accepts a ListMembersOptsBuilder, which allows you to filter and
+// sort the returned collection for greater efficiency.
 //
 // Default policy settings return only those members that are owned by the
 // tenant who submits the request, unless an admin user submits the request.
@@ -231,10 +244,8 @@ func ListMembers(c *gophercloud.ServiceClient, poolID string, opts ListMembersOp
 	})
 }
 
-// CreateMemberOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the CreateMember operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// CreateMemberOptsBuilder allows extensions to add additional parameters to the
+// CreateMember request.
 type CreateMemberOptsBuilder interface {
 	ToMemberCreateMap() (map[string]interface{}, error)
 }
@@ -242,29 +253,39 @@ type CreateMemberOptsBuilder interface {
 // CreateMemberOpts is the common options struct used in this package's CreateMember
 // operation.
 type CreateMemberOpts struct {
-	// Required. The IP address of the member to receive traffic from the load balancer.
+	// The IP address of the member to receive traffic from the load balancer.
 	Address string `json:"address" required:"true"`
-	// Required. The port on which to listen for client traffic.
+
+	// The port on which to listen for client traffic.
 	ProtocolPort int `json:"protocol_port" required:"true"`
-	// Optional. Name of the Member.
+
+	// Name of the Member.
 	Name string `json:"name,omitempty"`
-	// Only required if the caller has an admin role and wants to create a Member
-	// for another tenant.
+
+	// TenantID is the UUID of the project who owns the Member.
+	// Only administrative users can specify a project UUID other than their own.
 	TenantID string `json:"tenant_id,omitempty"`
-	// Optional. A positive integer value that indicates the relative portion of
-	// traffic that this member should receive from the pool. For example, a
-	// member with a weight of 10 receives five times as much traffic as a member
-	// with a weight of 2.
+
+	// ProjectID is the UUID of the project who owns the Member.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// A positive integer value that indicates the relative portion of traffic
+	// that  this member should receive from the pool. For example, a member with
+	// a weight  of 10 receives five times as much traffic as a member with a
+	// weight of 2.
 	Weight int `json:"weight,omitempty"`
-	// Optional.  If you omit this parameter, LBaaS uses the vip_subnet_id
-	// parameter value for the subnet UUID.
+
+	// If you omit this parameter, LBaaS uses the vip_subnet_id parameter value
+	// for the subnet UUID.
 	SubnetID string `json:"subnet_id,omitempty"`
-	// Optional. The administrative state of the Pool. A valid value is true (UP)
+
+	// The administrative state of the Pool. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 }
 
-// ToMemberCreateMap casts a CreateOpts struct to a map.
+// ToMemberCreateMap builds a request body from CreateMemberOpts.
 func (opts CreateMemberOpts) ToMemberCreateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "member")
 }
@@ -286,10 +307,8 @@ func GetMember(c *gophercloud.ServiceClient, poolID string, memberID string) (r 
 	return
 }
 
-// MemberUpdateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Update operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
+// UpdateMemberOptsBuilder allows extensions to add additional parameters to the
+// List request.
 type UpdateMemberOptsBuilder interface {
 	ToMemberUpdateMap() (map[string]interface{}, error)
 }
@@ -297,19 +316,21 @@ type UpdateMemberOptsBuilder interface {
 // UpdateMemberOpts is the common options struct used in this package's Update
 // operation.
 type UpdateMemberOpts struct {
-	// Optional. Name of the Member.
+	// Name of the Member.
 	Name string `json:"name,omitempty"`
-	// Optional. A positive integer value that indicates the relative portion of
-	// traffic that this member should receive from the pool. For example, a
-	// member with a weight of 10 receives five times as much traffic as a member
-	// with a weight of 2.
+
+	// A positive integer value that indicates the relative portion of traffic
+	// that this member should receive from the pool. For example, a member with
+	// a weight of 10 receives five times as much traffic as a member with a
+	// weight of 2.
 	Weight int `json:"weight,omitempty"`
-	// Optional. The administrative state of the Pool. A valid value is true (UP)
+
+	// The administrative state of the Pool. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 }
 
-// ToMemberUpdateMap casts a UpdateOpts struct to a map.
+// ToMemberUpdateMap builds a request body from UpdateMemberOpts.
 func (opts UpdateMemberOpts) ToMemberUpdateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "member")
 }
@@ -327,7 +348,8 @@ func UpdateMember(c *gophercloud.ServiceClient, poolID string, memberID string, 
 	return
 }
 
-// DisassociateMember will remove and disassociate a Member from a particular Pool.
+// DisassociateMember will remove and disassociate a Member from a particular
+// Pool.
 func DeleteMember(c *gophercloud.ServiceClient, poolID string, memberID string) (r DeleteMemberResult) {
 	_, r.Err = c.Delete(memberResourceURL(c, poolID, memberID), nil)
 	return

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools/results.go
@@ -22,17 +22,19 @@ import (
 //              requests carrying the same cookie value will be handled by the
 //              same Member of the Pool.
 type SessionPersistence struct {
-	// The type of persistence mode
+	// The type of persistence mode.
 	Type string `json:"type"`
 
-	// Name of cookie if persistence mode is set appropriately
+	// Name of cookie if persistence mode is set appropriately.
 	CookieName string `json:"cookie_name,omitempty"`
 }
 
+// LoadBalancerID represents a load balancer.
 type LoadBalancerID struct {
 	ID string `json:"id"`
 }
 
+// ListenerID represents a listener.
 type ListenerID struct {
 	ID string `json:"id"`
 }
@@ -46,36 +48,50 @@ type Pool struct {
 	// so on. This value, which must be supported, is dependent on the provider.
 	// Round-robin must be supported.
 	LBMethod string `json:"lb_algorithm"`
+
 	// The protocol of the Pool, which is TCP, HTTP, or HTTPS.
 	Protocol string `json:"protocol"`
+
 	// Description for the Pool.
 	Description string `json:"description"`
+
 	// A list of listeners objects IDs.
 	Listeners []ListenerID `json:"listeners"` //[]map[string]interface{}
+
 	// A list of member objects IDs.
 	Members []Member `json:"members"`
+
 	// The ID of associated health monitor.
 	MonitorID string `json:"healthmonitor_id"`
+
 	// The network on which the members of the Pool will be located. Only members
 	// that are on this network can be added to the Pool.
 	SubnetID string `json:"subnet_id"`
-	// Owner of the Pool. Only an administrative user can specify a tenant ID
-	// other than its own.
+
+	// Owner of the Pool.
 	TenantID string `json:"tenant_id"`
+
 	// The administrative state of the Pool, which is up (true) or down (false).
 	AdminStateUp bool `json:"admin_state_up"`
+
 	// Pool name. Does not have to be unique.
 	Name string `json:"name"`
+
 	// The unique ID for the Pool.
 	ID string `json:"id"`
+
 	// A list of load balancer objects IDs.
 	Loadbalancers []LoadBalancerID `json:"loadbalancers"`
+
 	// Indicates whether connections in the same session will be processed by the
 	// same Pool member or not.
 	Persistence SessionPersistence `json:"session_persistence"`
-	// The provider
-	Provider string           `json:"provider"`
-	Monitor  monitors.Monitor `json:"healthmonitor"`
+
+	// The load balancer provider.
+	Provider string `json:"provider"`
+
+	// The Monitor associated with this Pool.
+	Monitor monitors.Monitor `json:"healthmonitor"`
 }
 
 // PoolPage is the page returned by a pager when traversing over a
@@ -105,7 +121,7 @@ func (r PoolPage) IsEmpty() (bool, error) {
 }
 
 // ExtractPools accepts a Page struct, specifically a PoolPage struct,
-// and extracts the elements into a slice of Router structs. In other words,
+// and extracts the elements into a slice of Pool structs. In other words,
 // a generic collection is mapped into a relevant slice.
 func ExtractPools(r pagination.Page) ([]Pool, error) {
 	var s struct {
@@ -119,7 +135,7 @@ type commonResult struct {
 	gophercloud.Result
 }
 
-// Extract is a function that accepts a result and extracts a router.
+// Extract is a function that accepts a result and extracts a pool.
 func (r commonResult) Extract() (*Pool, error) {
 	var s struct {
 		Pool *Pool `json:"pool"`
@@ -128,22 +144,26 @@ func (r commonResult) Extract() (*Pool, error) {
 	return s.Pool, err
 }
 
-// CreateResult represents the result of a Create operation.
+// CreateResult represents the result of a Create operation. Call its Extract
+// method to interpret the result as a Pool.
 type CreateResult struct {
 	commonResult
 }
 
-// GetResult represents the result of a Get operation.
+// GetResult represents the result of a Get operation. Call its Extract
+// method to interpret the result as a Pool.
 type GetResult struct {
 	commonResult
 }
 
-// UpdateResult represents the result of an Update operation.
+// UpdateResult represents the result of an Update operation. Call its Extract
+// method to interpret the result as a Pool.
 type UpdateResult struct {
 	commonResult
 }
 
-// DeleteResult represents the result of a Delete operation.
+// DeleteResult represents the result of a Delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
@@ -152,21 +172,28 @@ type DeleteResult struct {
 type Member struct {
 	// Name of the Member.
 	Name string `json:"name"`
+
 	// Weight of Member.
 	Weight int `json:"weight"`
+
 	// The administrative state of the member, which is up (true) or down (false).
 	AdminStateUp bool `json:"admin_state_up"`
-	// Owner of the Member. Only an administrative user can specify a tenant ID
-	// other than its own.
+
+	// Owner of the Member.
 	TenantID string `json:"tenant_id"`
-	// parameter value for the subnet UUID.
+
+	// Parameter value for the subnet UUID.
 	SubnetID string `json:"subnet_id"`
+
 	// The Pool to which the Member belongs.
 	PoolID string `json:"pool_id"`
+
 	// The IP address of the Member.
 	Address string `json:"address"`
+
 	// The port on which the application is hosted.
 	ProtocolPort int `json:"protocol_port"`
+
 	// The unique ID for the Member.
 	ID string `json:"id"`
 }
@@ -197,8 +224,8 @@ func (r MemberPage) IsEmpty() (bool, error) {
 	return len(is) == 0, err
 }
 
-// ExtractMembers accepts a Page struct, specifically a RouterPage struct,
-// and extracts the elements into a slice of Router structs. In other words,
+// ExtractMembers accepts a Page struct, specifically a MemberPage struct,
+// and extracts the elements into a slice of Members structs. In other words,
 // a generic collection is mapped into a relevant slice.
 func ExtractMembers(r pagination.Page) ([]Member, error) {
 	var s struct {
@@ -212,7 +239,7 @@ type commonMemberResult struct {
 	gophercloud.Result
 }
 
-// ExtractMember is a function that accepts a result and extracts a router.
+// ExtractMember is a function that accepts a result and extracts a member.
 func (r commonMemberResult) Extract() (*Member, error) {
 	var s struct {
 		Member *Member `json:"member"`
@@ -222,21 +249,25 @@ func (r commonMemberResult) Extract() (*Member, error) {
 }
 
 // CreateMemberResult represents the result of a CreateMember operation.
+// Call its Extract method to interpret it as a Member.
 type CreateMemberResult struct {
 	commonMemberResult
 }
 
 // GetMemberResult represents the result of a GetMember operation.
+// Call its Extract method to interpret it as a Member.
 type GetMemberResult struct {
 	commonMemberResult
 }
 
 // UpdateMemberResult represents the result of an UpdateMember operation.
+// Call its Extract method to interpret it as a Member.
 type UpdateMemberResult struct {
 	commonMemberResult
 }
 
 // DeleteMemberResult represents the result of a DeleteMember operation.
+// Call its ExtractErr method to determine if the request succeeded or failed.
 type DeleteMemberResult struct {
 	gophercloud.ErrResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/provider/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/provider/doc.go
@@ -1,21 +1,73 @@
-// Package provider gives access to the provider Neutron plugin, allowing
-// network extended attributes. The provider extended attributes for networks
-// enable administrative users to specify how network objects map to the
-// underlying networking infrastructure. These extended attributes also appear
-// when administrative users query networks.
-//
-// For more information about extended attributes, see the NetworkExtAttrs
-// struct. The actual semantics of these attributes depend on the technology
-// back end of the particular plug-in. See the plug-in documentation and the
-// OpenStack Cloud Administrator Guide to understand which values should be
-// specific for each of these attributes when OpenStack Networking is deployed
-// with a particular plug-in. The examples shown in this chapter refer to the
-// Open vSwitch plug-in.
-//
-// The default policy settings enable only users with administrative rights to
-// specify these parameters in requests and to see their values in responses. By
-// default, the provider network extension attributes are completely hidden from
-// regular tenants. As a rule of thumb, if these attributes are not visible in a
-// GET /networks/<network-id> operation, this implies the user submitting the
-// request is not authorized to view or manipulate provider network attributes.
+/*
+Package provider gives access to the provider Neutron plugin, allowing
+network extended attributes. The provider extended attributes for networks
+enable administrative users to specify how network objects map to the
+underlying networking infrastructure. These extended attributes also appear
+when administrative users query networks.
+
+For more information about extended attributes, see the NetworkExtAttrs
+struct. The actual semantics of these attributes depend on the technology
+back end of the particular plug-in. See the plug-in documentation and the
+OpenStack Cloud Administrator Guide to understand which values should be
+specific for each of these attributes when OpenStack Networking is deployed
+with a particular plug-in. The examples shown in this chapter refer to the
+Open vSwitch plug-in.
+
+The default policy settings enable only users with administrative rights to
+specify these parameters in requests and to see their values in responses. By
+default, the provider network extension attributes are completely hidden from
+regular tenants. As a rule of thumb, if these attributes are not visible in a
+GET /networks/<network-id> operation, this implies the user submitting the
+request is not authorized to view or manipulate provider network attributes.
+
+Example to List Networks with Provider Information
+
+	type NetworkWithProvider {
+		networks.Network
+		provider.NetworkProviderExt
+	}
+
+	var allNetworks []NetworkWithProvider
+
+	allPages, err := networks.List(networkClient, nil).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	err = networks.ExtractNetworksInto(allPages, &allNetworks)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, network := range allNetworks {
+		fmt.Printf("%+v\n", network)
+	}
+
+Example to Create a Provider Network
+
+	segments := []provider.Segment{
+		provider.Segment{
+			NetworkType:     "vxlan",
+			PhysicalNetwork: "br-ex",
+			SegmentationID:  615,
+		},
+	}
+
+	iTrue := true
+	networkCreateOpts := networks.CreateOpts{
+		Name:         "provider-network",
+		AdminStateUp: &iTrue,
+		Shared:       &iTrue,
+	}
+
+	createOpts : provider.CreateOptsExt{
+		CreateOptsBuilder: networkCreateOpts,
+		Segments:          segments,
+	}
+
+	network, err := networks.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
 package provider

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/provider/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/provider/results.go
@@ -3,54 +3,31 @@ package provider
 import (
 	"encoding/json"
 	"strconv"
-
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
-	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// NetworkExtAttrs represents an extended form of a Network with additional fields.
-type NetworkExtAttrs struct {
-	// UUID for the network
-	ID string `json:"id"`
-
-	// Human-readable name for the network. Might not be unique.
-	Name string `json:"name"`
-
-	// The administrative state of network. If false (down), the network does not forward packets.
-	AdminStateUp bool `json:"admin_state_up"`
-
-	// Indicates whether network is currently operational. Possible values include
-	// `ACTIVE', `DOWN', `BUILD', or `ERROR'. Plug-ins might define additional values.
-	Status string `json:"status"`
-
-	// Subnets associated with this network.
-	Subnets []string `json:"subnets"`
-
-	// Owner of network. Only admin users can specify a tenant_id other than its own.
-	TenantID string `json:"tenant_id"`
-
-	// Specifies whether the network resource can be accessed by any tenant or not.
-	Shared bool `json:"shared"`
-
+// NetworkProviderExt represents an extended form of a Network with additional
+// fields.
+type NetworkProviderExt struct {
 	// Specifies the nature of the physical network mapped to this network
 	// resource. Examples are flat, vlan, or gre.
 	NetworkType string `json:"provider:network_type"`
 
 	// Identifies the physical network on top of which this network object is
-	// being implemented. The OpenStack Networking API does not expose any facility
-	// for retrieving the list of available physical networks. As an example, in
-	// the Open vSwitch plug-in this is a symbolic name which is then mapped to
-	// specific bridges on each compute host through the Open vSwitch plug-in
-	// configuration file.
+	// being implemented. The OpenStack Networking API does not expose any
+	// facility for retrieving the list of available physical networks. As an
+	// example, in the Open vSwitch plug-in this is a symbolic name which is
+	// then mapped to specific bridges on each compute host through the Open
+	// vSwitch plug-in configuration file.
 	PhysicalNetwork string `json:"provider:physical_network"`
 
 	// Identifies an isolated segment on the physical network; the nature of the
 	// segment depends on the segmentation model defined by network_type. For
 	// instance, if network_type is vlan, then this is a vlan identifier;
 	// otherwise, if network_type is gre, then this will be a gre key.
-	SegmentationID string `json:"provider:segmentation_id"`
+	SegmentationID string `json:"-"`
 
-	// Segments is an array of Segment which defines multiple physical bindings to logical networks.
+	// Segments is an array of Segment which defines multiple physical bindings
+	// to logical networks.
 	Segments []Segment `json:"segments"`
 }
 
@@ -61,66 +38,25 @@ type Segment struct {
 	SegmentationID  int    `json:"provider:segmentation_id"`
 }
 
-func (n *NetworkExtAttrs) UnmarshalJSON(b []byte) error {
-	type tmp NetworkExtAttrs
-	var networkExtAttrs *struct {
+func (r *NetworkProviderExt) UnmarshalJSON(b []byte) error {
+	type tmp NetworkProviderExt
+	var networkProviderExt struct {
 		tmp
 		SegmentationID interface{} `json:"provider:segmentation_id"`
 	}
 
-	if err := json.Unmarshal(b, &networkExtAttrs); err != nil {
+	if err := json.Unmarshal(b, &networkProviderExt); err != nil {
 		return err
 	}
 
-	*n = NetworkExtAttrs(networkExtAttrs.tmp)
+	*r = NetworkProviderExt(networkProviderExt.tmp)
 
-	switch t := networkExtAttrs.SegmentationID.(type) {
+	switch t := networkProviderExt.SegmentationID.(type) {
 	case float64:
-		n.SegmentationID = strconv.FormatFloat(t, 'f', -1, 64)
+		r.SegmentationID = strconv.FormatFloat(t, 'f', -1, 64)
 	case string:
-		n.SegmentationID = string(t)
+		r.SegmentationID = string(t)
 	}
 
 	return nil
-}
-
-// ExtractGet decorates a GetResult struct returned from a networks.Get()
-// function with extended attributes.
-func ExtractGet(r networks.GetResult) (*NetworkExtAttrs, error) {
-	var s struct {
-		Network *NetworkExtAttrs `json:"network"`
-	}
-	err := r.ExtractInto(&s)
-	return s.Network, err
-}
-
-// ExtractCreate decorates a CreateResult struct returned from a networks.Create()
-// function with extended attributes.
-func ExtractCreate(r networks.CreateResult) (*NetworkExtAttrs, error) {
-	var s struct {
-		Network *NetworkExtAttrs `json:"network"`
-	}
-	err := r.ExtractInto(&s)
-	return s.Network, err
-}
-
-// ExtractUpdate decorates a UpdateResult struct returned from a
-// networks.Update() function with extended attributes.
-func ExtractUpdate(r networks.UpdateResult) (*NetworkExtAttrs, error) {
-	var s struct {
-		Network *NetworkExtAttrs `json:"network"`
-	}
-	err := r.ExtractInto(&s)
-	return s.Network, err
-}
-
-// ExtractList accepts a Page struct, specifically a NetworkPage struct, and
-// extracts the elements into a slice of NetworkExtAttrs structs. In other
-// words, a generic collection is mapped into a relevant slice.
-func ExtractList(r pagination.Page) ([]NetworkExtAttrs, error) {
-	var s struct {
-		Networks []NetworkExtAttrs `json:"networks" json:"networks"`
-	}
-	err := (r.(networks.NetworkPage)).ExtractInto(&s)
-	return s.Networks, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/doc.go
@@ -1,0 +1,58 @@
+/*
+Package groups provides information and interaction with Security Groups
+for the OpenStack Networking service.
+
+Example to List Security Groups
+
+	listOpts := groups.ListOpts{
+		TenantID: "966b3c7d36a24facaf20b7e458bf2192",
+	}
+
+	allPages, err := groups.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allGroups, err := groups.ExtractGroups(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, group := range allGroups {
+		fmt.Printf("%+v\n", group)
+	}
+
+Example to Create a Security Group
+
+	createOpts := groups.CreateOpts{
+		Name:        "group_name",
+		Description: "A Security Group",
+	}
+
+	group, err := groups.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Security Group
+
+	groupID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
+
+	updateOpts := groups.UpdateOpts{
+		Name: "new_name",
+	}
+
+	group, err := groups.Update(networkClient, groupID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Security Group
+
+	groupID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
+	err := groups.Delete(networkClient, groupID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package groups

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/requests.go
@@ -7,17 +7,18 @@ import (
 
 // ListOpts allows the filtering and sorting of paginated collections through
 // the API. Filtering is achieved by passing in struct field values that map to
-// the floating IP attributes you want to see returned. SortKey allows you to
+// the group attributes you want to see returned. SortKey allows you to
 // sort by a particular network attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	ID       string `q:"id"`
-	Name     string `q:"name"`
-	TenantID string `q:"tenant_id"`
-	Limit    int    `q:"limit"`
-	Marker   string `q:"marker"`
-	SortKey  string `q:"sort_key"`
-	SortDir  string `q:"sort_dir"`
+	ID        string `q:"id"`
+	Name      string `q:"name"`
+	TenantID  string `q:"tenant_id"`
+	ProjectID string `q:"project_id"`
+	Limit     int    `q:"limit"`
+	Marker    string `q:"marker"`
+	SortKey   string `q:"sort_key"`
+	SortDir   string `q:"sort_dir"`
 }
 
 // List returns a Pager which allows you to iterate over a collection of
@@ -34,20 +35,30 @@ func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
 	})
 }
 
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToSecGroupCreateMap() (map[string]interface{}, error)
 }
 
 // CreateOpts contains all the values needed to create a new security group.
 type CreateOpts struct {
-	// Required. Human-readable name for the Security Group. Does not have to be unique.
+	// Human-readable name for the Security Group. Does not have to be unique.
 	Name string `json:"name" required:"true"`
-	// Required for admins. Indicates the owner of the Security Group.
+
+	// TenantID is the UUID of the project who owns the Group.
+	// Only administrative users can specify a tenant UUID other than their own.
 	TenantID string `json:"tenant_id,omitempty"`
-	// Optional. Describes the security group.
+
+	// ProjectID is the UUID of the project who owns the Group.
+	// Only administrative users can specify a tenant UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// Describes the security group.
 	Description string `json:"description,omitempty"`
 }
 
+// ToSecGroupCreateMap builds a request body from CreateOpts.
 func (opts CreateOpts) ToSecGroupCreateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "security_group")
 }
@@ -64,18 +75,23 @@ func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResul
 	return
 }
 
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToSecGroupUpdateMap() (map[string]interface{}, error)
 }
 
-// UpdateOpts contains all the values needed to update an existing security group.
+// UpdateOpts contains all the values needed to update an existing security
+// group.
 type UpdateOpts struct {
 	// Human-readable name for the Security Group. Does not have to be unique.
 	Name string `json:"name,omitempty"`
-	// Optional. Describes the security group.
+
+	// Describes the security group.
 	Description string `json:"description,omitempty"`
 }
 
+// ToSecGroupUpdateMap builds a request body from UpdateOpts.
 func (opts UpdateOpts) ToSecGroupUpdateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "security_group")
 }
@@ -100,13 +116,15 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
-// Delete will permanently delete a particular security group based on its unique ID.
+// Delete will permanently delete a particular security group based on its
+// unique ID.
 func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = c.Delete(resourceURL(c, id), nil)
 	return
 }
 
-// IDFromName is a convenience function that returns a security group's ID given its name.
+// IDFromName is a convenience function that returns a security group's ID,
+// given its name.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/results.go
@@ -11,8 +11,8 @@ type SecGroup struct {
 	// The UUID for the security group.
 	ID string
 
-	// Human-readable name for the security group. Might not be unique. Cannot be
-	// named "default" as that is automatically created for a tenant.
+	// Human-readable name for the security group. Might not be unique.
+	// Cannot be named "default" as that is automatically created for a tenant.
 	Name string
 
 	// The security group description.
@@ -22,9 +22,11 @@ type SecGroup struct {
 	// traffic entering and leaving the group.
 	Rules []rules.SecGroupRule `json:"security_group_rules"`
 
-	// Owner of the security group. Only admin users can specify a TenantID
-	// other than their own.
+	// TenantID is the project owner of the security group.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the security group.
+	ProjectID string `json:"project_id"`
 }
 
 // SecGroupPage is the page returned by a pager when traversing over a
@@ -78,22 +80,26 @@ func (r commonResult) Extract() (*SecGroup, error) {
 	return s.SecGroup, err
 }
 
-// CreateResult represents the result of a create operation.
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a SecGroup.
 type CreateResult struct {
 	commonResult
 }
 
-// UpdateResult represents the result of an update operation.
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a SecGroup.
 type UpdateResult struct {
 	commonResult
 }
 
-// GetResult represents the result of a get operation.
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a SecGroup.
 type GetResult struct {
 	commonResult
 }
 
-// DeleteResult represents the result of a delete operation.
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/doc.go
@@ -1,0 +1,50 @@
+/*
+Package rules provides information and interaction with Security Group Rules
+for the OpenStack Networking service.
+
+Example to List Security Groups Rules
+
+	listOpts := rules.ListOpts{
+		Protocol: "tcp",
+	}
+
+	allPages, err := rules.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allRules, err := rules.ExtractRules(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, rule := range allRules {
+		fmt.Printf("%+v\n", rule)
+	}
+
+Example to Create a Security Group Rule
+
+	createOpts := rules.CreateOpts{
+		Direction:     "ingress",
+		PortRangeMin:  80,
+		EtherType:     rules.EtherType4,
+		PortRangeMax:  80,
+		Protocol:      "tcp",
+		RemoteGroupID: "85cc3048-abc3-43cc-89b3-377341426ac5",
+		SecGroupID:    "a7734e61-b545-452d-a3cd-0189cbd9747a",
+	}
+
+	rule, err := rules.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Security Group Rule
+
+	ruleID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
+	err := rules.Delete(networkClient, ruleID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package rules

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/requests.go
@@ -7,9 +7,9 @@ import (
 
 // ListOpts allows the filtering and sorting of paginated collections through
 // the API. Filtering is achieved by passing in struct field values that map to
-// the security group attributes you want to see returned. SortKey allows you to
-// sort by a particular network attribute. SortDir sets the direction, and is
-// either `asc' or `desc'. Marker and Limit are used for pagination.
+// the security group rule attributes you want to see returned. SortKey allows
+// you to sort by a particular network attribute. SortDir sets the direction,
+// and is either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
 	Direction      string `q:"direction"`
 	EtherType      string `q:"ethertype"`
@@ -21,6 +21,7 @@ type ListOpts struct {
 	RemoteIPPrefix string `q:"remote_ip_prefix"`
 	SecGroupID     string `q:"security_group_id"`
 	TenantID       string `q:"tenant_id"`
+	ProjectID      string `q:"project_id"`
 	Limit          int    `q:"limit"`
 	Marker         string `q:"marker"`
 	SortKey        string `q:"sort_key"`
@@ -74,48 +75,56 @@ const (
 	ProtocolVRRP      RuleProtocol  = "vrrp"
 )
 
-// CreateOptsBuilder is what types must satisfy to be used as Create
-// options.
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToSecGroupRuleCreateMap() (map[string]interface{}, error)
 }
 
-// CreateOpts contains all the values needed to create a new security group rule.
+// CreateOpts contains all the values needed to create a new security group
+// rule.
 type CreateOpts struct {
-	// Required. Must be either "ingress" or "egress": the direction in which the
-	// security group rule is applied.
+	// Must be either "ingress" or "egress": the direction in which the security
+	// group rule is applied.
 	Direction RuleDirection `json:"direction" required:"true"`
-	// Required. Must be "IPv4" or "IPv6", and addresses represented in CIDR must
-	// match the ingress or egress rules.
+
+	// Must be "IPv4" or "IPv6", and addresses represented in CIDR must match the
+	// ingress or egress rules.
 	EtherType RuleEtherType `json:"ethertype" required:"true"`
-	// Required. The security group ID to associate with this security group rule.
+
+	// The security group ID to associate with this security group rule.
 	SecGroupID string `json:"security_group_id" required:"true"`
-	// Optional. The maximum port number in the range that is matched by the
-	// security group rule. The PortRangeMin attribute constrains the PortRangeMax
-	// attribute. If the protocol is ICMP, this value must be an ICMP type.
+
+	// The maximum port number in the range that is matched by the security group
+	// rule. The PortRangeMin attribute constrains the PortRangeMax attribute. If
+	// the protocol is ICMP, this value must be an ICMP type.
 	PortRangeMax int `json:"port_range_max,omitempty"`
-	// Optional. The minimum port number in the range that is matched by the
-	// security group rule. If the protocol is TCP or UDP, this value must be
-	// less than or equal to the value of the PortRangeMax attribute. If the
-	// protocol is ICMP, this value must be an ICMP type.
+
+	// The minimum port number in the range that is matched by the security group
+	// rule. If the protocol is TCP or UDP, this value must be less than or equal
+	// to the value of the PortRangeMax attribute. If the protocol is ICMP, this
+	// value must be an ICMP type.
 	PortRangeMin int `json:"port_range_min,omitempty"`
-	// Optional. The protocol that is matched by the security group rule. Valid
-	// values are "tcp", "udp", "icmp" or an empty string.
+
+	// The protocol that is matched by the security group rule. Valid values are
+	// "tcp", "udp", "icmp" or an empty string.
 	Protocol RuleProtocol `json:"protocol,omitempty"`
-	// Optional. The remote group ID to be associated with this security group
-	// rule. You can specify either RemoteGroupID or RemoteIPPrefix.
+
+	// The remote group ID to be associated with this security group rule. You can
+	// specify either RemoteGroupID or RemoteIPPrefix.
 	RemoteGroupID string `json:"remote_group_id,omitempty"`
-	// Optional. The remote IP prefix to be associated with this security group
-	// rule. You can specify either RemoteGroupID or RemoteIPPrefix. This
-	// attribute matches the specified IP prefix as the source IP address of the
-	// IP packet.
+
+	// The remote IP prefix to be associated with this security group rule. You can
+	// specify either RemoteGroupID or RemoteIPPrefix. This attribute matches the
+	// specified IP prefix as the source IP address of the IP packet.
 	RemoteIPPrefix string `json:"remote_ip_prefix,omitempty"`
-	// Required for admins. Indicates the owner of the VIP.
-	TenantID string `json:"tenant_id,omitempty"`
+
+	// TenantID is the UUID of the project who owns the Rule.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
 }
 
-// ToSecGroupRuleCreateMap allows CreateOpts to satisfy the CreateOptsBuilder
-// interface
+// ToSecGroupRuleCreateMap builds a request body from CreateOpts.
 func (opts CreateOpts) ToSecGroupRuleCreateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "security_group_rule")
 }
@@ -138,7 +147,8 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
-// Delete will permanently delete a particular security group rule based on its unique ID.
+// Delete will permanently delete a particular security group rule based on its
+// unique ID.
 func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = c.Delete(resourceURL(c, id), nil)
 	return

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/results.go
@@ -48,8 +48,11 @@ type SecGroupRule struct {
 	// matches the specified IP prefix as the source IP address of the IP packet.
 	RemoteIPPrefix string `json:"remote_ip_prefix"`
 
-	// The owner of this security group rule.
+	// TenantID is the project owner of this security group rule.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of this security group rule.
+	ProjectID string `json:"project_id"`
 }
 
 // SecGroupRulePage is the page returned by a pager when traversing over a
@@ -102,17 +105,20 @@ func (r commonResult) Extract() (*SecGroupRule, error) {
 	return s.SecGroupRule, err
 }
 
-// CreateResult represents the result of a create operation.
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a SecGroupRule.
 type CreateResult struct {
 	commonResult
 }
 
-// GetResult represents the result of a get operation.
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a SecGroupRule.
 type GetResult struct {
 	commonResult
 }
 
-// DeleteResult represents the result of a delete operation.
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/requests.go
@@ -21,6 +21,7 @@ type ListOpts struct {
 	Name         string `q:"name"`
 	AdminStateUp *bool  `q:"admin_state_up"`
 	TenantID     string `q:"tenant_id"`
+	ProjectID    string `q:"project_id"`
 	Shared       *bool  `q:"shared"`
 	ID           string `q:"id"`
 	Marker       string `q:"marker"`
@@ -70,6 +71,7 @@ type CreateOpts struct {
 	Name                  string   `json:"name,omitempty"`
 	Shared                *bool    `json:"shared,omitempty"`
 	TenantID              string   `json:"tenant_id,omitempty"`
+	ProjectID             string   `json:"project_id,omitempty"`
 	AvailabilityZoneHints []string `json:"availability_zone_hints,omitempty"`
 }
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/results.go
@@ -64,8 +64,11 @@ type Network struct {
 	// Subnets associated with this network.
 	Subnets []string `json:"subnets"`
 
-	// Owner of network.
+	// TenantID is the project owner of the network.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the network.
+	ProjectID string `json:"project_id"`
 
 	// Specifies whether the network resource can be accessed by any tenant.
 	Shared bool `json:"shared"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/requests.go
@@ -22,6 +22,7 @@ type ListOpts struct {
 	AdminStateUp *bool  `q:"admin_state_up"`
 	NetworkID    string `q:"network_id"`
 	TenantID     string `q:"tenant_id"`
+	ProjectID    string `q:"project_id"`
 	DeviceOwner  string `q:"device_owner"`
 	MACAddress   string `q:"mac_address"`
 	ID           string `q:"id"`
@@ -81,6 +82,7 @@ type CreateOpts struct {
 	DeviceID            string        `json:"device_id,omitempty"`
 	DeviceOwner         string        `json:"device_owner,omitempty"`
 	TenantID            string        `json:"tenant_id,omitempty"`
+	ProjectID           string        `json:"project_id,omitempty"`
 	SecurityGroups      *[]string     `json:"security_groups,omitempty"`
 	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs,omitempty"`
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/results.go
@@ -11,11 +11,13 @@ type commonResult struct {
 
 // Extract is a function that accepts a result and extracts a port resource.
 func (r commonResult) Extract() (*Port, error) {
-	var s struct {
-		Port *Port `json:"port"`
-	}
+	var s Port
 	err := r.ExtractInto(&s)
-	return s.Port, err
+	return &s, err
+}
+
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "port")
 }
 
 // CreateResult represents the result of a create operation. Call its Extract
@@ -82,8 +84,11 @@ type Port struct {
 	// the subnets where the IP addresses are picked from
 	FixedIPs []IP `json:"fixed_ips"`
 
-	// Owner of network.
+	// TenantID is the project owner of the port.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the port.
+	ProjectID string `json:"project_id"`
 
 	// Identifies the entity (e.g.: dhcp agent) using this port.
 	DeviceOwner string `json:"device_owner"`
@@ -128,9 +133,11 @@ func (r PortPage) IsEmpty() (bool, error) {
 // and extracts the elements into a slice of Port structs. In other words,
 // a generic collection is mapped into a relevant slice.
 func ExtractPorts(r pagination.Page) ([]Port, error) {
-	var s struct {
-		Ports []Port `json:"ports"`
-	}
-	err := (r.(PortPage)).ExtractInto(&s)
-	return s.Ports, err
+	var s []Port
+	err := ExtractPortsInto(r, &s)
+	return s, err
+}
+
+func ExtractPortsInto(r pagination.Page, v interface{}) error {
+	return r.(PortPage).Result.ExtractIntoSlicePtr(v, "ports")
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/requests.go
@@ -21,6 +21,7 @@ type ListOpts struct {
 	EnableDHCP      *bool  `q:"enable_dhcp"`
 	NetworkID       string `q:"network_id"`
 	TenantID        string `q:"tenant_id"`
+	ProjectID       string `q:"project_id"`
 	IPVersion       int    `q:"ip_version"`
 	GatewayIP       string `q:"gateway_ip"`
 	CIDR            string `q:"cidr"`
@@ -79,14 +80,18 @@ type CreateOpts struct {
 	NetworkID string `json:"network_id" required:"true"`
 
 	// CIDR is the address CIDR of the subnet.
-	CIDR string `json:"cidr" required:"true"`
+	CIDR string `json:"cidr,omitempty"`
 
 	// Name is a human-readable name of the subnet.
 	Name string `json:"name,omitempty"`
 
-	// The UUID of the tenant who owns the Subnet. Only administrative users
-	// can specify a tenant UUID other than their own.
+	// The UUID of the project who owns the Subnet. Only administrative users
+	// can specify a project UUID other than their own.
 	TenantID string `json:"tenant_id,omitempty"`
+
+	// The UUID of the project who owns the Subnet. Only administrative users
+	// can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
 
 	// AllocationPools are IP Address pools that will be available for DHCP.
 	AllocationPools []AllocationPool `json:"allocation_pools,omitempty"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/results.go
@@ -91,8 +91,11 @@ type Subnet struct {
 	// Specifies whether DHCP is enabled for this subnet or not.
 	EnableDHCP bool `json:"enable_dhcp"`
 
-	// Owner of network.
+	// TenantID is the project owner of the subnet.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the subnet.
+	ProjectID string `json:"project_id"`
 
 	// The IPv6 address modes specifies mechanisms for assigning IPv6 IP addresses.
 	IPv6AddressMode string `json:"ipv6_address_mode"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -445,130 +445,130 @@
 			"revisionTime": "2017-09-08T04:14:34Z"
 		},
 		{
-			"checksumSHA1": "YqqqrMdOCKY2xwFkwxskkx8XtTQ=",
+			"checksumSHA1": "a++vnjXX0eXWLylR29L3z8dcxwU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls",
-			"revision": "3027adb1ce72bc52b87b2decccc7852574b90031",
-			"revisionTime": "2017-05-24T13:09:59Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "14ZhP0wE/WCL/6oujcML755AaH4=",
+			"checksumSHA1": "bqEG939LJ5te1hZuZXRxy1CLMyw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "nHGhVRP69paJsebTRp4Q1cfQtag=",
+			"checksumSHA1": "FDgt1WaVGbp8w6vyCJbtkbsbWBc=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/routerinsertion",
-			"revision": "3027adb1ce72bc52b87b2decccc7852574b90031",
-			"revisionTime": "2017-05-24T13:09:59Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "sYET5A7WTyJ7dpuxR/VXYoReldw=",
+			"checksumSHA1": "uZ5/gCROQHaiHpXfoLrfisRzbAU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "w1Mm8OqxEelnDWKtvRf4gsEyjOo=",
+			"checksumSHA1": "K4VAatvB/jywsU+g/mU7bnSaVaI=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips",
-			"revision": "6da026c32e2d622cc242d32984259c77237aefe1",
-			"revisionTime": "2018-02-10T02:43:43Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "X2qWZ68Xlfobx/EQR0EEGEpUJBk=",
+			"checksumSHA1": "tvOf0FGjKmpz9vZD0ZBHtcMFpwI=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers",
-			"revision": "92fb632e86f730790c3d240e468617c6f8d4a3bf",
-			"revisionTime": "2017-12-14T02:21:50Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "mCTz2rnyVfhjJ+AD/WihCNcYWiY=",
+			"checksumSHA1": "HiGzZXGIxrItijPCH+L7EbbCb9w=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/members",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "B2mtHvADREtFLam72wyijyQh/Ds=",
+			"checksumSHA1": "KZJLk70d5SX8TQO1q0MLAxGEBCU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/monitors",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "pTr22CKKJ26yvhgd0SRxFF4jkEs=",
+			"checksumSHA1": "KXKo/TByIHelRDES1IB01nlQMoM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/pools",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "E7/Z7g5O9o+ge+8YklheTpKgWNw=",
+			"checksumSHA1": "3QfwJnsJHohoYV16/BOtDXpNEYI=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/vips",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "mhpwj5tPv7Uw5aUfC55fhLPBcKo=",
+			"checksumSHA1": "HOmjWn7LqpHWJMpGIR7xbSffGbU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "5efJz6UH7JCFeav5ZCCzicXCFTU=",
+			"checksumSHA1": "CgrfM+dEvV3q3iFcw5CZnljw3xg=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "TVFgBTz7B6bb1R4TWdgAkbE1/fk=",
+			"checksumSHA1": "M3lTM04nSdVMnOINImf96Xi2NP8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/monitors",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "xirjw9vJIN6rmkT3T56bfPfOLUM=",
+			"checksumSHA1": "D6G0MvbxDffUT0G9S5wrL5N3cNE=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "z4Wpu5WejbJzYMztu8UlCR3riBA=",
+			"checksumSHA1": "eUvwdXvz/Zkckr/isvP+2nXY2J8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/provider",
-			"revision": "5a6e13341e63bd202a0da558a2a7187720042676",
-			"revisionTime": "2017-05-22T01:35:44Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "qabBGU1tfT99h1YXyxO9nGxMghE=",
+			"checksumSHA1": "ONshdaKbzuBzG+tvpRQ6FS6DHRA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups",
-			"revision": "3027adb1ce72bc52b87b2decccc7852574b90031",
-			"revisionTime": "2017-05-24T13:09:59Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "E/5q7DTCoOD15K1KGFXSwFCGDE4=",
+			"checksumSHA1": "RYd8K6FLhidexFNm9iqPXrStnZM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules",
-			"revision": "3027adb1ce72bc52b87b2decccc7852574b90031",
-			"revisionTime": "2017-05-24T13:09:59Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
 			"checksumSHA1": "nbFJZRXhTvv4g0LK+FCzG0W11G4=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools",
-			"revision": "47e78c6bba46f5484da66c8e9ba0ecb94093641c",
-			"revisionTime": "2018-02-24T04:26:33Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "YnP/P8Tr8hHw+NVZ/KegcGCbK0I=",
+			"checksumSHA1": "XEVvG2f/dqATN4aCluZlPylW+9A=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/networks",
-			"revision": "4d2733c962898d8cd68456bd275aee64256cd2a1",
-			"revisionTime": "2017-12-08T16:30:52Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "68RL/R3cHJvkHPNZmu0GW4xd4cY=",
+			"checksumSHA1": "/4nBrtUCcHILgmPwOwBKoebKnMY=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/ports",
-			"revision": "e764e6cf0316a135851b56f8eea946b906988707",
-			"revisionTime": "2017-09-08T04:14:34Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "djCtqYRuSbd+IYGH3Vc9B63fCqM=",
+			"checksumSHA1": "8ODTbSq44HuX4vKNSWAuN43km7w=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets",
-			"revision": "d693a2e15df35aba7480c4c719d63066bc59adee",
-			"revisionTime": "2018-02-21T03:03:51Z"
+			"revision": "482bcee3e503006779c2c99437c0613881160de1",
+			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
 			"checksumSHA1": "Q9VHGSztw2B4PmN4kyvY9TcJD6c=",


### PR DESCRIPTION
This commit makes the subnet CIDR optional so that a subnet can
be created with a subnet pool and have the pool automatically
delegate a CIDR.

The CIDR argument/attribute is now also computed to reflect the
CIDR supplied by the pool.

Fixes #282 