### PR TITLE
LBaaS v2: Lower Delays for Load Balancer Resources

### DIFF
--- a/openstack/lb_v2_shared.go
+++ b/openstack/lb_v2_shared.go
@@ -23,7 +23,7 @@ func waitForLBV2Listener(networkingClient *gophercloud.ServiceClient, id string,
 		Pending:    pending,
 		Refresh:    resourceLBV2ListenerRefreshFunc(networkingClient, id),
 		Timeout:    timeout,
-		Delay:      5 * time.Second,
+		Delay:      1 * time.Second,
 		MinTimeout: 1 * time.Second,
 	}
 
@@ -63,7 +63,7 @@ func waitForLBV2LoadBalancer(networkingClient *gophercloud.ServiceClient, id str
 		Pending:    pending,
 		Refresh:    resourceLBV2LoadBalancerRefreshFunc(networkingClient, id),
 		Timeout:    timeout,
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 1 * time.Second,
 	}
 
@@ -102,7 +102,7 @@ func waitForLBV2Member(networkingClient *gophercloud.ServiceClient, poolID, memb
 		Pending:    pending,
 		Refresh:    resourceLBV2MemberRefreshFunc(networkingClient, poolID, memberID),
 		Timeout:    timeout,
-		Delay:      5 * time.Second,
+		Delay:      1 * time.Second,
 		MinTimeout: 1 * time.Second,
 	}
 
@@ -142,7 +142,7 @@ func waitForLBV2Monitor(networkingClient *gophercloud.ServiceClient, id string, 
 		Pending:    pending,
 		Refresh:    resourceLBV2MonitorRefreshFunc(networkingClient, id),
 		Timeout:    timeout,
-		Delay:      5 * time.Second,
+		Delay:      1 * time.Second,
 		MinTimeout: 1 * time.Second,
 	}
 
@@ -182,7 +182,7 @@ func waitForLBV2Pool(networkingClient *gophercloud.ServiceClient, id string, tar
 		Pending:    pending,
 		Refresh:    resourceLBV2PoolRefreshFunc(networkingClient, id),
 		Timeout:    timeout,
-		Delay:      5 * time.Second,
+		Delay:      1 * time.Second,
 		MinTimeout: 1 * time.Second,
 	}
 


### PR DESCRIPTION
This commit lowers the delays for the load balancer resources
while waiting for a certain state. For the LoadBalancer resource
in particular, the delay is set to 0.

Fixes #295 

I tested setting all delays to 0 and everything worked, but I want to be cautious here. #295 specifically requested the load balancer delay to be set to 0, so I've implemented that. For everything else, I've lowered it to 1 second.