### PR TITLE
Networking V2: support external network datasource

### DIFF
--- a/openstack/data_source_openstack_networking_network_v2.go
+++ b/openstack/data_source_openstack_networking_network_v2.go
@@ -54,7 +54,7 @@ func dataSourceNetworkingNetworkV2() *schema.Resource {
 				Computed: true,
 			},
 			"external": &schema.Schema{
-				Type:     schema.TypeString,
+				Type:     schema.TypeBool,
 				Optional: true,
 			},
 			"availability_zone_hints": &schema.Schema{
@@ -79,17 +79,10 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 		listOpts.Status = v.(string)
 	}
 
-	networkIsExternal := false
-	externalRaw := d.Get("external").(string)
-	if externalRaw != "" {
-		networkIsExternal, err = strconv.ParseBool(externalRaw)
-		if err != nil {
-			return fmt.Errorf("external, if provided, must be either 'true' or 'false': %v", err)
-		}
-	}
+	isExternal := d.Get("external").(bool)
 	listExternalOpts := external.ListOptsExt{
 		ListOptsBuilder: listOpts,
-		External:        &networkIsExternal,
+		External:        &isExternal,
 	}
 
 	pages, err := networks.List(networkingClient, listExternalOpts).AllPages()

--- a/openstack/data_source_openstack_networking_network_v2.go
+++ b/openstack/data_source_openstack_networking_network_v2.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 )
@@ -52,6 +53,10 @@ func dataSourceNetworkingNetworkV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"external": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"availability_zone_hints": &schema.Schema{
 				Type:     schema.TypeList,
 				Computed: true,
@@ -70,22 +75,38 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 		Name:     d.Get("name").(string),
 		TenantID: d.Get("tenant_id").(string),
 	}
-
 	if v, ok := d.GetOk("status"); ok {
 		listOpts.Status = v.(string)
 	}
 
-	pages, err := networks.List(networkingClient, listOpts).AllPages()
+	networkIsExternal := false
+	externalRaw := d.Get("external").(string)
+	if externalRaw != "" {
+		networkIsExternal, err = strconv.ParseBool(externalRaw)
+		if err != nil {
+			return fmt.Errorf("external, if provided, must be either 'true' or 'false': %v", err)
+		}
+	}
+	listExternalOpts := external.ListOptsExt{
+		ListOptsBuilder: listOpts,
+		External:        &networkIsExternal,
+	}
+
+	pages, err := networks.List(networkingClient, listExternalOpts).AllPages()
 	if err != nil {
 		return err
 	}
-
-	allNetworks, err := networks.ExtractNetworks(pages)
+	type networkWithExternalExt struct {
+		networks.Network
+		external.NetworkExternalExt
+	}
+	var allNetworks []networkWithExternalExt
+	err = networks.ExtractNetworksInto(pages, &allNetworks)
 	if err != nil {
 		return fmt.Errorf("Unable to retrieve networks: %s", err)
 	}
 
