### PR TITLE
Images v2: Allow 0 Values for arguments

### DIFF
--- a/openstack/resource_openstack_images_image_v2.go
+++ b/openstack/resource_openstack_images_image_v2.go
@@ -387,7 +387,7 @@ func resourceImagesImageV2ValidateVisibility(v interface{}, k string) (ws []stri
 
 func validatePositiveInt(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(int)
-	if value > 0 {
+	if value >= 0 {
 		return
 	}
 	errors = append(errors, fmt.Errorf("%q must be a positive integer", k))


### PR DESCRIPTION
This commit allows an explicit value of 0 to be set for the
openstack_images_image_v2 min_disk_gb and min_ram_mb arguments.

Fixes #341 