### PR TITLE
Compute v2: Add wait_until_associated to floating IP association

### DIFF
--- a/openstack/import_openstack_compute_floatingip_associate_v2_test.go
+++ b/openstack/import_openstack_compute_floatingip_associate_v2_test.go
@@ -22,6 +22,9 @@ func TestAccComputeV2FloatingIPAssociate_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"wait_until_associated",
+				},
 			},
 		},
 	})

--- a/openstack/resource_openstack_compute_floatingip_associate_v2.go
+++ b/openstack/resource_openstack_compute_floatingip_associate_v2.go
@@ -4,12 +4,15 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	nfloatingips "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
-	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func resourceComputeFloatingIPAssociateV2() *schema.Resource {
@@ -19,6 +22,10 @@ func resourceComputeFloatingIPAssociateV2() *schema.Resource {
 		Delete: resourceComputeFloatingIPAssociateV2Delete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -34,13 +41,22 @@ func resourceComputeFloatingIPAssociateV2() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+
 			"instance_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
+
 			"fixed_ip": &schema.Schema{
 				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"wait_until_associated": &schema.Schema{
+				Type:     schema.TypeBool,
+				Default:  false,
 				Optional: true,
 				ForceNew: true,
 			},
@@ -70,14 +86,31 @@ func resourceComputeFloatingIPAssociateV2Create(d *schema.ResourceData, meta int
 		return fmt.Errorf("Error associating Floating IP: %s", err)
 	}
 
+	// This API call should be synchronous, but we've had reports where it isn't.
+	// If the user opted in to wait for association, then poll here.
+	waitUntilAssociated := d.Get("wait_until_associated").(bool)
+
+	if waitUntilAssociated {
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{"NOT_ASSOCIATED"},
+			Target:     []string{"ASSOCIATED"},
+			Refresh:    resourceComputeFloatingIPAssociateV2CheckAssociation(computeClient, instanceId, floatingIP),
+			Timeout:    d.Timeout(schema.TimeoutCreate),
+			Delay:      0,
+			MinTimeout: 3 * time.Second,
+		}
+
+		_, err := stateConf.WaitForState()
+		if err != nil {
+			return err
+		}
+	}
+
 	// There's an API call to get this information, but it has been
 	// deprecated. The Neutron API could be used, but I'm trying not
 	// to mix service APIs. Therefore, a faux ID will be used.
 	id := fmt.Sprintf("%s/%s/%s", floatingIP, instanceId, fixedIP)
 	d.SetId(id)
-
-	// This API call is synchronous, so Create won't return until the IP
-	// is attached. No need to wait for a state.
 
 	return resourceComputeFloatingIPAssociateV2Read(d, meta)
 }
@@ -232,4 +265,31 @@ func resourceComputeFloatingIPAssociateV2ComputeExists(computeClient *gopherclou
 	}
 
 	return false, nil
+}
+
+func resourceComputeFloatingIPAssociateV2CheckAssociation(
+	computeClient *gophercloud.ServiceClient, instanceId, floatingIP string) resource.StateRefreshFunc {
+
+	return func() (interface{}, string, error) {
+		instance, err := servers.Get(computeClient, instanceId).Extract()
+		if err != nil {
+			return instance, "", err
+		}
+
+		var associated bool
+		for _, networkAddresses := range instance.Addresses {
+			for _, element := range networkAddresses.([]interface{}) {
+				address := element.(map[string]interface{})
+				if address["OS-EXT-IPS:type"] == "floating" && address["addr"] == floatingIP {
+					associated = true
+				}
+			}
+		}
+
+		if associated {
+			return instance, "ASSOCIATED", nil
+		}
+
+		return instance, "NOT_ASSOCIATED", nil
+	}
 }

--- a/website/docs/r/compute_floatingip_associate_v2.html.markdown
+++ b/website/docs/r/compute_floatingip_associate_v2.html.markdown
@@ -79,6 +79,11 @@ The following arguments are supported:
 
 * `fixed_ip` - (Optional) The specific IP address to direct traffic to.
 
+* `wait_until_associated` - (Optional) In cases where the OpenStack environment
+    does not automatically wait until the association has finished, set this
+    option to have Terraform poll the instance until the floating IP has been
+    associated. Defaults to false.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
This commit adds the wait_until_associated argument to the
openstack_compute_floatingip_associate_v2 resource. This is useful
in environments where the OpenStack environment won't automatically
wait for the floating IP association to finish before returning.

Use this option to instead have Terraform wait until the association
has finished.

Fixes #88 