### PR TITLE
New/update blockstorage vendor

### DIFF
--- a/openstack/config.go
+++ b/openstack/config.go
@@ -200,6 +200,13 @@ func (c *Config) blockStorageV2Client(region string) (*gophercloud.ServiceClient
 	})
 }
 
+func (c *Config) blockStorageV3Client(region string) (*gophercloud.ServiceClient, error) {
+	return openstack.NewBlockStorageV3(c.OsClient, gophercloud.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getEndpointType(),
+	})
+}
+
 func (c *Config) computeV2Client(region string) (*gophercloud.ServiceClient, error) {
 	return openstack.NewComputeV2(c.OsClient, gophercloud.EndpointOpts{
 		Region:       c.determineRegion(region),

--- a/openstack/import_openstack_blockstorage_volume_v3_test.go
+++ b/openstack/import_openstack_blockstorage_volume_v3_test.go
@@ -1,0 +1,28 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccBlockStorageV3Volume_importBasic(t *testing.T) {
+	resourceName := "openstack_blockstorage_volume_v3.volume_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBlockStorageV3VolumeDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccBlockStorageV3Volume_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -208,7 +208,9 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"openstack_blockstorage_volume_v1":             resourceBlockStorageVolumeV1(),
 			"openstack_blockstorage_volume_v2":             resourceBlockStorageVolumeV2(),
+			"openstack_blockstorage_volume_v3":             resourceBlockStorageVolumeV3(),
 			"openstack_blockstorage_volume_attach_v2":      resourceBlockStorageVolumeAttachV2(),
+			"openstack_blockstorage_volume_attach_v3":      resourceBlockStorageVolumeAttachV3(),
 			"openstack_compute_flavor_v2":                  resourceComputeFlavorV2(),
 			"openstack_compute_instance_v2":                resourceComputeInstanceV2(),
 			"openstack_compute_keypair_v2":                 resourceComputeKeypairV2(),

--- a/openstack/resource_openstack_blockstorage_volume_attach_v3_test.go
+++ b/openstack/resource_openstack_blockstorage_volume_attach_v3_test.go
@@ -11,45 +11,45 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 )
 
-func TestAccBlockStorageVolumeAttachV3_basic(t *testing.T) {
+func TestAccBlockStorageVolumeAttachV2_basic(t *testing.T) {
 	var va volumes.Attachment
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckBlockStorageVolumeAttachV3Destroy,
+		CheckDestroy: testAccCheckBlockStorageVolumeAttachV2Destroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccBlockStorageVolumeAttachV3_basic,
+				Config: testAccBlockStorageVolumeAttachV2_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageVolumeAttachV3Exists("openstack_blockstorage_volume_attach_v2.va_1", &va),
+					testAccCheckBlockStorageVolumeAttachV2Exists("openstack_blockstorage_volume_attach_v2.va_1", &va),
 				),
 			},
 		},
 	})
 }
 
