### PR TITLE
Networking v2: Fix router distributed argument

### DIFF
--- a/openstack/resource_openstack_fw_firewall_v1_test.go
+++ b/openstack/resource_openstack_fw_firewall_v1_test.go
@@ -286,7 +286,6 @@ const testAccFWFirewallV1_router = `
 resource "openstack_networking_router_v2" "router_1" {
   name = "router_1"
   admin_state_up = "true"
-  distributed = "false"
 }
 
 resource "openstack_fw_policy_v1" "policy_1" {
@@ -305,13 +304,11 @@ const testAccFWFirewallV1_router_add = `
 resource "openstack_networking_router_v2" "router_1" {
   name = "router_1"
   admin_state_up = "true"
-  distributed = "false"
 }
 
 resource "openstack_networking_router_v2" "router_2" {
   name = "router_2"
   admin_state_up = "true"
-  distributed = "false"
 }
 
 resource "openstack_fw_policy_v1" "policy_1" {

--- a/openstack/resource_openstack_networking_router_v2.go
+++ b/openstack/resource_openstack_networking_router_v2.go
@@ -148,7 +148,7 @@ func resourceNetworkingRouterV2Create(d *schema.ResourceData, meta interface{}) 
 		createOpts.AdminStateUp = &asu
 	}
 
-	if dRaw, ok := d.GetOk("distributed"); ok {
+	if dRaw, ok := d.GetOkExists("distributed"); ok {
 		d := dRaw.(bool)
 		createOpts.Distributed = &d
 	}

--- a/openstack/resource_openstack_networking_router_v2_test.go
+++ b/openstack/resource_openstack_networking_router_v2_test.go
@@ -60,7 +60,7 @@ func TestAccNetworkingV2Router_updateExternalGateway(t *testing.T) {
 	})
 }
 
-func TestAccNetworkingV2Router_timeout(t *testing.T) {
+func TestAccNetworkingV2Router_vendor_opts(t *testing.T) {
 	var router routers.Router
 
 	resource.Test(t, resource.TestCase{
@@ -69,9 +69,11 @@ func TestAccNetworkingV2Router_timeout(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkingV2RouterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccNetworkingV2Router_timeout,
+				Config: testAccNetworkingV2Router_vendor_opts,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2RouterExists("openstack_networking_router_v2.router_1", &router),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_router_v2.router_1", "external_gateway", OS_EXTGW_ID),
 				),
 			},
 		},
@@ -135,35 +137,23 @@ const testAccNetworkingV2Router_basic = `
 resource "openstack_networking_router_v2" "router_1" {
 	name = "router_1"
 	admin_state_up = "true"
-	distributed = "false"
+
+  timeouts {
+    create = "5m"
+    delete = "5m"
+  }
 }
 `
-
-func TestAccNetworkingV2Router_vendor_opts(t *testing.T) {
-	var router routers.Router
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNetworkingV2RouterDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccNetworkingV2Router_vendor_opts,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingV2RouterExists("openstack_networking_router_v2.router_1", &router),
-					resource.TestCheckResourceAttr(
-						"openstack_networking_router_v2.router_1", "external_gateway", OS_EXTGW_ID),
-				),
-			},
-		},
-	})
-}
 
 const testAccNetworkingV2Router_update = `
 resource "openstack_networking_router_v2" "router_1" {
 	name = "router_2"
 	admin_state_up = "true"
-	distributed = "false"
+
+  timeouts {
+    create = "5m"
+    delete = "5m"
+  }
 }
 `
 
@@ -171,7 +161,6 @@ var testAccNetworkingV2Router_vendor_opts = fmt.Sprintf(`
 resource "openstack_networking_router_v2" "router_1" {
 	name = "router_1"
 	admin_state_up = "true"
-	distributed = "false"
 	external_network_id = "%s"
 	vendor_options {
 		set_router_gateway_after_create = true
@@ -183,7 +172,6 @@ const testAccNetworkingV2Router_updateExternalGateway1 = `
 resource "openstack_networking_router_v2" "router_1" {
 	name = "router"
 	admin_state_up = "true"
-	distributed = "false"
 }
 `
 
@@ -191,20 +179,6 @@ var testAccNetworkingV2Router_updateExternalGateway2 = fmt.Sprintf(`
 resource "openstack_networking_router_v2" "router_1" {
 	name = "router"
 	admin_state_up = "true"
-	distributed = "false"
 	external_network_id = "%s"
 }
 `, OS_EXTGW_ID)
-
-const testAccNetworkingV2Router_timeout = `
-resource "openstack_networking_router_v2" "router_1" {
-	name = "router_1"
-	admin_state_up = "true"
-	distributed = "false"
-
-  timeouts {
-    create = "5m"
-    delete = "5m"
-  }
-}
-`


### PR DESCRIPTION
This commit fixes the "distributed" argument for the
openstack_networking_router_v2 resource so that the value of
"false" is passed correctly.

"distributed" is removed from all acceptance tests since it is
now being passed correctly in the request body and this setting
is very dependent upon the testing environment configuration.

Fixes #285 