### PR TITLE
 Add support for default_domain

### DIFF
--- a/openstack/config.go
+++ b/openstack/config.go
@@ -21,21 +21,22 @@ type Config struct {
 	ClientCertFile    string
 	ClientKeyFile     string
 	Cloud             string
-	UserDomainName    string
-	UserDomainID      string
-	ProjectDomainName string
-	ProjectDomainID   string
+	DefaultDomain     string
 	DomainID          string
 	DomainName        string
 	EndpointType      string
 	IdentityEndpoint  string
 	Insecure          *bool
 	Password          string
+	ProjectDomainName string
+	ProjectDomainID   string
 	Region            string
 	Swauth            bool
 	TenantID          string
 	TenantName        string
 	Token             string
+	UserDomainName    string
+	UserDomainID      string
 	Username          string
 	UserID            string
 	useOctavia        bool
@@ -101,6 +102,7 @@ func (c *Config) LoadAndValidate() error {
 	} else {
 		authInfo := &clientconfig.AuthInfo{
 			AuthURL:           c.IdentityEndpoint,
+			DefaultDomain:     c.DefaultDomain,
 			DomainID:          c.DomainID,
 			DomainName:        c.DomainName,
 			Password:          c.Password,

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -80,58 +80,52 @@ func Provider() terraform.ResourceProvider {
 			},
 
 			"user_domain_name": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-					"OS_USER_DOMAIN_NAME",
-				}, ""),
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_USER_DOMAIN_NAME", ""),
 				Description: descriptions["user_domain_name"],
 			},
 
 			"user_domain_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-					"OS_USER_DOMAIN_ID",
-				}, ""),
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_USER_DOMAIN_ID", ""),
 				Description: descriptions["user_domain_id"],
 			},
 
 			"project_domain_name": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-					"OS_PROJECT_DOMAIN_NAME",
-				}, ""),
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_PROJECT_DOMAIN_NAME", ""),
 				Description: descriptions["project_domain_name"],
 			},
 
 			"project_domain_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-					"OS_PROJECT_DOMAIN_ID",
-				}, ""),
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_PROJECT_DOMAIN_ID", ""),
 				Description: descriptions["project_domain_id"],
 			},
 
 			"domain_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-					"OS_DOMAIN_ID",
-				}, ""),
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_DOMAIN_ID", ""),
 				Description: descriptions["domain_id"],
 			},
 
 			"domain_name": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-					"OS_DOMAIN_NAME",
-					"OS_DEFAULT_DOMAIN",
-				}, ""),
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_DOMAIN_NAME", ""),
 				Description: descriptions["domain_name"],
+			},
+
+			"default_domain": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_DEFAULT_DOMAIN", "default"),
+				Description: descriptions["default_domain"],
 			},
 
 			"insecure": &schema.Schema{
@@ -301,6 +295,8 @@ func init() {
 
 		"domain_name": "The name of the Domain to scope to (Identity v3).",
 
+		"default_domain": "The name of the Domain ID to scope to if no other domain is specified. Defaults to `default` (Identity v3).",
+
 		"insecure": "Trust self-signed certificates.",
 
 		"cacert_file": "A Custom CA certificate.",
@@ -327,6 +323,7 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		ClientCertFile:    d.Get("cert").(string),
 		ClientKeyFile:     d.Get("key").(string),
 		Cloud:             d.Get("cloud").(string),
+		DefaultDomain:     d.Get("default_domain").(string),
 		DomainID:          d.Get("domain_id").(string),
 		DomainName:        d.Get("domain_name").(string),
 		EndpointType:      d.Get("endpoint_type").(string),

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -96,8 +96,9 @@ The following arguments are supported:
   `OS_DOMAIN_NAME`.
 
 * `default_domain` - (Optional) The ID of the Domain to scope to if no other
-  domain is specified (Identity v3). Defaults to `default` and is also checked
-  via the `OS_DEFAULT_DOMAIN` environment variable.
+  domain is specified (Identity v3). If omitted, the environment variable
+  `OS_DEFAULT_DOMAIN` is checked or a default value of "default" will be
+  used.
 
 * `insecure` - (Optional) Trust self-signed SSL certificates. If omitted, the
   `OS_INSECURE` environment variable is used.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -93,7 +93,11 @@ The following arguments are supported:
 
 * `domain_name` - (Optional) The Name of the Domain to scope to (Identity v3).
   If omitted, the following environment variables are checked (in this order):
-  `OS_DOMAIN_NAME`, `OS_DEFAULT_DOMAIN`.
+  `OS_DOMAIN_NAME`.
+
+* `default_domain` - (Optional) The ID of the Domain to scope to if no other
+  domain is specified (Identity v3). Defaults to `default` and is also checked
+  via the `OS_DEFAULT_DOMAIN` environment variable.
 
 * `insecure` - (Optional) Trust self-signed SSL certificates. If omitted, the
   `OS_INSECURE` environment variable is used.


### PR DESCRIPTION
This commit adds support for `default_domain`, similar to the
`--os-default-domain` and `OS_DEFAULT_DOMAIN` arguments with the
OpenStack CLI. If omitted, a default value of `domain` is used,
which also matches the CLI behavior.