### PR TITLE
Switch peer_ep_group_id to Optional and documentation fix

### DIFF
--- a/openstack/resource_openstack_vpnaas_site_connection.go
+++ b/openstack/resource_openstack_vpnaas_site_connection.go
@@ -57,7 +57,7 @@ func resourceSiteConnectionV2() *schema.Resource {
 			},
 			"peer_ep_group_id": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"local_id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/website/docs/r/vpnaas_site_connection_v2.html.markdown
+++ b/website/docs/r/vpnaas_site_connection_v2.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `vpnservice_id` - (Required) The ID of the VPN service. Changing this creates a new connection.
 
-* `local_ep_group_id` - (Required) The ID for the endpoint group that contains private subnets for the local side of the connection.
+* `local_ep_group_id` - (Optional) The ID for the endpoint group that contains private subnets for the local side of the connection.
     You must specify this parameter with the peer_ep_group_id parameter unless
 	in backward- compatible mode where peer_cidrs is provided with a subnet_id for the VPN service.
     Changing this updates the existing connection.
@@ -61,7 +61,7 @@ The following arguments are supported:
 	Typically, this value matches the peer_address value.
 	Changing this updates the existing policy.
 
-* `peer_ep_group_id` - (Required) The ID for the endpoint group that contains private CIDRs in the form < net_address > / < prefix > for the peer side of the connection.
+* `peer_ep_group_id` - (Optional) The ID for the endpoint group that contains private CIDRs in the form < net_address > / < prefix > for the peer side of the connection.
 	You must specify this parameter with the local_ep_group_id parameter unless in backward-compatible mode
 	where peer_cidrs is provided with a subnet_id for the VPN service.
 


### PR DESCRIPTION
Hello,

First a big thanks to @simonre for his work on vpnaas.

I noticed two things : 
 - peer_ep_group_id should be optional in order to respect the [Openstack API](https://developer.openstack.org/api-ref/network/v2/index.html#create-ipsec-connection). It's currently impossible to specify only peer_cidrs when you have a VPN service with a subnet 
 - a minor nitpick inside documentation (Optional inside the schema but Required in the documentation).

Regards