-func TestAccBlockStorageVolumeAttachV3_timeout(t *testing.T) {
+func TestAccBlockStorageVolumeAttachV2_timeout(t *testing.T) {
 	var va volumes.Attachment
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckBlockStorageVolumeAttachV3Destroy,
+		CheckDestroy: testAccCheckBlockStorageVolumeAttachV2Destroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccBlockStorageVolumeAttachV3_timeout,
+				Config: testAccBlockStorageVolumeAttachV2_timeout,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageVolumeAttachV3Exists("openstack_blockstorage_volume_attach_v2.va_1", &va),
+					testAccCheckBlockStorageVolumeAttachV2Exists("openstack_blockstorage_volume_attach_v2.va_1", &va),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckBlockStorageVolumeAttachV3Destroy(s *terraform.State) error {
+func testAccCheckBlockStorageVolumeAttachV2Destroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	client, err := config.blockStorageV3Client(OS_REGION_NAME)
+	client, err := config.blockStorageV2Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
 	}
@@ -59,7 +59,7 @@ func testAccCheckBlockStorageVolumeAttachV3Destroy(s *terraform.State) error {
 			continue
 		}
 
-		volumeId, attachmentId, err := blockStorageVolumeAttachV3ParseId(rs.Primary.ID)
+		volumeId, attachmentId, err := blockStorageVolumeAttachV2ParseId(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -82,7 +82,7 @@ func testAccCheckBlockStorageVolumeAttachV3Destroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckBlockStorageVolumeAttachV3Exists(n string, va *volumes.Attachment) resource.TestCheckFunc {
+func testAccCheckBlockStorageVolumeAttachV2Exists(n string, va *volumes.Attachment) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -94,12 +94,12 @@ func testAccCheckBlockStorageVolumeAttachV3Exists(n string, va *volumes.Attachme
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		client, err := config.blockStorageV3Client(OS_REGION_NAME)
+		client, err := config.blockStorageV2Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
 		}
 
-		volumeId, attachmentId, err := blockStorageVolumeAttachV3ParseId(rs.Primary.ID)
+		volumeId, attachmentId, err := blockStorageVolumeAttachV2ParseId(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -125,7 +125,7 @@ func testAccCheckBlockStorageVolumeAttachV3Exists(n string, va *volumes.Attachme
 	}
 }
 
-const testAccBlockStorageVolumeAttachV3_basic = `
+const testAccBlockStorageVolumeAttachV2_basic = `
 resource "openstack_blockstorage_volume_v2" "volume_1" {
   name = "volume_1"
   size = 1
@@ -143,7 +143,7 @@ resource "openstack_blockstorage_volume_attach_v2" "va_1" {
 }
 `
 
-const testAccBlockStorageVolumeAttachV3_timeout = `
+const testAccBlockStorageVolumeAttachV2_timeout = `
 resource "openstack_blockstorage_volume_v2" "volume_1" {
   name = "volume_1"
   size = 1

--- a/openstack/resource_openstack_blockstorage_volume_v3.go
+++ b/openstack/resource_openstack_blockstorage_volume_v3.go
@@ -1,0 +1,380 @@
+package openstack
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceBlockStorageVolumeV3() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceBlockStorageVolumeV3Create,
+		Read:   resourceBlockStorageVolumeV3Read,
+		Update: resourceBlockStorageVolumeV3Update,
+		Delete: resourceBlockStorageVolumeV3Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"size": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
+			"availability_zone": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"metadata": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"snapshot_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"source_vol_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"image_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"volume_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"consistency_group_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"source_replica": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"attachment": &schema.Schema{
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_id": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"device": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+				Set: resourceVolumeV3AttachmentHash,
+			},
+		},
+	}
+}
+
+func resourceBlockStorageVolumeV3Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	blockStorageClient, err := config.blockStorageV3Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
+	}
+
+	createOpts := &volumes.CreateOpts{
+		AvailabilityZone:   d.Get("availability_zone").(string),
+		ConsistencyGroupID: d.Get("consistency_group_id").(string),
+		Description:        d.Get("description").(string),
+		ImageID:            d.Get("image_id").(string),
+		Metadata:           resourceContainerMetadataV2(d),
+		Name:               d.Get("name").(string),
+		Size:               d.Get("size").(int),
+		SnapshotID:         d.Get("snapshot_id").(string),
+		SourceReplica:      d.Get("source_replica").(string),
+		SourceVolID:        d.Get("source_vol_id").(string),
+		VolumeType:         d.Get("volume_type").(string),
+	}
+
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	v, err := volumes.Create(blockStorageClient, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack volume: %s", err)
+	}
+	log.Printf("[INFO] Volume ID: %s", v.ID)
+
+	// Wait for the volume to become available.
+	log.Printf(
+		"[DEBUG] Waiting for volume (%s) to become available",
+		v.ID)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"downloading", "creating"},
+		Target:     []string{"available"},
+		Refresh:    VolumeV3StateRefreshFunc(blockStorageClient, v.ID),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf(
+			"Error waiting for volume (%s) to become ready: %s",
+			v.ID, err)
+	}
+
+	// Store the ID now
+	d.SetId(v.ID)
+
+	return resourceBlockStorageVolumeV3Read(d, meta)
+}
+
+func resourceBlockStorageVolumeV3Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	blockStorageClient, err := config.blockStorageV3Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
+	}
+
+	v, err := volumes.Get(blockStorageClient, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "volume")
+	}
+
+	log.Printf("[DEBUG] Retrieved volume %s: %+v", d.Id(), v)
+
+	d.Set("size", v.Size)
+	d.Set("description", v.Description)
+	d.Set("availability_zone", v.AvailabilityZone)
+	d.Set("name", v.Name)
+	d.Set("snapshot_id", v.SnapshotID)
+	d.Set("source_vol_id", v.SourceVolID)
+	d.Set("volume_type", v.VolumeType)
+	d.Set("metadata", v.Metadata)
+	d.Set("region", GetRegion(d, config))
+
+	attachments := make([]map[string]interface{}, len(v.Attachments))
+	for i, attachment := range v.Attachments {
+		attachments[i] = make(map[string]interface{})
+		attachments[i]["id"] = attachment.ID
+		attachments[i]["instance_id"] = attachment.ServerID
+		attachments[i]["device"] = attachment.Device
+		log.Printf("[DEBUG] attachment: %v", attachment)
+	}
+	d.Set("attachment", attachments)
+
+	return nil
+}
+
+func resourceBlockStorageVolumeV3Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	blockStorageClient, err := config.blockStorageV3Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
+	}
+
+	updateOpts := volumes.UpdateOpts{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+	}
+
+	if d.HasChange("metadata") {
+		updateOpts.Metadata = resourceVolumeMetadataV3(d)
+	}
+
+	if d.HasChange("size") {
+		blockStorageClient.Microversion = "3.42"
+		extendOpts := volumeactions.ExtendSizeOpts{d.Get("size").(int)}
+		err = volumeactions.ExtendSize(blockStorageClient, d.Id(), extendOpts).ExtractErr()
+		if err != nil {
+			return fmt.Errorf(
+				"Error extending volume (%s) size (%s)",
+				d.Id(), err)
+		}
+
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{"available", "in-use"},
+			Target:     []string{"available", "in-use"},
+			Refresh:    VolumeV3StateRefreshFunc(blockStorageClient, d.Id()),
+			Timeout:    d.Timeout(schema.TimeoutCreate),
+			Delay:      10 * time.Second,
+			MinTimeout: 3 * time.Second,
+		}
+
+		_, err := stateConf.WaitForState()
+		if err != nil {
+			return fmt.Errorf(
+				"Error waiting for volume (%s) to become ready (%s)",
+				d.Id(), err)
+		}
+
+		return resourceBlockStorageVolumeV3Read(d, meta)
+	}
+
+	_, err = volumes.Update(blockStorageClient, d.Id(), updateOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error updating OpenStack volume: %s", err)
+	}
+
+	return resourceBlockStorageVolumeV3Read(d, meta)
+}
+
+func resourceBlockStorageVolumeV3Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	blockStorageClient, err := config.blockStorageV3Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
+	}
+
+	v, err := volumes.Get(blockStorageClient, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "volume")
+	}
+
+	// make sure this volume is detached from all instances before deleting
+	if len(v.Attachments) > 0 {
+		log.Printf("[DEBUG] detaching volumes")
+		if computeClient, err := config.computeV2Client(GetRegion(d, config)); err != nil {
+			return err
+		} else {
+			for _, volumeAttachment := range v.Attachments {
+				log.Printf("[DEBUG] Attachment: %v", volumeAttachment)
+				if err := volumeattach.Delete(computeClient, volumeAttachment.ServerID, volumeAttachment.ID).ExtractErr(); err != nil {
+					return err
+				}
+			}
+
+			stateConf := &resource.StateChangeConf{
+				Pending:    []string{"in-use", "attaching", "detaching"},
+				Target:     []string{"available"},
+				Refresh:    VolumeV3StateRefreshFunc(blockStorageClient, d.Id()),
+				Timeout:    10 * time.Minute,
+				Delay:      10 * time.Second,
+				MinTimeout: 3 * time.Second,
+			}
+
+			_, err = stateConf.WaitForState()
+			if err != nil {
+				return fmt.Errorf(
+					"Error waiting for volume (%s) to become available: %s",
+					d.Id(), err)
+			}
+		}
+	}
+
+	// It's possible that this volume was used as a boot device and is currently
+	// in a "deleting" state from when the instance was terminated.
+	// If this is true, just move on. It'll eventually delete.
+	if v.Status != "deleting" {
+		if err := volumes.Delete(blockStorageClient, d.Id()).ExtractErr(); err != nil {
+			return CheckDeleted(d, err, "volume")
+		}
+	}
+
+	// Wait for the volume to delete before moving on.
+	log.Printf("[DEBUG] Waiting for volume (%s) to delete", d.Id())
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"deleting", "downloading", "available"},
+		Target:     []string{"deleted"},
+		Refresh:    VolumeV3StateRefreshFunc(blockStorageClient, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf(
+			"Error waiting for volume (%s) to delete: %s",
+			d.Id(), err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceVolumeMetadataV3(d *schema.ResourceData) map[string]string {
+	m := make(map[string]string)
+	for key, val := range d.Get("metadata").(map[string]interface{}) {
+		m[key] = val.(string)
+	}
+	return m
+}
+
+// VolumeV3StateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
+// an OpenStack volume.
+func VolumeV3StateRefreshFunc(client *gophercloud.ServiceClient, volumeID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		v, err := volumes.Get(client, volumeID).Extract()
+		if err != nil {
+			if _, ok := err.(gophercloud.ErrDefault404); ok {
+				return v, "deleted", nil
+			}
+			return nil, "", err
+		}
+
+		if v.Status == "error" {
+			return v, v.Status, fmt.Errorf("There was an error creating the volume. " +
+				"Please check with your cloud admin or check the Block Storage " +
+				"API logs to see why this error occurred.")
+		}
+
+		return v, v.Status, nil
+	}
+}
+
+func resourceVolumeV3AttachmentHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	if m["instance_id"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["instance_id"].(string)))
+	}
+	return hashcode.String(buf.String())
+}

--- a/openstack/resource_openstack_blockstorage_volume_v3_test.go
+++ b/openstack/resource_openstack_blockstorage_volume_v3_test.go
@@ -1,0 +1,219 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
+)
+
+func TestAccBlockStorageV3Volume_basic(t *testing.T) {
+	var volume volumes.Volume
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBlockStorageV3VolumeDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccBlockStorageV3Volume_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBlockStorageV3VolumeExists("openstack_blockstorage_volume_v2.volume_1", &volume),
+					testAccCheckBlockStorageV3VolumeMetadata(&volume, "foo", "bar"),
+					resource.TestCheckResourceAttr(
+						"openstack_blockstorage_volume_v2.volume_1", "name", "volume_1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccBlockStorageV3Volume_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBlockStorageV3VolumeExists("openstack_blockstorage_volume_v2.volume_1", &volume),
+					testAccCheckBlockStorageV3VolumeMetadata(&volume, "foo", "bar"),
+					resource.TestCheckResourceAttr(
+						"openstack_blockstorage_volume_v2.volume_1", "name", "volume_1-updated"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBlockStorageV3Volume_image(t *testing.T) {
+	var volume volumes.Volume
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBlockStorageV3VolumeDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccBlockStorageV3Volume_image,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBlockStorageV3VolumeExists("openstack_blockstorage_volume_v2.volume_1", &volume),
+					resource.TestCheckResourceAttr(
+						"openstack_blockstorage_volume_v2.volume_1", "name", "volume_1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBlockStorageV3Volume_timeout(t *testing.T) {
+	var volume volumes.Volume
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBlockStorageV3VolumeDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccBlockStorageV3Volume_timeout,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBlockStorageV3VolumeExists("openstack_blockstorage_volume_v2.volume_1", &volume),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckBlockStorageV3VolumeDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	blockStorageClient, err := config.blockStorageV3Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "openstack_blockstorage_volume_v2" {
+			continue
+		}
+
+		_, err := volumes.Get(blockStorageClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Volume still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckBlockStorageV3VolumeExists(n string, volume *volumes.Volume) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		blockStorageClient, err := config.blockStorageV3Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
+		}
+
+		found, err := volumes.Get(blockStorageClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("Volume not found")
+		}
+
+		*volume = *found
+
+		return nil
+	}
+}
+
+func testAccCheckBlockStorageV3VolumeDoesNotExist(t *testing.T, n string, volume *volumes.Volume) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*Config)
+		blockStorageClient, err := config.blockStorageV3Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
+		}
+
+		_, err = volumes.Get(blockStorageClient, volume.ID).Extract()
+		if err != nil {
+			if _, ok := err.(gophercloud.ErrDefault404); ok {
+				return nil
+			}
+			return err
+		}
+
+		return fmt.Errorf("Volume still exists")
+	}
+}
+
+func testAccCheckBlockStorageV3VolumeMetadata(
+	volume *volumes.Volume, k string, v string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if volume.Metadata == nil {
+			return fmt.Errorf("No metadata")
+		}
+
+		for key, value := range volume.Metadata {
+			if k != key {
+				continue
+			}
+
+			if v == value {
+				return nil
+			}
+
+			return fmt.Errorf("Bad value for %s: %s", k, value)
+		}
+
+		return fmt.Errorf("Metadata not found: %s", k)
+	}
+}
+
+const testAccBlockStorageV3Volume_basic = `
+resource "openstack_blockstorage_volume_v2" "volume_1" {
+  name = "volume_1"
+  description = "first test volume"
+  metadata {
+    foo = "bar"
+  }
+  size = 1
+}
+`
+
+const testAccBlockStorageV3Volume_update = `
+resource "openstack_blockstorage_volume_v2" "volume_1" {
+  name = "volume_1-updated"
+  description = "first test volume"
+  metadata {
+    foo = "bar"
+  }
+  size = 1
+}
+`
+
+var testAccBlockStorageV3Volume_image = fmt.Sprintf(`
+resource "openstack_blockstorage_volume_v2" "volume_1" {
+  name = "volume_1"
+  size = 5
+  image_id = "%s"
+}
+`, OS_IMAGE_ID)
+
+const testAccBlockStorageV3Volume_timeout = `
+resource "openstack_blockstorage_volume_v2" "volume_1" {
+  name = "volume_1"
+  description = "first test volume"
+  size = 1
+
+  timeouts {
+    create = "5m"
+    delete = "5m"
+  }
+}
+`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/doc.go
@@ -1,5 +1,86 @@
-// Package volumeactions provides information and interaction with volumes in the
-// OpenStack Block Storage service. A volume is a detachable block storage
-// device, akin to a USB hard drive. It can only be attached to one instance at
-// a time.
+/*
+Package volumeactions provides information and interaction with volumes in the
+OpenStack Block Storage service. A volume is a detachable block storage
+device, akin to a USB hard drive.
+
+Example of Attaching a Volume to an Instance
+
+	attachOpts := volumeactions.AttachOpts{
+		MountPoint:   "/mnt",
+		Mode:         "rw",
+		InstanceUUID: server.ID,
+	}
+
+	err := volumeactions.Attach(client, volume.ID, attachOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+	detachOpts := volumeactions.DetachOpts{
+		AttachmentID: volume.Attachments[0].AttachmentID,
+	}
+
+	err = volumeactions.Detach(client, volume.ID, detachOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+
+Example of Creating an Image from a Volume
+
+	uploadImageOpts := volumeactions.UploadImageOpts{
+		ImageName: "my_vol",
+		Force:     true,
+	}
+
+	volumeImage, err := volumeactions.UploadImage(client, volume.ID, uploadImageOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", volumeImage)
+
+Example of Extending a Volume's Size
+
+	extendOpts := volumeactions.ExtendSizeOpts{
+		NewSize: 100,
+	}
+
+	err := volumeactions.ExtendSize(client, volume.ID, extendOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Initializing a Volume Connection
+
+	connectOpts := &volumeactions.InitializeConnectionOpts{
+		IP:        "127.0.0.1",
+		Host:      "stack",
+		Initiator: "iqn.1994-05.com.redhat:17cf566367d2",
+		Multipath: gophercloud.Disabled,
+		Platform:  "x86_64",
+		OSType:    "linux2",
+	}
+
+	connectionInfo, err := volumeactions.InitializeConnection(client, volume.ID, connectOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", connectionInfo["data"])
+
+	terminateOpts := &volumeactions.InitializeConnectionOpts{
+		IP:        "127.0.0.1",
+		Host:      "stack",
+		Initiator: "iqn.1994-05.com.redhat:17cf566367d2",
+		Multipath: gophercloud.Disabled,
+		Platform:  "x86_64",
+		OSType:    "linux2",
+	}
+
+	err = volumeactions.TerminateConnection(client, volume.ID, terminateOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
 package volumeactions

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/requests.go
@@ -13,7 +13,7 @@ type AttachOptsBuilder interface {
 // AttachMode describes the attachment mode for volumes.
 type AttachMode string
 
-// These constants determine how a volume is attached
+// These constants determine how a volume is attached.
 const (
 	ReadOnly  AttachMode = "ro"
 	ReadWrite AttachMode = "rw"
@@ -21,13 +21,16 @@ const (
 
 // AttachOpts contains options for attaching a Volume.
 type AttachOpts struct {
-	// The mountpoint of this volume
+	// The mountpoint of this volume.
 	MountPoint string `json:"mountpoint,omitempty"`
-	// The nova instance ID, can't set simultaneously with HostName
+
+	// The nova instance ID, can't set simultaneously with HostName.
 	InstanceUUID string `json:"instance_uuid,omitempty"`
-	// The hostname of baremetal host, can't set simultaneously with InstanceUUID
+
+	// The hostname of baremetal host, can't set simultaneously with InstanceUUID.
 	HostName string `json:"host_name,omitempty"`
-	// Mount mode of this volume
+
+	// Mount mode of this volume.
 	Mode AttachMode `json:"mode,omitempty"`
 }
 
@@ -44,16 +47,16 @@ func Attach(client *gophercloud.ServiceClient, id string, opts AttachOptsBuilder
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(attachURL(client, id), b, nil, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
 	return
 }
 
-// BeginDetach will mark the volume as detaching
+// BeginDetach will mark the volume as detaching.
 func BeginDetaching(client *gophercloud.ServiceClient, id string) (r BeginDetachingResult) {
 	b := map[string]interface{}{"os-begin_detaching": make(map[string]interface{})}
-	_, r.Err = client.Post(beginDetachingURL(client, id), b, nil, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
 	return
@@ -65,7 +68,9 @@ type DetachOptsBuilder interface {
 	ToVolumeDetachMap() (map[string]interface{}, error)
 }
 
+// DetachOpts contains options for detaching a Volume.
 type DetachOpts struct {
+	// AttachmentID is the ID of the attachment between a volume and instance.
 	AttachmentID string `json:"attachment_id,omitempty"`
 }
 
@@ -75,32 +80,32 @@ func (opts DetachOpts) ToVolumeDetachMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "os-detach")
 }
 
-// Detach will detach a volume based on volume id.
+// Detach will detach a volume based on volume ID.
 func Detach(client *gophercloud.ServiceClient, id string, opts DetachOptsBuilder) (r DetachResult) {
 	b, err := opts.ToVolumeDetachMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(detachURL(client, id), b, nil, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
 	return
 }
 
-// Reserve will reserve a volume based on volume id.
+// Reserve will reserve a volume based on volume ID.
 func Reserve(client *gophercloud.ServiceClient, id string) (r ReserveResult) {
 	b := map[string]interface{}{"os-reserve": make(map[string]interface{})}
-	_, r.Err = client.Post(reserveURL(client, id), b, nil, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 201, 202},
 	})
 	return
 }
 
-// Unreserve will unreserve a volume based on volume id.
+// Unreserve will unreserve a volume based on volume ID.
 func Unreserve(client *gophercloud.ServiceClient, id string) (r UnreserveResult) {
 	b := map[string]interface{}{"os-unreserve": make(map[string]interface{})}
-	_, r.Err = client.Post(unreserveURL(client, id), b, nil, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 201, 202},
 	})
 	return
@@ -113,6 +118,8 @@ type InitializeConnectionOptsBuilder interface {
 }
 
 // InitializeConnectionOpts hosts options for InitializeConnection.
+// The fields are specific to the storage driver in use and the destination
+// attachment.
 type InitializeConnectionOpts struct {
 	IP        string   `json:"ip,omitempty"`
 	Host      string   `json:"host,omitempty"`
@@ -131,14 +138,14 @@ func (opts InitializeConnectionOpts) ToVolumeInitializeConnectionMap() (map[stri
 	return map[string]interface{}{"os-initialize_connection": b}, err
 }
 
-// InitializeConnection initializes iscsi connection.
+// InitializeConnection initializes an iSCSI connection by volume ID.
 func InitializeConnection(client *gophercloud.ServiceClient, id string, opts InitializeConnectionOptsBuilder) (r InitializeConnectionResult) {
 	b, err := opts.ToVolumeInitializeConnectionMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(initializeConnectionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 201, 202},
 	})
 	return
@@ -169,14 +176,14 @@ func (opts TerminateConnectionOpts) ToVolumeTerminateConnectionMap() (map[string
 	return map[string]interface{}{"os-terminate_connection": b}, err
 }
 
-// TerminateConnection terminates iscsi connection.
+// TerminateConnection terminates an iSCSI connection by volume ID.
 func TerminateConnection(client *gophercloud.ServiceClient, id string, opts TerminateConnectionOptsBuilder) (r TerminateConnectionResult) {
 	b, err := opts.ToVolumeTerminateConnectionMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(teminateConnectionURL(client, id), b, nil, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
 	return
@@ -188,10 +195,10 @@ type ExtendSizeOptsBuilder interface {
 	ToVolumeExtendSizeMap() (map[string]interface{}, error)
 }
 
-// ExtendSizeOpts contain options for extending the size of an existing Volume. This object is passed
-// to the volumes.ExtendSize function.
+// ExtendSizeOpts contains options for extending the size of an existing Volume.
+// This object is passed to the volumes.ExtendSize function.
 type ExtendSizeOpts struct {
-	// NewSize is the new size of the volume, in GB
+	// NewSize is the new size of the volume, in GB.
 	NewSize int `json:"new_size" required:"true"`
 }
 
@@ -209,7 +216,7 @@ func ExtendSize(client *gophercloud.ServiceClient, id string, opts ExtendSizeOpt
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(extendSizeURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
 	return
@@ -225,11 +232,14 @@ type UploadImageOptsBuilder interface {
 type UploadImageOpts struct {
 	// Container format, may be bare, ofv, ova, etc.
 	ContainerFormat string `json:"container_format,omitempty"`
+
 	// Disk format, may be raw, qcow2, vhd, vdi, vmdk, etc.
 	DiskFormat string `json:"disk_format,omitempty"`
-	// The name of image that will be stored in glance
+
+	// The name of image that will be stored in glance.
 	ImageName string `json:"image_name,omitempty"`
-	// Force image creation, usable if volume attached to instance
+
+	// Force image creation, usable if volume attached to instance.
 	Force bool `json:"force,omitempty"`
 }
 
@@ -239,15 +249,21 @@ func (opts UploadImageOpts) ToVolumeUploadImageMap() (map[string]interface{}, er
 	return gophercloud.BuildRequestBody(opts, "os-volume_upload_image")
 }
 
-// UploadImage will upload image base on the values in UploadImageOptsBuilder
+// UploadImage will upload an image based on the values in UploadImageOptsBuilder.
 func UploadImage(client *gophercloud.ServiceClient, id string, opts UploadImageOptsBuilder) (r UploadImageResult) {
 	b, err := opts.ToVolumeUploadImageMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(uploadURL(client, id), b, nil, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
+	return
+}
+
+// ForceDelete will delete the volume regardless of state.
+func ForceDelete(client *gophercloud.ServiceClient, id string) (r ForceDeleteResult) {
+	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"os-force_delete": ""}, nil, nil)
 	return
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/results.go
@@ -1,48 +1,68 @@
 package volumeactions
 
-import "github.com/gophercloud/gophercloud"
+import (
+	"encoding/json"
+	"time"
 
-// AttachResult contains the response body and error from a Get request.
+	"github.com/gophercloud/gophercloud"
+)
+
+// AttachResult contains the response body and error from an Attach request.
 type AttachResult struct {
 	gophercloud.ErrResult
 }
 
-// BeginDetachingResult contains the response body and error from a Get request.
+// BeginDetachingResult contains the response body and error from a BeginDetach
+// request.
 type BeginDetachingResult struct {
 	gophercloud.ErrResult
 }
 
-// DetachResult contains the response body and error from a Get request.
+// DetachResult contains the response body and error from a Detach request.
 type DetachResult struct {
 	gophercloud.ErrResult
 }
 
-// UploadImageResult contains the response body and error from a UploadImage request.
+// UploadImageResult contains the response body and error from an UploadImage
+// request.
 type UploadImageResult struct {
-	gophercloud.ErrResult
+	gophercloud.Result
 }
 
-// ReserveResult contains the response body and error from a Get request.
+// ReserveResult contains the response body and error from a Reserve request.
 type ReserveResult struct {
 	gophercloud.ErrResult
 }
 
-// UnreserveResult contains the response body and error from a Get request.
+// UnreserveResult contains the response body and error from an Unreserve
+// request.
 type UnreserveResult struct {
 	gophercloud.ErrResult
 }
 
-// TerminateConnectionResult contains the response body and error from a Get request.
+// TerminateConnectionResult contains the response body and error from a
+// TerminateConnection request.
 type TerminateConnectionResult struct {
 	gophercloud.ErrResult
 }
 
-type commonResult struct {
+// InitializeConnectionResult contains the response body and error from an
+// InitializeConnection request.
+type InitializeConnectionResult struct {
 	gophercloud.Result
 }
 
-// Extract will get the Volume object out of the commonResult object.
-func (r commonResult) Extract() (map[string]interface{}, error) {
+// ExtendSizeResult contains the response body and error from an ExtendSize request.
+type ExtendSizeResult struct {
+	gophercloud.ErrResult
+}
+
+// Extract will get the connection information out of the
+// InitializeConnectionResult object.
+//
+// This will be a generic map[string]interface{} and the results will be
+// dependent on the type of connection made.
+func (r InitializeConnectionResult) Extract() (map[string]interface{}, error) {
 	var s struct {
 		ConnectionInfo map[string]interface{} `json:"connection_info"`
 	}
@@ -50,12 +70,122 @@ func (r commonResult) Extract() (map[string]interface{}, error) {
 	return s.ConnectionInfo, err
 }
 
-// InitializeConnectionResult contains the response body and error from a Get request.
-type InitializeConnectionResult struct {
-	commonResult
+// ImageVolumeType contains volume type information obtained from UploadImage
+// action.
+type ImageVolumeType struct {
+	// The ID of a volume type.
+	ID string `json:"id"`
+
+	// Human-readable display name for the volume type.
+	Name string `json:"name"`
+
+	// Human-readable description for the volume type.
+	Description string `json:"display_description"`
+
+	// Flag for public access.
+	IsPublic bool `json:"is_public"`
+
+	// Extra specifications for volume type.
+	ExtraSpecs map[string]interface{} `json:"extra_specs"`
+
+	// ID of quality of service specs.
+	QosSpecsID string `json:"qos_specs_id"`
+
+	// Flag for deletion status of volume type.
+	Deleted bool `json:"deleted"`
+
+	// The date when volume type was deleted.
+	DeletedAt time.Time `json:"-"`
+
+	// The date when volume type was created.
+	CreatedAt time.Time `json:"-"`
+
+	// The date when this volume was last updated.
+	UpdatedAt time.Time `json:"-"`
 }
 
-// ExtendSizeResult contains the response body and error from an ExtendSize request.
-type ExtendSizeResult struct {
+func (r *ImageVolumeType) UnmarshalJSON(b []byte) error {
+	type tmp ImageVolumeType
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+		DeletedAt gophercloud.JSONRFC3339MilliNoZ `json:"deleted_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = ImageVolumeType(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+	r.DeletedAt = time.Time(s.DeletedAt)
+
+	return err
+}
+
+// VolumeImage contains information about volume uploaded to an image service.
+type VolumeImage struct {
+	// The ID of a volume an image is created from.
+	VolumeID string `json:"id"`
+
+	// Container format, may be bare, ofv, ova, etc.
+	ContainerFormat string `json:"container_format"`
+
+	// Disk format, may be raw, qcow2, vhd, vdi, vmdk, etc.
+	DiskFormat string `json:"disk_format"`
+
+	// Human-readable description for the volume.
+	Description string `json:"display_description"`
+
+	// The ID of the created image.
+	ImageID string `json:"image_id"`
+
+	// Human-readable display name for the image.
+	ImageName string `json:"image_name"`
+
+	// Size of the volume in GB.
+	Size int `json:"size"`
+
+	// Current status of the volume.
+	Status string `json:"status"`
+
+	// The date when this volume was last updated.
+	UpdatedAt time.Time `json:"-"`
+
+	// Volume type object of used volume.
+	VolumeType ImageVolumeType `json:"volume_type"`
+}
+
+func (r *VolumeImage) UnmarshalJSON(b []byte) error {
+	type tmp VolumeImage
+	var s struct {
+		tmp
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = VolumeImage(s.tmp)
+
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return err
+}
+
+// Extract will get an object with info about the uploaded image out of the
+// UploadImageResult object.
+func (r UploadImageResult) Extract() (VolumeImage, error) {
+	var s struct {
+		VolumeImage VolumeImage `json:"os-volume_upload_image"`
+	}
+	err := r.ExtractInto(&s)
+	return s.VolumeImage, err
+}
+
+// ForceDeleteResult contains the response body and error from a ForceDelete request.
+type ForceDeleteResult struct {
 	gophercloud.ErrResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/urls.go
@@ -2,38 +2,6 @@ package volumeactions
 
 import "github.com/gophercloud/gophercloud"
 
-func attachURL(c *gophercloud.ServiceClient, id string) string {
+func actionURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("volumes", id, "action")
-}
-
-func beginDetachingURL(c *gophercloud.ServiceClient, id string) string {
-	return attachURL(c, id)
-}
-
-func detachURL(c *gophercloud.ServiceClient, id string) string {
-	return attachURL(c, id)
-}
-
-func uploadURL(c *gophercloud.ServiceClient, id string) string {
-	return attachURL(c, id)
-}
-
-func reserveURL(c *gophercloud.ServiceClient, id string) string {
-	return attachURL(c, id)
-}
-
-func unreserveURL(c *gophercloud.ServiceClient, id string) string {
-	return attachURL(c, id)
-}
-
-func initializeConnectionURL(c *gophercloud.ServiceClient, id string) string {
-	return attachURL(c, id)
-}
-
-func teminateConnectionURL(c *gophercloud.ServiceClient, id string) string {
-	return attachURL(c, id)
-}
-
-func extendSizeURL(c *gophercloud.ServiceClient, id string) string {
-	return attachURL(c, id)
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/doc.go
@@ -1,0 +1,5 @@
+// Package snapshots provides information and interaction with snapshots in the
+// OpenStack Block Storage service. A snapshot is a point in time copy of the
+// data contained in an external storage volume, and can be controlled
+// programmatically.
+package snapshots

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/requests.go
@@ -1,0 +1,181 @@
+package snapshots
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToSnapshotCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains options for creating a Snapshot. This object is passed to
+// the snapshots.Create function. For more information about these parameters,
+// see the Snapshot object.
+type CreateOpts struct {
+	VolumeID    string            `json:"volume_id" required:"true"`
+	Force       bool              `json:"force,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// ToSnapshotCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToSnapshotCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "snapshot")
+}
+
+// Create will create a new Snapshot based on the values in CreateOpts. To
+// extract the Snapshot object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToSnapshotCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// Delete will delete the existing Snapshot with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}
+
+// Get retrieves the Snapshot with the provided ID. To extract the Snapshot
+// object from the response, call the Extract method on the GetResult.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToSnapshotListQuery() (string, error)
+}
+
+type ListOpts struct {
+	// AllTenants will retrieve snapshots of all tenants/projects.
+	AllTenants bool `q:"all_tenants"`
+
+	// Name will filter by the specified snapshot name.
+	Name string `q:"name"`
+
+	// Status will filter by the specified status.
+	Status string `q:"status"`
+
+	// TenantID will filter by a specific tenant/project ID.
+	// Setting AllTenants is required to use this.
+	TenantID string `q:"project_id"`
+
+	// VolumeID will filter by a specified volume ID.
+	VolumeID string `q:"volume_id"`
+
+	// Comma-separated list of sort keys and optional sort directions in the
+	// form of <key>[:<direction>].
+	Sort string `q:"sort"`
+
+	// Requests a page size of items.
+	Limit int `q:"limit"`
+
+	// Used in conjunction with limit to return a slice of items.
+	Offset int `q:"offset"`
+
+	// The ID of the last-seen item.
+	Marker string `q:"marker"`
+}
+
+// ToSnapshotListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToSnapshotListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns Snapshots optionally limited by the conditions provided in
+// ListOpts.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToSnapshotListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return SnapshotPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// UpdateMetadataOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateMetadataOptsBuilder interface {
+	ToSnapshotUpdateMetadataMap() (map[string]interface{}, error)
+}
+
+// UpdateMetadataOpts contain options for updating an existing Snapshot. This
+// object is passed to the snapshots.Update function. For more information
+// about the parameters, see the Snapshot object.
+type UpdateMetadataOpts struct {
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// ToSnapshotUpdateMetadataMap assembles a request body based on the contents of
+// an UpdateMetadataOpts.
+func (opts UpdateMetadataOpts) ToSnapshotUpdateMetadataMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// UpdateMetadata will update the Snapshot with provided information. To
+// extract the updated Snapshot from the response, call the ExtractMetadata
+// method on the UpdateMetadataResult.
+func UpdateMetadata(client *gophercloud.ServiceClient, id string, opts UpdateMetadataOptsBuilder) (r UpdateMetadataResult) {
+	b, err := opts.ToSnapshotUpdateMetadataMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateMetadataURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// IDFromName is a convienience function that returns a snapshot's ID given its name.
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+	pages, err := List(client, nil).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractSnapshots(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "snapshot"}
+	case 1:
+		return id, nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "snapshot"}
+	}
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/results.go
@@ -1,0 +1,132 @@
+package snapshots
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Snapshot contains all the information associated with a Cinder Snapshot.
+type Snapshot struct {
+	// Unique identifier.
+	ID string `json:"id"`
+
+	// Date created.
+	CreatedAt time.Time `json:"-"`
+
+	// Date updated.
+	UpdatedAt time.Time `json:"-"`
+
+	// Display name.
+	Name string `json:"name"`
+
+	// Display description.
+	Description string `json:"description"`
+
+	// ID of the Volume from which this Snapshot was created.
+	VolumeID string `json:"volume_id"`
+
+	// Currect status of the Snapshot.
+	Status string `json:"status"`
+
+	// Size of the Snapshot, in GB.
+	Size int `json:"size"`
+
+	// User-defined key-value pairs.
+	Metadata map[string]string `json:"metadata"`
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// SnapshotPage is a pagination.Pager that is returned from a call to the List function.
+type SnapshotPage struct {
+	pagination.LinkedPageBase
+}
+
+// UnmarshalJSON converts our JSON API response into our snapshot struct
+func (r *Snapshot) UnmarshalJSON(b []byte) error {
+	type tmp Snapshot
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Snapshot(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return err
+}
+
+// IsEmpty returns true if a SnapshotPage contains no Snapshots.
+func (r SnapshotPage) IsEmpty() (bool, error) {
+	volumes, err := ExtractSnapshots(r)
+	return len(volumes) == 0, err
+}
+
+func (page SnapshotPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"snapshots_links"`
+	}
+	err := page.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// ExtractSnapshots extracts and returns Snapshots. It is used while iterating over a snapshots.List call.
+func ExtractSnapshots(r pagination.Page) ([]Snapshot, error) {
+	var s struct {
+		Snapshots []Snapshot `json:"snapshots"`
+	}
+	err := (r.(SnapshotPage)).ExtractInto(&s)
+	return s.Snapshots, err
+}
+
+// UpdateMetadataResult contains the response body and error from an UpdateMetadata request.
+type UpdateMetadataResult struct {
+	commonResult
+}
+
+// ExtractMetadata returns the metadata from a response from snapshots.UpdateMetadata.
+func (r UpdateMetadataResult) ExtractMetadata() (map[string]interface{}, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	m := r.Body.(map[string]interface{})["metadata"]
+	return m.(map[string]interface{}), nil
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the Snapshot object out of the commonResult object.
+func (r commonResult) Extract() (*Snapshot, error) {
+	var s struct {
+		Snapshot *Snapshot `json:"snapshot"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Snapshot, err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/urls.go
@@ -1,0 +1,27 @@
+package snapshots
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("snapshots")
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("snapshots", id)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return createURL(c)
+}
+
+func metadataURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("snapshots", id, "metadata")
+}
+
+func updateMetadataURL(c *gophercloud.ServiceClient, id string) string {
+	return metadataURL(c, id)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/util.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/util.go
@@ -1,0 +1,22 @@
+package snapshots
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// WaitForStatus will continually poll the resource, checking for a particular
+// status. It will do this for the amount of seconds defined.
+func WaitForStatus(c *gophercloud.ServiceClient, id, status string, secs int) error {
+	return gophercloud.WaitFor(secs, func() (bool, error) {
+		current, err := Get(c, id).Extract()
+		if err != nil {
+			return false, err
+		}
+
+		if current.Status == status {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/doc.go
@@ -1,0 +1,5 @@
+// Package volumes provides information and interaction with volumes in the
+// OpenStack Block Storage service. A volume is a detachable block storage
+// device, akin to a USB hard drive. It can only be attached to one instance at
+// a time.
+package volumes

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/requests.go
@@ -1,0 +1,202 @@
+package volumes
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToVolumeCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains options for creating a Volume. This object is passed to
+// the volumes.Create function. For more information about these parameters,
+// see the Volume object.
+type CreateOpts struct {
+	// The size of the volume, in GB
+	Size int `json:"size" required:"true"`
+	// The availability zone
+	AvailabilityZone string `json:"availability_zone,omitempty"`
+	// ConsistencyGroupID is the ID of a consistency group
+	ConsistencyGroupID string `json:"consistencygroup_id,omitempty"`
+	// The volume description
+	Description string `json:"description,omitempty"`
+	// One or more metadata key and value pairs to associate with the volume
+	Metadata map[string]string `json:"metadata,omitempty"`
+	// The volume name
+	Name string `json:"name,omitempty"`
+	// the ID of the existing volume snapshot
+	SnapshotID string `json:"snapshot_id,omitempty"`
+	// SourceReplica is a UUID of an existing volume to replicate with
+	SourceReplica string `json:"source_replica,omitempty"`
+	// the ID of the existing volume
+	SourceVolID string `json:"source_volid,omitempty"`
+	// The ID of the image from which you want to create the volume.
+	// Required to create a bootable volume.
+	ImageID string `json:"imageRef,omitempty"`
+	// The associated volume type
+	VolumeType string `json:"volume_type,omitempty"`
+}
+
+// ToVolumeCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToVolumeCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "volume")
+}
+
+// Create will create a new Volume based on the values in CreateOpts. To extract
+// the Volume object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToVolumeCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// Delete will delete the existing Volume with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}
+
+// Get retrieves the Volume with the provided ID. To extract the Volume object
+// from the response, call the Extract method on the GetResult.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToVolumeListQuery() (string, error)
+}
+
+// ListOpts holds options for listing Volumes. It is passed to the volumes.List
+// function.
+type ListOpts struct {
+	// AllTenants will retrieve volumes of all tenants/projects.
+	AllTenants bool `q:"all_tenants"`
+
+	// Metadata will filter results based on specified metadata.
+	Metadata map[string]string `q:"metadata"`
+
+	// Name will filter by the specified volume name.
+	Name string `q:"name"`
+
+	// Status will filter by the specified status.
+	Status string `q:"status"`
+
+	// TenantID will filter by a specific tenant/project ID.
+	// Setting AllTenants is required for this.
+	TenantID string `q:"project_id"`
+
+	// Comma-separated list of sort keys and optional sort directions in the
+	// form of <key>[:<direction>].
+	Sort string `q:"sort"`
+
+	// Requests a page size of items.
+	Limit int `q:"limit"`
+
+	// Used in conjunction with limit to return a slice of items.
+	Offset int `q:"offset"`
+
+	// The ID of the last-seen item.
+	Marker string `q:"marker"`
+}
+
+// ToVolumeListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToVolumeListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns Volumes optionally limited by the conditions provided in ListOpts.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToVolumeListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return VolumePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToVolumeUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contain options for updating an existing Volume. This object is passed
+// to the volumes.Update function. For more information about the parameters, see
+// the Volume object.
+type UpdateOpts struct {
+	Name        string            `json:"name,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// ToVolumeUpdateMap assembles a request body based on the contents of an
+// UpdateOpts.
+func (opts UpdateOpts) ToVolumeUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "volume")
+}
+
+// Update will update the Volume with provided information. To extract the updated
+// Volume from the response, call the Extract method on the UpdateResult.
+func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToVolumeUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// IDFromName is a convienience function that returns a server's ID given its name.
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+	pages, err := List(client, nil).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractVolumes(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "volume"}
+	case 1:
+		return id, nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "volume"}
+	}
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/results.go
@@ -1,0 +1,170 @@
+package volumes
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Attachment represents a Volume Attachment record
+type Attachment struct {
+	AttachedAt   time.Time `json:"-"`
+	AttachmentID string    `json:"attachment_id"`
+	Device       string    `json:"device"`
+	HostName     string    `json:"host_name"`
+	ID           string    `json:"id"`
+	ServerID     string    `json:"server_id"`
+	VolumeID     string    `json:"volume_id"`
+}
+
+// UnmarshalJSON is our unmarshalling helper
+func (r *Attachment) UnmarshalJSON(b []byte) error {
+	type tmp Attachment
+	var s struct {
+		tmp
+		AttachedAt gophercloud.JSONRFC3339MilliNoZ `json:"attached_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Attachment(s.tmp)
+
+	r.AttachedAt = time.Time(s.AttachedAt)
+
+	return err
+}
+
+// Volume contains all the information associated with an OpenStack Volume.
+type Volume struct {
+	// Unique identifier for the volume.
+	ID string `json:"id"`
+	// Current status of the volume.
+	Status string `json:"status"`
+	// Size of the volume in GB.
+	Size int `json:"size"`
+	// AvailabilityZone is which availability zone the volume is in.
+	AvailabilityZone string `json:"availability_zone"`
+	// The date when this volume was created.
+	CreatedAt time.Time `json:"-"`
+	// The date when this volume was last updated
+	UpdatedAt time.Time `json:"-"`
+	// Instances onto which the volume is attached.
+	Attachments []Attachment `json:"attachments"`
+	// Human-readable display name for the volume.
+	Name string `json:"name"`
+	// Human-readable description for the volume.
+	Description string `json:"description"`
+	// The type of volume to create, either SATA or SSD.
+	VolumeType string `json:"volume_type"`
+	// The ID of the snapshot from which the volume was created
+	SnapshotID string `json:"snapshot_id"`
+	// The ID of another block storage volume from which the current volume was created
+	SourceVolID string `json:"source_volid"`
+	// Arbitrary key-value pairs defined by the user.
+	Metadata map[string]string `json:"metadata"`
+	// UserID is the id of the user who created the volume.
+	UserID string `json:"user_id"`
+	// Indicates whether this is a bootable volume.
+	Bootable string `json:"bootable"`
+	// Encrypted denotes if the volume is encrypted.
+	Encrypted bool `json:"encrypted"`
+	// ReplicationStatus is the status of replication.
+	ReplicationStatus string `json:"replication_status"`
+	// ConsistencyGroupID is the consistency group ID.
+	ConsistencyGroupID string `json:"consistencygroup_id"`
+	// Multiattach denotes if the volume is multi-attach capable.
+	Multiattach bool `json:"multiattach"`
+}
+
+// UnmarshalJSON another unmarshalling function
+func (r *Volume) UnmarshalJSON(b []byte) error {
+	type tmp Volume
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Volume(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return err
+}
+
+// VolumePage is a pagination.pager that is returned from a call to the List function.
+type VolumePage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if a ListResult contains no Volumes.
+func (r VolumePage) IsEmpty() (bool, error) {
+	volumes, err := ExtractVolumes(r)
+	return len(volumes) == 0, err
+}
+
+func (page VolumePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"volumes_links"`
+	}
+	err := page.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// ExtractVolumes extracts and returns Volumes. It is used while iterating over a volumes.List call.
+func ExtractVolumes(r pagination.Page) ([]Volume, error) {
+	var s []Volume
+	err := ExtractVolumesInto(r, &s)
+	return s, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the Volume object out of the commonResult object.
+func (r commonResult) Extract() (*Volume, error) {
+	var s Volume
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractInto converts our response data into a volume struct
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "volume")
+}
+
+// ExtractVolumesInto similar to ExtractInto but operates on a `list` of volumes
+func ExtractVolumesInto(r pagination.Page, v interface{}) error {
+	return r.(VolumePage).Result.ExtractIntoSlicePtr(v, "volumes")
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult contains the response body and error from an Update request.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/urls.go
@@ -1,0 +1,23 @@
+package volumes
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("volumes")
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("volumes", "detail")
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("volumes", id)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/util.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/util.go
@@ -1,0 +1,22 @@
+package volumes
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// WaitForStatus will continually poll the resource, checking for a particular
+// status. It will do this for the amount of seconds defined.
+func WaitForStatus(c *gophercloud.ServiceClient, id, status string, secs int) error {
+	return gophercloud.WaitFor(secs, func() (bool, error) {
+		current, err := Get(c, id).Extract()
+		if err != nil {
+			return false, err
+		}
+
+		if current.Status == status {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/client.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/client.go
@@ -308,6 +308,12 @@ func NewBlockStorageV2(client *gophercloud.ProviderClient, eo gophercloud.Endpoi
 	return initClientOpts(client, eo, "volumev2")
 }
 
+// NewBlockStorageV3 creates a ServiceClient that may be used to access the v3
+// block storage service.
+func NewBlockStorageV3(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "volumev3")
+}
+
 // NewSharedFileSystemV2 creates a ServiceClient that may be used to access the
 // v2 shared file system service.
 func NewSharedFileSystemV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -325,10 +325,16 @@
 			"revisionTime": "2017-11-03T04:02:05Z"
 		},
 		{
-			"checksumSHA1": "f2hdkOhYmmO2ljNtr+OThK8VAEI=",
+			"checksumSHA1": "EObQxWsRxmQqEbAjYc9it5Gr7Pk=",
+			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions",
+			"revision": "31405f70e8aafdca5f9b40d0c85281c0fdf9544f",
+			"revisionTime": "2018-05-11T01:57:25Z"
+		},
+		{
+			"checksumSHA1": "8YtBD+Um7I8ee1Xf1ZAWu74eP7w=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "31405f70e8aafdca5f9b40d0c85281c0fdf9544f",
+			"revisionTime": "2018-05-11T01:57:25Z"
 		},
 		{
 			"checksumSHA1": "9DTfNt/B4aZWXEmTNqXU5rNrrDc=",
@@ -341,6 +347,18 @@
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes",
 			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
 			"revisionTime": "2017-03-10T01:59:53Z"
+		},
+		{
+			"checksumSHA1": "DNPNiVPlFHTfLmRXx6VrU9TF5RI=",
+			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots",
+			"revision": "31405f70e8aafdca5f9b40d0c85281c0fdf9544f",
+			"revisionTime": "2018-05-11T01:57:25Z"
+		},
+		{
+			"checksumSHA1": "vqXNCd2My0y/5tPC/Bs79uf6Q4E=",
+			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes",
+			"revision": "31405f70e8aafdca5f9b40d0c85281c0fdf9544f",
+			"revisionTime": "2018-05-11T01:57:25Z"
 		},
 		{
 			"checksumSHA1": "y49Ur726Juznj85+23ZgqMvehgg=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -327,14 +327,14 @@
 		{
 			"checksumSHA1": "EObQxWsRxmQqEbAjYc9it5Gr7Pk=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions",
-			"revision": "31405f70e8aafdca5f9b40d0c85281c0fdf9544f",
-			"revisionTime": "2018-05-11T01:57:25Z"
+			"revision": "1ba3c5196d701270954c957d8696695713db199b",
+			"revisionTime": "2018-05-11T04:49:20Z"
 		},
 		{
 			"checksumSHA1": "8YtBD+Um7I8ee1Xf1ZAWu74eP7w=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions",
-			"revision": "31405f70e8aafdca5f9b40d0c85281c0fdf9544f",
-			"revisionTime": "2018-05-11T01:57:25Z"
+			"revision": "1ba3c5196d701270954c957d8696695713db199b",
+			"revisionTime": "2018-05-11T04:49:20Z"
 		},
 		{
 			"checksumSHA1": "9DTfNt/B4aZWXEmTNqXU5rNrrDc=",
@@ -351,14 +351,14 @@
 		{
 			"checksumSHA1": "DNPNiVPlFHTfLmRXx6VrU9TF5RI=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots",
-			"revision": "31405f70e8aafdca5f9b40d0c85281c0fdf9544f",
-			"revisionTime": "2018-05-11T01:57:25Z"
+			"revision": "1ba3c5196d701270954c957d8696695713db199b",
+			"revisionTime": "2018-05-11T04:49:20Z"
 		},
 		{
 			"checksumSHA1": "vqXNCd2My0y/5tPC/Bs79uf6Q4E=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes",
-			"revision": "31405f70e8aafdca5f9b40d0c85281c0fdf9544f",
-			"revisionTime": "2018-05-11T01:57:25Z"
+			"revision": "1ba3c5196d701270954c957d8696695713db199b",
+			"revisionTime": "2018-05-11T04:49:20Z"
 		},
 		{
 			"checksumSHA1": "y49Ur726Juznj85+23ZgqMvehgg=",


### PR DESCRIPTION
This PR updates block storage related vendor and introduces CinderV3 resources.

Issue: https://github.com/terraform-providers/terraform-provider-openstack/issues/322

* V3 volumes could be resized on-line, without detaching them first. [see](https://blueprints.launchpad.net/cinder/+spec/extend-attached-volume)