-	var refinedNetworks []networks.Network
+	var refinedNetworks []networkWithExternalExt
 	if cidr := d.Get("matching_subnet_cidr").(string); cidr != "" {
 		for _, n := range allNetworks {
 			for _, s := range n.Subnets {
@@ -127,6 +148,7 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 	d.Set("name", network.Name)
 	d.Set("admin_state_up", strconv.FormatBool(network.AdminStateUp))
 	d.Set("shared", strconv.FormatBool(network.Shared))
+	d.Set("external", strconv.FormatBool(network.External))
 	d.Set("tenant_id", network.TenantID)
 	d.Set("region", GetRegion(d, config))
 

--- a/openstack/data_source_openstack_networking_network_v2_test.go
+++ b/openstack/data_source_openstack_networking_network_v2_test.go
@@ -74,6 +74,30 @@ func TestAccOpenStackNetworkingNetworkV2DataSource_networkID(t *testing.T) {
 	})
 }
 
+func TestAccOpenStackNetworkingNetworkV2DataSource_external(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOpenStackNetworkingNetworkV2DataSource_networkExternal,
+			},
+			resource.TestStep{
+				Config: testAccOpenStackNetworkingNetworkV2DataSource_external,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingNetworkV2DataSourceID("data.openstack_networking_network_v2.net"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_network_v2.net", "name", "tf_test_network"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_network_v2.net", "admin_state_up", "true"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_network_v2.net", "external", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingNetworkV2DataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -103,6 +127,14 @@ resource "openstack_networking_subnet_v2" "subnet" {
 }
 `
 
+const testAccOpenStackNetworkingNetworkV2DataSource_networkExternal = `
+resource "openstack_networking_network_v2" "net" {
+  name = "tf_test_network"
+  admin_state_up = "true"
+  external = "true"
+}
+`
+
 var testAccOpenStackNetworkingNetworkV2DataSource_basic = fmt.Sprintf(`
 %s
 
@@ -126,3 +158,12 @@ data "openstack_networking_network_v2" "net" {
 	network_id = "${openstack_networking_network_v2.net.id}"
 }
 `, testAccOpenStackNetworkingNetworkV2DataSource_network)
+
+var testAccOpenStackNetworkingNetworkV2DataSource_external = fmt.Sprintf(`
+%s
+
+data "openstack_networking_network_v2" "net" {
+	name = "${openstack_networking_network_v2.net.name}"
+	external = "true"
+}
+`, testAccOpenStackNetworkingNetworkV2DataSource_networkExternal)

--- a/openstack/data_source_openstack_networking_network_v2_test.go
+++ b/openstack/data_source_openstack_networking_network_v2_test.go
@@ -76,7 +76,10 @@ func TestAccOpenStackNetworkingNetworkV2DataSource_networkID(t *testing.T) {
 
 func TestAccOpenStackNetworkingNetworkV2DataSource_external(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{

--- a/vendor/github.com/gophercloud/gophercloud/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/results.go
@@ -89,23 +89,45 @@ func (r Result) extractIntoPtr(to interface{}, label string) error {
 		if typeOfV.Kind() == reflect.Struct {
 			if typeOfV.NumField() > 0 && typeOfV.Field(0).Anonymous {
 				newSlice := reflect.MakeSlice(reflect.SliceOf(typeOfV), 0, 0)
-				newType := reflect.New(typeOfV).Elem()
 
 				for _, v := range m[label].([]interface{}) {
+					// For each iteration of the slice, we create a new struct.
+					// This is to work around a bug where elements of a slice
+					// are reused and not overwritten when the same copy of the
+					// struct is used:
+					//
+					// https://github.com/golang/go/issues/21092
+					// https://github.com/golang/go/issues/24155
+					// https://play.golang.org/p/NHo3ywlPZli
+					newType := reflect.New(typeOfV).Elem()
+
 					b, err := json.Marshal(v)
 					if err != nil {
 						return err
 					}
 
+					// This is needed for structs with an UnmarshalJSON method.
+					// Technically this is just unmarshalling the response into
+					// a struct that is never used, but it's good enough to
+					// trigger the UnmarshalJSON method.
 					for i := 0; i < newType.NumField(); i++ {
 						s := newType.Field(i).Addr().Interface()
-						err = json.NewDecoder(bytes.NewReader(b)).Decode(s)
+
+						// Unmarshal is used rather than NewDecoder to also work
+						// around the above-mentioned bug.
+						err = json.Unmarshal(b, s)
 						if err != nil {
 							return err
 						}
 					}
+
 					newSlice = reflect.Append(newSlice, newType)
 				}
+
+				// "to" should now be properly modeled to receive the
+				// JSON response body and unmarshal into all the correct
+				// fields of the struct or composed extension struct
+				// at the end of this method.
 				toValue.Set(newSlice)
 			}
 		}
@@ -363,6 +385,27 @@ func (jt *JSONRFC3339ZNoT) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	*jt = JSONRFC3339ZNoT(t)
+	return nil
+}
+
+// RFC3339ZNoTNoZ is another time format used in Zun (Containers Service).
+const RFC3339ZNoTNoZ = "2006-01-02 15:04:05"
+
+type JSONRFC3339ZNoTNoZ time.Time
+
+func (jt *JSONRFC3339ZNoTNoZ) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	if s == "" {
+		return nil
+	}
+	t, err := time.Parse(RFC3339ZNoTNoZ, s)
+	if err != nil {
+		return err
+	}
+	*jt = JSONRFC3339ZNoTNoZ(t)
 	return nil
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -313,10 +313,10 @@
 			"revisionTime": "2018-03-28T16:31:53Z"
 		},
 		{
-			"checksumSHA1": "qduT9GZUhXc00XoHEwLx16Xn9gM=",
+			"checksumSHA1": "8yXacRqh4LK7u/1r6qxrUS2oACs=",
 			"path": "github.com/gophercloud/gophercloud",
-			"revision": "7112fcd50da4ea27e8d4d499b30f04eea143bec2",
-			"revisionTime": "2018-05-31T02:06:30Z"
+			"revision": "aac68cb146cb045a2c7c76ea060c81c9318f3dcd",
+			"revisionTime": "2018-07-06T03:57:03Z"
 		},
 		{
 			"checksumSHA1": "YDNvjFNQS+UxqZMLm/shFs7aLNU=",

--- a/website/docs/d/networking_network_v2.html.markdown
+++ b/website/docs/d/networking_network_v2.html.markdown
@@ -30,6 +30,8 @@ data "openstack_networking_network_v2" "network" {
 
 * `status` - (Optional) The status of the network.
 
+* `external` - (Optional) The external routing facility of the network.
+
 * `matching_subnet_cidr` - (Optional) The CIDR of a subnet within the network.
 
 * `tenant_id` - (Optional) The owner of the network.
@@ -45,6 +47,7 @@ are exported:
 * `admin_state_up` - (Optional) The administrative state of the network.
 * `name` - See Argument Reference above.
 * `region` - See Argument Reference above.
+* `external` - See Argument Reference above.
 * `shared` - (Optional)  Specifies whether the network resource can be accessed
     by any tenant or not.
 * `availability_zone_hints` - (Optional) The availability zone candidates for the network.


### PR DESCRIPTION
Add "router:external" OpenStack Networking service attribute to the data_source_openstack_networking_network_v2
Add tests for datasource network with that attribute.

For #356 