### PR TITLE
Add openstack_networking_subnet_route_v2 resource

### DIFF
--- a/openstack/import_openstack_networking_subnet_route_v2_test.go
+++ b/openstack/import_openstack_networking_subnet_route_v2_test.go
@@ -1,0 +1,28 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccNetworkingV2SubnetRoute_importBasic(t *testing.T) {
+	resourceName := "openstack_networking_subnet_route_v2.subnet_route_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2SubnetRouteDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2SubnetRoute_create,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -242,6 +242,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_lb_monitor_v2":                   resourceMonitorV2(),
 			"openstack_networking_network_v2":           resourceNetworkingNetworkV2(),
 			"openstack_networking_subnet_v2":            resourceNetworkingSubnetV2(),
+			"openstack_networking_subnet_route_v2":      resourceNetworkingSubnetRouteV2(),
 			"openstack_networking_floatingip_v2":        resourceNetworkingFloatingIPV2(),
 			"openstack_networking_port_v2":              resourceNetworkingPortV2(),
 			"openstack_networking_router_v2":            resourceNetworkingRouterV2(),

--- a/openstack/resource_openstack_networking_subnet_route_v2.go
+++ b/openstack/resource_openstack_networking_subnet_route_v2.go
@@ -1,0 +1,224 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+)
+
+func resourceNetworkingSubnetRouteV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNetworkingSubnetRouteV2Create,
+		Read:   resourceNetworkingSubnetRouteV2Read,
+		Delete: resourceNetworkingSubnetRouteV2Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"subnet_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"destination_cidr": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"next_hop": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceNetworkingSubnetRouteV2Create(d *schema.ResourceData, meta interface{}) error {
+
+	subnetId := d.Get("subnet_id").(string)
+	osMutexKV.Lock(subnetId)
+	defer osMutexKV.Unlock(subnetId)
+
+	var destCidr string = d.Get("destination_cidr").(string)
+	var nextHop string = d.Get("next_hop").(string)
+
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	subnet, err := subnets.Get(networkingClient, subnetId).Extract()
+	if err != nil {
+		if _, ok := err.(gophercloud.ErrDefault404); ok {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving OpenStack Neutron Subnet: %s", err)
+	}
+
+	var updateOpts subnets.UpdateOpts
+	var routeExists bool = false
+
+	var rts []subnets.HostRoute = subnet.HostRoutes
+	for _, r := range rts {
+
+		if r.DestinationCIDR == destCidr && r.NextHop == nextHop {
+			routeExists = true
+			break
+		}
+	}
+
+	if routeExists {
+		return fmt.Errorf("Subnet %s has route already", subnetId)
+	}
+
+	if destCidr != "" && nextHop != "" {
+		r := subnets.HostRoute{DestinationCIDR: destCidr, NextHop: nextHop}
+		log.Printf("[INFO] Adding route %s", r)
+		rts = append(rts, r)
+	}
+
+	updateOpts.HostRoutes = &rts
+
+	log.Printf("[DEBUG] Updating Subnet %s with options: %+v", subnetId, updateOpts)
+
+	_, err = subnets.Update(networkingClient, subnetId, updateOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error updating OpenStack Neutron Subnet: %s", err)
+	}
+	id := fmt.Sprintf("%s-route-%s-%s", subnetId, destCidr, nextHop)
+	d.SetId(id)
+
+	return resourceNetworkingSubnetRouteV2Read(d, meta)
+}
+
+func resourceNetworkingSubnetRouteV2Read(d *schema.ResourceData, meta interface{}) error {
+
+	subnetId := d.Get("subnet_id").(string)
+
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	destCidr := d.Get("destination_cidr").(string)
+	nextHop := d.Get("next_hop").(string)
+
+	routeIDParts := []string{}
+	if d.Id() != "" && strings.Contains(d.Id(), "-route-") {
+		routeIDParts = strings.Split(d.Id(), "-route-")
+		routeLastIDParts := strings.Split(routeIDParts[1], "-")
+
+		if subnetId == "" {
+			subnetId = routeIDParts[0]
+			d.Set("subnet_id", subnetId)
+		}
+		if destCidr == "" {
+			destCidr = routeLastIDParts[0]
+		}
+		if nextHop == "" {
+			nextHop = routeLastIDParts[1]
+		}
+	}
+
+	subnet, err := subnets.Get(networkingClient, subnetId).Extract()
+	if err != nil {
+		if _, ok := err.(gophercloud.ErrDefault404); ok {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving OpenStack Neutron Subnet: %s", err)
+	}
+
+	log.Printf("[DEBUG] Retrieved Subnet %s: %+v", subnetId, subnet)
+
+	var exists bool
+	for _, r := range subnet.HostRoutes {
+		if r.DestinationCIDR == destCidr && r.NextHop == nextHop {
+			exists = true
+		}
+	}
+
+	if !exists {
+		return fmt.Errorf("Route doesn't exist")
+	}
+
+	d.Set("next_hop", nextHop)
+	d.Set("destination_cidr", destCidr)
+
+	d.Set("region", GetRegion(d, config))
+
+	return nil
+}
+
+func resourceNetworkingSubnetRouteV2Delete(d *schema.ResourceData, meta interface{}) error {
+
+	subnetId := d.Get("subnet_id").(string)
+	osMutexKV.Lock(subnetId)
+	defer osMutexKV.Unlock(subnetId)
+
+	config := meta.(*Config)
+
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	subnet, err := subnets.Get(networkingClient, subnetId).Extract()
+	if err != nil {
+		if _, ok := err.(gophercloud.ErrDefault404); ok {
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving OpenStack Neutron Subnet: %s", err)
+	}
+
+	var updateOpts subnets.UpdateOpts
+
+	var destCidr string = d.Get("destination_cidr").(string)
+	var nextHop string = d.Get("next_hop").(string)
+
+	var oldRts []subnets.HostRoute = subnet.HostRoutes
+	var newRts []subnets.HostRoute
+
+	for _, r := range oldRts {
+
+		if r.DestinationCIDR != destCidr || r.NextHop != nextHop {
+			newRts = append(newRts, r)
+		}
+	}
+
+	if len(oldRts) == len(newRts) {
+		return fmt.Errorf("Route did not exist already")
+	}
+
+	r := subnets.HostRoute{DestinationCIDR: destCidr, NextHop: nextHop}
+	log.Printf("[INFO] Deleting route %s", r)
+	updateOpts.HostRoutes = &newRts
+
+	log.Printf("[DEBUG] Updating Subnet %s with options: %+v", subnetId, updateOpts)
+
+	_, err = subnets.Update(networkingClient, subnetId, updateOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error updating OpenStack Neutron Subnet: %s", err)
+	}
+
+	return nil
+}

--- a/openstack/resource_openstack_networking_subnet_route_v2_test.go
+++ b/openstack/resource_openstack_networking_subnet_route_v2_test.go
@@ -1,0 +1,287 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+)
+
+func TestAccNetworkingV2SubnetRoute_basic(t *testing.T) {
+	var router routers.Router
+	var network [1]networks.Network
+	var subnet [1]subnets.Subnet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2SubnetRoute_create,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2RouterExists("openstack_networking_router_v2.router_1", &router),
+					testAccCheckNetworkingV2NetworkExists(
+						"openstack_networking_network_v2.network_1", &network[0]),
+					testAccCheckNetworkingV2SubnetExists(
+						"openstack_networking_subnet_v2.subnet_1", &subnet[0]),
+					testAccCheckNetworkingV2RouterInterfaceExists(
+						"openstack_networking_router_interface_v2.int_1"),
+					testAccCheckNetworkingV2SubnetRouteExists(
+						"openstack_networking_subnet_route_v2.subnet_route_1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccNetworkingV2SubnetRoute_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2SubnetRouteExists(
+						"openstack_networking_subnet_route_v2.subnet_route_1"),
+					testAccCheckNetworkingV2SubnetRouteExists(
+						"openstack_networking_subnet_route_v2.subnet_route_2"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccNetworkingV2SubnetRoute_destroy,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2SubnetRouteEmpty("openstack_networking_subnet_v2.subnet_1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckNetworkingV2SubnetRouteEmpty(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+		}
+
+		subnet, err := subnets.Get(networkingClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if subnet.ID != rs.Primary.ID {
+			return fmt.Errorf("Subnet not found")
+		}
+
+		if len(subnet.HostRoutes) != 0 {
+			return fmt.Errorf("Invalid number of route entries: %d", len(subnet.HostRoutes))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckNetworkingV2SubnetRouteExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+		}
+
+		subnet, err := subnets.Get(networkingClient, rs.Primary.Attributes["subnet_id"]).Extract()
+		if err != nil {
+			return err
+		}
+
+		if subnet.ID != rs.Primary.Attributes["subnet_id"] {
+			return fmt.Errorf("Subnet for route not found")
+		}
+
+		var found bool = false
+		for _, r := range subnet.HostRoutes {
+			if r.DestinationCIDR == rs.Primary.Attributes["destination_cidr"] && r.NextHop == rs.Primary.Attributes["next_hop"] {
+				found = true
+			}
+		}
+		if !found {
+			return fmt.Errorf("Could not find route for destination CIDR: %s, next hop: %s", rs.Primary.Attributes["destination_cidr"], rs.Primary.Attributes["next_hop"])
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckNetworkingV2SubnetRouteDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "openstack_networking_subnet_route_v2" {
+			continue
+		}
+
+		var routeExists = false
+
+		subnet, err := subnets.Get(networkingClient, rs.Primary.Attributes["subnet_id"]).Extract()
+		if err == nil {
+
+			var rts = subnet.HostRoutes
+			for _, r := range rts {
+
+				if r.DestinationCIDR == rs.Primary.Attributes["destination_cidr"] && r.NextHop == rs.Primary.Attributes["next_hop"] {
+					routeExists = true
+					break
+				}
+			}
+		}
+
+		if routeExists {
+			return fmt.Errorf("Route still exists")
+		}
+	}
+
+	return nil
+}
+
+const testAccNetworkingV2SubnetRoute_create = `
+resource "openstack_networking_router_v2" "router_1" {
+  name = "router_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  cidr = "192.168.199.0/24"
+  ip_version = 4
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+}
+
+resource "openstack_networking_port_v2" "port_1" {
+  name = "port_1"
+  admin_state_up = "true"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+
+  fixed_ip {
+    subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+    ip_address = "192.168.199.1"
+  }
+}
+
+resource "openstack_networking_router_interface_v2" "int_1" {
+  router_id = "${openstack_networking_router_v2.router_1.id}"
+  port_id = "${openstack_networking_port_v2.port_1.id}"
+}
+
+resource "openstack_networking_subnet_route_v2" "subnet_route_1" {
+  destination_cidr = "10.0.1.0/24"
+  next_hop = "192.168.199.254"
+
+  subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+}
+`
+
+const testAccNetworkingV2SubnetRoute_update = `
+resource "openstack_networking_router_v2" "router_1" {
+  name = "router_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  cidr = "192.168.199.0/24"
+  ip_version = 4
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+}
+
+resource "openstack_networking_port_v2" "port_1" {
+  name = "port_1"
+  admin_state_up = "true"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+
+  fixed_ip {
+    subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+    ip_address = "192.168.199.1"
+  }
+}
+
+resource "openstack_networking_router_interface_v2" "int_1" {
+  router_id = "${openstack_networking_router_v2.router_1.id}"
+  port_id = "${openstack_networking_port_v2.port_1.id}"
+}
+
+resource "openstack_networking_subnet_route_v2" "subnet_route_1" {
+  destination_cidr = "10.0.1.0/24"
+  next_hop = "192.168.199.254"
+
+  subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+}
+
+resource "openstack_networking_subnet_route_v2" "subnet_route_2" {
+  destination_cidr = "10.0.2.0/24"
+  next_hop = "192.168.199.254"
+
+  subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+}
+`
+
+const testAccNetworkingV2SubnetRoute_destroy = `
+resource "openstack_networking_router_v2" "router_1" {
+  name = "router_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  cidr = "192.168.199.0/24"
+  ip_version = 4
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+}
+
+resource "openstack_networking_port_v2" "port_1" {
+  name = "port_1"
+  admin_state_up = "true"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+
+  fixed_ip {
+    subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+    ip_address = "192.168.199.1"
+  }
+}
+
+resource "openstack_networking_router_interface_v2" "int_1" {
+  router_id = "${openstack_networking_router_v2.router_1.id}"
+  port_id = "${openstack_networking_port_v2.port_1.id}"
+}
+`

--- a/openstack/resource_openstack_networking_subnet_v2.go
+++ b/openstack/resource_openstack_networking_subnet_v2.go
@@ -313,7 +313,8 @@ func resourceNetworkingSubnetV2Update(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if d.HasChange("host_routes") {
-		updateOpts.HostRoutes = resourceSubnetHostRoutesV2(d)
+		newHostRoutes := resourceSubnetHostRoutesV2(d)
+		updateOpts.HostRoutes = &newHostRoutes
 	}
 
 	if d.HasChange("enable_dhcp") {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/requests.go
@@ -176,7 +176,7 @@ type UpdateOpts struct {
 	DNSNameservers []string `json:"dns_nameservers,omitempty"`
 
 	// HostRoutes are any static host routes to be set via DHCP.
-	HostRoutes []HostRoute `json:"host_routes,omitempty"`
+	HostRoutes *[]HostRoute `json:"host_routes,omitempty"`
 
 	// EnableDHCP will either enable to disable the DHCP service.
 	EnableDHCP *bool `json:"enable_dhcp,omitempty"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -631,10 +631,10 @@
 			"revisionTime": "2018-04-18T04:52:34Z"
 		},
 		{
-			"checksumSHA1": "8ODTbSq44HuX4vKNSWAuN43km7w=",
+			"checksumSHA1": "oSLCi+kQy0xYTkWi6NalsQKKxn4=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "a3512ad52c42eeed0f51163174ed4cb8f7e8d2ce",
+			"revisionTime": "2018-05-04T15:57:42Z"
 		},
 		{
 			"checksumSHA1": "Q9VHGSztw2B4PmN4kyvY9TcJD6c=",

--- a/website/docs/r/networking_subnet_route_v2.html.markdown
+++ b/website/docs/r/networking_subnet_route_v2.html.markdown
@@ -1,0 +1,74 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_networking_subnet_route_v2"
+sidebar_current: "docs-openstack-resource-networking-subnet-route-v2"
+description: |-
+  Creates a routing entry on a OpenStack V2 subnet.
+---
+
+# openstack\_networking\_subnet\_route\_v2
+
+Creates a routing entry on a OpenStack V2 subnet.
+
+## Example Usage
+
+```hcl
+resource "openstack_networking_router_v2" "router_1" {
+  name           = "router_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_network_v2" "network_1" {
+  name           = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+  cidr       = "192.168.199.0/24"
+  ip_version = 4
+}
+
+resource "openstack_networking_subnet_route_v2" "subnet_route_1" {
+  subnet_id        = "${openstack_networking_subnet_v2.subnet_1.id}"
+  destination_cidr = "10.0.1.0/24"
+  next_hop         = "192.168.199.254"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional) The region in which to obtain the V2 networking client.
+    A networking client is needed to configure a routing entry on a subnet. If omitted, the
+    `region` argument of the provider is used. Changing this creates a new
+    routing entry.
+
+* `subnet_id` - (Required) ID of the subnet this routing entry belongs to. Changing
+    this creates a new routing entry.
+
+* `destination_cidr` - (Required) CIDR block to match on the packet’s destination IP. Changing
+    this creates a new routing entry.
+
+* `next_hop` - (Required) IP address of the next hop gateway.  Changing
+    this creates a new routing entry.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `subnet_id` - See Argument Reference above.
+* `destination_cidr` - See Argument Reference above.
+* `next_hop` - See Argument Reference above.
+
+## Notes
+
+## Import
+
+Routing entries can be imported using a combined ID using the following format: ``<subnet_id>-route-<destination_cidr>-<next_hop>``
+
+```
+$ terraform import openstack_networking_subnet_route_v2.subnet_route_1 686fe248-386c-4f70-9f6c-281607dad079-route-10.0.1.0/24-192.168.199.25
+```

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -176,6 +176,9 @@
             <li<%= sidebar_current("docs-openstack-resource-networking-subnet-v2") %>>
               <a href="/docs/providers/openstack/r/networking_subnet_v2.html">openstack_networking_subnet_v2</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-resource-networking-subnet-route-v2") %>>
+              <a href="/docs/providers/openstack/r/networking_subnet_route_v2.html">openstack_networking_subnet_route_v2</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-resource-networking-subnetpool-v2") %>>
               <a href="/docs/providers/openstack/r/networking_subnetpool_v2.html">openstack_networking_subnetpool_v2</a>
             </li>


### PR DESCRIPTION
Currently, it's not easy to manage multiple routes on a single subnet. 

This resource splits the route management out into a separate resource that can easily be iterated over. 

TODO: 
- [x] Verify tests
- [x] Add docs
- [x] Update Gophercloud `subnets` package.
- [x] Squash commits down