### PR TITLE
Networking V2: support external network resource

### DIFF
--- a/openstack/resource_openstack_networking_network_v2_test.go
+++ b/openstack/resource_openstack_networking_network_v2_test.go
@@ -133,7 +133,10 @@ func TestAccNetworkingV2Network_externalCreate(t *testing.T) {
 	var network networks.Network
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNetworkingV2NetworkDestroy,
 		Steps: []resource.TestStep{
@@ -153,7 +156,10 @@ func TestAccNetworkingV2Network_externalUpdate(t *testing.T) {
 	var network networks.Network
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNetworkingV2NetworkDestroy,
 		Steps: []resource.TestStep{

--- a/openstack/resource_openstack_networking_network_v2_test.go
+++ b/openstack/resource_openstack_networking_network_v2_test.go
@@ -129,6 +129,52 @@ func TestAccNetworkingV2Network_multipleSegmentMappings(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2Network_externalCreate(t *testing.T) {
+	var network networks.Network
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2NetworkDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2Network_external,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_network_v2.network_1", "external", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2Network_externalUpdate(t *testing.T) {
+	var network networks.Network
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2NetworkDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2Network_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
+				),
+			},
+			resource.TestStep{
+				Config: testAccNetworkingV2Network_external,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_network_v2.network_1", "external", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingV2NetworkDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
@@ -287,5 +333,13 @@ resource "openstack_networking_network_v2" "network_1" {
     }
   ],
   admin_state_up = "true"
+}
+`
+
+const testAccNetworkingV2Network_external = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+	admin_state_up = "true"
+	external = "true"
 }
 `

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external/doc.go
@@ -1,0 +1,53 @@
+/*
+Package external provides information and interaction with the external
+extension for the OpenStack Networking service.
+
+Example to List Networks with External Information
+
+	iTrue := true
+	networkListOpts := networks.ListOpts{}
+	listOpts := external.ListOptsExt{
+		ListOptsBuilder: networkListOpts,
+		External: &iTrue,
+	}
+
+	type NetworkWithExternalExt struct {
+		networks.Network
+		external.NetworkExternalExt
+	}
+
+	var allNetworks []NetworkWithExternalExt
+
+	allPages, err := networks.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	err = networks.ExtractNetworksInto(allPages, &allNetworks)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, network := range allNetworks {
+		fmt.Println("%+v\n", network)
+	}
+
+Example to Create a Network with External Information
+
+	iTrue := true
+	networkCreateOpts := networks.CreateOpts{
+		Name:         "private",
+		AdminStateUp: &iTrue,
+	}
+
+	createOpts := external.CreateOptsExt{
+		networkCreateOpts,
+		&iTrue,
+	}
+
+	network, err := networks.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
+package external

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external/requests.go
@@ -1,0 +1,84 @@
+package external
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+)
+
+// ListOptsExt adds the external network options to the base ListOpts.
+type ListOptsExt struct {
+	networks.ListOptsBuilder
+	External *bool `q:"router:external"`
+}
+
+// ToNetworkListQuery adds the router:external option to the base network
+// list options.
+func (opts ListOptsExt) ToNetworkListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts.ListOptsBuilder)
+	if err != nil {
+		return "", err
+	}
+
+	params := q.Query()
+	if opts.External != nil {
+		v := strconv.FormatBool(*opts.External)
+		params.Add("router:external", v)
+	}
+
+	q = &url.URL{RawQuery: params.Encode()}
+	return q.String(), err
+}
+
+// CreateOptsExt is the structure used when creating new external network
+// resources. It embeds networks.CreateOpts and so inherits all of its required
+// and optional fields, with the addition of the External field.
+type CreateOptsExt struct {
+	networks.CreateOptsBuilder
+	External *bool `json:"router:external,omitempty"`
+}
+
+// ToNetworkCreateMap adds the router:external options to the base network
+// creation options.
+func (opts CreateOptsExt) ToNetworkCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToNetworkCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.External == nil {
+		return base, nil
+	}
+
+	networkMap := base["network"].(map[string]interface{})
+	networkMap["router:external"] = opts.External
+
+	return base, nil
+}
+
+// UpdateOptsExt is the structure used when updating existing external network
+// resources. It embeds networks.UpdateOpts and so inherits all of its required
+// and optional fields, with the addition of the External field.
+type UpdateOptsExt struct {
+	networks.UpdateOptsBuilder
+	External *bool `json:"router:external,omitempty"`
+}
+
+// ToNetworkUpdateMap casts an UpdateOpts struct to a map.
+func (opts UpdateOptsExt) ToNetworkUpdateMap() (map[string]interface{}, error) {
+	base, err := opts.UpdateOptsBuilder.ToNetworkUpdateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.External == nil {
+		return base, nil
+	}
+
+	networkMap := base["network"].(map[string]interface{})
+	networkMap["router:external"] = opts.External
+
+	return base, nil
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external/results.go
@@ -1,0 +1,8 @@
+package external
+
+// NetworkExternalExt represents a decorated form of a Network with based on the
+// "external-net" extension.
+type NetworkExternalExt struct {
+	// Specifies whether the network is an external network or not.
+	External bool `json:"router:external"`
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -511,6 +511,12 @@
 			"revisionTime": "2018-04-17T21:29:20Z"
 		},
 		{
+			"checksumSHA1": "x6lD4wQOZc1rtm6kMaUBMwLxAlA=",
+			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external",
+			"revision": "9e34f46860442c3331b0f5456500004abcea71db",
+			"revisionTime": "2018-06-29T21:59:09Z"
+		},
+		{
 			"checksumSHA1": "a++vnjXX0eXWLylR29L3z8dcxwU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls",
 			"revision": "482bcee3e503006779c2c99437c0613881160de1",

--- a/website/docs/r/networking_network_v2.html.markdown
+++ b/website/docs/r/networking_network_v2.html.markdown
@@ -75,6 +75,10 @@ The following arguments are supported:
     by any tenant or not. Changing this updates the sharing capabalities of the
     existing network.
 
+* `external` - (Optional)  Specifies whether the network resource has the
+    external routing facility. Changing this updates the external attribute of
+    the existing network.
+
 * `tenant_id` - (Optional) The owner of the network. Required if admin wants to
     create a network for another tenant. Changing this creates a new network.
 
@@ -104,6 +108,7 @@ The following attributes are exported:
 * `region` - See Argument Reference above.
 * `name` - See Argument Reference above.
 * `shared` - See Argument Reference above.
+* `external` - See Argument Reference above.
 * `tenant_id` - See Argument Reference above.
 * `admin_state_up` - See Argument Reference above.
 * `availability_zone_hints` - See Argument Reference above.

--- a/website/docs/r/networking_network_v2.html.markdown
+++ b/website/docs/r/networking_network_v2.html.markdown
@@ -76,8 +76,8 @@ The following arguments are supported:
     existing network.
 
 * `external` - (Optional)  Specifies whether the network resource has the
-    external routing facility. Changing this updates the external attribute of
-    the existing network.
+    external routing facility. Valid values are true and false. Defaults to
+    false. Changing this updates the external attribute of the existing network.
 
 * `tenant_id` - (Optional) The owner of the network. Required if admin wants to
     create a network for another tenant. Changing this creates a new network.


### PR DESCRIPTION
Add "router:external" OpenStack Networking service attribute to the resource_openstack_networking_network_v2.
Add tests for create and update of network with that attribute.

For #356 