### PR TITLE
Enable OpenLab periodic check

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -31,3 +31,7 @@
     recheck-fwaas:
       jobs:
         - terraform-provider-openstack-acceptance-test-fwaas
+    periodic:
+      jobs:
+        - terraform-provider-openstack-unittest
+        - terraform-provider-openstack-acceptance-test


### PR DESCRIPTION
Periodic check will be triggered at UTC-0 0:00 and 12:00 of everyday
automatically, unit and acceptance tests will be executed, results will
be shown in OpenLab CI dashboard http://status.openlabtesting.org/t/openlab/builds.html

Closes theopenlab/openlab#63