### PR TITLE
Unify gophercloud revision

### DIFF
--- a/openstack/resource_openstack_blockstorage_volume_v3.go
+++ b/openstack/resource_openstack_blockstorage_volume_v3.go
@@ -253,7 +253,9 @@ func resourceBlockStorageVolumeV3Update(d *schema.ResourceData, meta interface{}
 			blockStorageClient.Microversion = "3.42"
 		}
 
-		extendOpts := volumeactions.ExtendSizeOpts{d.Get("size").(int)}
+		extendOpts := volumeactions.ExtendSizeOpts{
+			NewSize: d.Get("size").(int),
+		}
 		err = volumeactions.ExtendSize(blockStorageClient, d.Id(), extendOpts).ExtractErr()
 		if err != nil {
 			return fmt.Errorf(

--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -598,7 +598,7 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 	// Build a custom struct for the availability zone extension
 	var serverWithAZ struct {
 		servers.Server
-		availabilityzones.ServerExt
+		availabilityzones.ServerAvailabilityZoneExt
 	}
 
 	// Do another Get so the above work is not disturbed.

--- a/openstack/resource_openstack_objectstorage_container_v1.go
+++ b/openstack/resource_openstack_objectstorage_container_v1.go
@@ -108,7 +108,7 @@ func resourceObjectStorageContainerV1Read(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error creating OpenStack object storage client: %s", err)
 	}
 
-	result := containers.Get(objectStorageClient, d.Id())
+	result := containers.Get(objectStorageClient, d.Id(), nil)
 
 	if result.Err != nil {
 		return CheckDeleted(d, result.Err, "container")

--- a/openstack/resource_openstack_objectstorage_container_v1_test.go
+++ b/openstack/resource_openstack_objectstorage_container_v1_test.go
@@ -50,7 +50,7 @@ func testAccCheckObjectStorageV1ContainerDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := containers.Get(objectStorageClient, rs.Primary.ID).Extract()
+		_, err := containers.Get(objectStorageClient, rs.Primary.ID, nil).Extract()
 		if err == nil {
 			return fmt.Errorf("Container still exists")
 		}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v1/volumes/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v1/volumes/requests.go
@@ -139,7 +139,12 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""
-	pages, err := List(client, nil).AllPages()
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v1/volumes/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v1/volumes/results.go
@@ -1,6 +1,9 @@
 package volumes
 
 import (
+	"encoding/json"
+	"time"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -18,7 +21,7 @@ type Volume struct {
 	// Indicates whether this is a bootable volume.
 	Bootable string `json:"bootable"`
 	// The date when this volume was created.
-	CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+	CreatedAt time.Time `json:"-"`
 	// Human-readable description for the volume.
 	Description string `json:"display_description"`
 	// The type of volume to create, either SATA or SSD.
@@ -33,6 +36,23 @@ type Volume struct {
 	ID string `json:"id"`
 	// Size of the volume in GB.
 	Size int `json:"size"`
+}
+
+func (r *Volume) UnmarshalJSON(b []byte) error {
+	type tmp Volume
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Volume(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+
+	return err
 }
 
 // CreateResult contains the response body and error from a Create request.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes/requests.go
@@ -83,14 +83,34 @@ type ListOptsBuilder interface {
 // ListOpts holds options for listing Volumes. It is passed to the volumes.List
 // function.
 type ListOpts struct {
-	// admin-only option. Set it to true to see all tenant volumes.
+	// AllTenants will retrieve volumes of all tenants/projects.
 	AllTenants bool `q:"all_tenants"`
-	// List only volumes that contain Metadata.
+
+	// Metadata will filter results based on specified metadata.
 	Metadata map[string]string `q:"metadata"`
-	// List only volumes that have Name as the display name.
+
+	// Name will filter by the specified volume name.
 	Name string `q:"name"`
-	// List only volumes that have a status of Status.
+
+	// Status will filter by the specified status.
 	Status string `q:"status"`
+
+	// TenantID will filter by a specific tenant/project ID.
+	// Setting AllTenants is required for this.
+	TenantID string `q:"project_id"`
+
+	// Comma-separated list of sort keys and optional sort directions in the
+	// form of <key>[:<direction>].
+	Sort string `q:"sort"`
+
+	// Requests a page size of items.
+	Limit int `q:"limit"`
+
+	// Used in conjunction with limit to return a slice of items.
+	Offset int `q:"offset"`
+
+	// The ID of the last-seen item.
+	Marker string `q:"marker"`
 }
 
 // ToVolumeListQuery formats a ListOpts into a query string.
@@ -111,7 +131,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	}
 
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return VolumePage{pagination.SinglePageBase(r)}
+		return VolumePage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
 
@@ -154,7 +174,12 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""
-	pages, err := List(client, nil).AllPages()
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes/results.go
@@ -98,13 +98,26 @@ func (r *Volume) UnmarshalJSON(b []byte) error {
 
 // VolumePage is a pagination.pager that is returned from a call to the List function.
 type VolumePage struct {
-	pagination.SinglePageBase
+	pagination.LinkedPageBase
 }
 
 // IsEmpty returns true if a ListResult contains no Volumes.
 func (r VolumePage) IsEmpty() (bool, error) {
 	volumes, err := ExtractVolumes(r)
 	return len(volumes) == 0, err
+}
+
+// NextPageURL uses the response's embedded link reference to navigate to the
+// next page of results.
+func (r VolumePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"volumes_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
 }
 
 // ExtractVolumes extracts and returns Volumes. It is used while iterating over a volumes.List call.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/requests.go
@@ -174,7 +174,12 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""
-	pages, err := List(client, nil).AllPages()
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/client.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/client.go
@@ -406,3 +406,17 @@ func NewMessagingV2(client *gophercloud.ProviderClient, clientID string, eo goph
 func NewContainerV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
 	return initClientOpts(client, eo, "container")
 }
+
+// NewKeyManagerV1 creates a ServiceClient that may be used with the v1 key
+// manager service.
+func NewKeyManagerV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "key-manager")
+	sc.ResourceBase = sc.Endpoint + "v1/"
+	return sc, err
+}
+
+// NewContainerInfraV1 creates a ServiceClient that may be used with the v1 container infra management
+// package.
+func NewContainerInfraV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "container-infra")
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones/doc.go
@@ -1,0 +1,61 @@
+/*
+Package availabilityzones provides the ability to get lists and detailed
+availability zone information and to extend a server result with
+availability zone information.
+
+Example of Extend server result with Availability Zone Information:
+
+	type ServerWithAZ struct {
+		servers.Server
+		availabilityzones.ServerAvailabilityZoneExt
+	}
+
+	var allServers []ServerWithAZ
+
+	allPages, err := servers.List(client, nil).AllPages()
+	if err != nil {
+		panic("Unable to retrieve servers: %s", err)
+	}
+
+	err = servers.ExtractServersInto(allPages, &allServers)
+	if err != nil {
+		panic("Unable to extract servers: %s", err)
+	}
+
+	for _, server := range allServers {
+		fmt.Println(server.AvailabilityZone)
+	}
+
+Example of Get Availability Zone Information
+
+	allPages, err := availabilityzones.List(computeClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	availabilityZoneInfo, err := availabilityzones.ExtractAvailabilityZones(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, zoneInfo := range availabilityZoneInfo {
+  		fmt.Printf("%+v\n", zoneInfo)
+	}
+
+Example of Get Detailed Availability Zone Information
+
+	allPages, err := availabilityzones.ListDetail(computeClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	availabilityZoneInfo, err := availabilityzones.ExtractAvailabilityZones(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, zoneInfo := range availabilityZoneInfo {
+  		fmt.Printf("%+v\n", zoneInfo)
+	}
+*/
+package availabilityzones

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones/requests.go
@@ -1,0 +1,20 @@
+package availabilityzones
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List will return the existing availability zones.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
+		return AvailabilityZonePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// ListDetail will return the existing availability zones with detailed information.
+func ListDetail(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, listDetailURL(client), func(r pagination.PageResult) pagination.Page {
+		return AvailabilityZonePage{pagination.SinglePageBase(r)}
+	})
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones/results.go
@@ -1,12 +1,76 @@
 package availabilityzones
 
-// ServerExt is an extension to the base Server object
-type ServerExt struct {
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ServerAvailabilityZoneExt is an extension to the base Server object.
+type ServerAvailabilityZoneExt struct {
 	// AvailabilityZone is the availabilty zone the server is in.
 	AvailabilityZone string `json:"OS-EXT-AZ:availability_zone"`
 }
 
+// ServiceState represents the state of a service in an AvailabilityZone.
+type ServiceState struct {
+	Active    bool      `json:"active"`
+	Available bool      `json:"available"`
+	UpdatedAt time.Time `json:"-"`
+}
+
 // UnmarshalJSON to override default
-func (r *ServerExt) UnmarshalJSON(b []byte) error {
+func (r *ServiceState) UnmarshalJSON(b []byte) error {
+	type tmp ServiceState
+	var s struct {
+		tmp
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = ServiceState(s.tmp)
+
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
 	return nil
+}
+
+// Services is a map of services contained in an AvailabilityZone.
+type Services map[string]ServiceState
+
+// Hosts is map of hosts/nodes contained in an AvailabilityZone.
+// Each host can have multiple services.
+type Hosts map[string]Services
+
+// ZoneState represents the current state of the availability zone.
+type ZoneState struct {
+	// Returns true if the availability zone is available
+	Available bool `json:"available"`
+}
+
+// AvailabilityZone contains all the information associated with an OpenStack
+// AvailabilityZone.
+type AvailabilityZone struct {
+	Hosts Hosts `json:"hosts"`
+	// The availability zone name
+	ZoneName  string    `json:"zoneName"`
+	ZoneState ZoneState `json:"zoneState"`
+}
+
+type AvailabilityZonePage struct {
+	pagination.SinglePageBase
+}
+
+// ExtractAvailabilityZones returns a slice of AvailabilityZones contained in a
+// single page of results.
+func ExtractAvailabilityZones(r pagination.Page) ([]AvailabilityZone, error) {
+	var s struct {
+		AvailabilityZoneInfo []AvailabilityZone `json:"availabilityZoneInfo"`
+	}
+	err := (r.(AvailabilityZonePage)).ExtractInto(&s)
+	return s.AvailabilityZoneInfo, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones/urls.go
@@ -1,0 +1,11 @@
+package availabilityzones
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("os-availability-zone")
+}
+
+func listDetailURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("os-availability-zone", "detail")
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/doc.go
@@ -1,0 +1,152 @@
+/*
+Package bootfromvolume extends a server create request with the ability to
+specify block device options. This can be used to boot a server from a block
+storage volume as well as specify multiple ephemeral disks upon creation.
+
+It is recommended to refer to the Block Device Mapping documentation to see
+all possible ways to configure a server's block devices at creation time:
+
+https://docs.openstack.org/nova/latest/user/block-device-mapping.html
+
+Note that this package implements `block_device_mapping_v2`.
+
+Example of Creating a Server From an Image
+
+This example will boot a server from an image and use a standard ephemeral
+disk as the server's root disk. This is virtually no different than creating
+a server without using block device mappings.
+
+	blockDevices := []bootfromvolume.BlockDevice{
+		bootfromvolume.BlockDevice{
+			BootIndex:           0,
+			DeleteOnTermination: true,
+			DestinationType:     bootfromvolume.DestinationLocal,
+			SourceType:          bootfromvolume.SourceImage,
+			UUID:                "image-uuid",
+		},
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		FlavorRef: "flavor-uuid",
+		ImageRef:  "image-uuid",
+	}
+
+	createOpts := bootfromvolume.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		BlockDevice:       blockDevices,
+	}
+
+	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Creating a Server From a New Volume
+
+This example will create a block storage volume based on the given Image. The
+server will use this volume as its root disk.
+
+	blockDevices := []bootfromvolume.BlockDevice{
+		bootfromvolume.BlockDevice{
+			DeleteOnTermination: true,
+			DestinationType:     bootfromvolume.DestinationVolume,
+			SourceType:          bootfromvolume.SourceImage,
+			UUID:                "image-uuid",
+			VolumeSize:          2,
+		},
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := bootfromvolume.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		BlockDevice:       blockDevices,
+	}
+
+	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Creating a Server From an Existing Volume
+
+This example will create a server with an existing volume as its root disk.
+
+	blockDevices := []bootfromvolume.BlockDevice{
+		bootfromvolume.BlockDevice{
+			DeleteOnTermination: true,
+			DestinationType:     bootfromvolume.DestinationVolume,
+			SourceType:          bootfromvolume.SourceVolume,
+			UUID:                "volume-uuid",
+		},
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := bootfromvolume.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		BlockDevice:       blockDevices,
+	}
+
+	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Creating a Server with Multiple Ephemeral Disks
+
+This example will create a server with multiple ephemeral disks. The first
+block device will be based off of an existing Image. Each additional
+ephemeral disks must have an index of -1.
+
+	blockDevices := []bootfromvolume.BlockDevice{
+		bootfromvolume.BlockDevice{
+			BootIndex:           0,
+			DestinationType:     bootfromvolume.DestinationLocal,
+			DeleteOnTermination: true,
+			SourceType:          bootfromvolume.SourceImage,
+			UUID:                "image-uuid",
+			VolumeSize:          5,
+		},
+		bootfromvolume.BlockDevice{
+			BootIndex:           -1,
+			DestinationType:     bootfromvolume.DestinationLocal,
+			DeleteOnTermination: true,
+			GuestFormat:         "ext4",
+			SourceType:          bootfromvolume.SourceBlank,
+			VolumeSize:          1,
+		},
+		bootfromvolume.BlockDevice{
+			BootIndex:           -1,
+			DestinationType:     bootfromvolume.DestinationLocal,
+			DeleteOnTermination: true,
+			GuestFormat:         "ext4",
+			SourceType:          bootfromvolume.SourceBlank,
+			VolumeSize:          1,
+		},
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		FlavorRef: "flavor-uuid",
+		ImageRef:  "image-uuid",
+	}
+
+	createOpts := bootfromvolume.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		BlockDevice:       blockDevices,
+	}
+
+	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
+package bootfromvolume

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/requests.go
@@ -67,6 +67,14 @@ type BlockDevice struct {
 	// VolumeSize is the size of the volume to create (in gigabytes). This can be
 	// omitted for existing volumes.
 	VolumeSize int `json:"volume_size,omitempty"`
+
+	// DeviceType specifies the device type of the block devices.
+	// Examples of this are disk, cdrom, floppy, lun, etc.
+	DeviceType string `json:"device_type,omitempty"`
+
+	// DiskBus is the bus type of the block devices.
+	// Examples of this are ide, usb, virtio, scsi, etc.
+	DiskBus string `json:"disk_bus,omitempty"`
 }
 
 // CreateOptsExt is a structure that extends the server `CreateOpts` structure

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/results.go
@@ -5,6 +5,8 @@ import (
 )
 
 // CreateResult temporarily contains the response from a Create call.
+// It embeds the standard servers.CreateResults type and so can be used the
+// same way as a standard server request result.
 type CreateResult struct {
 	os.CreateResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips/doc.go
@@ -1,3 +1,68 @@
-// Package floatingips provides the ability to manage floating ips through
-// nova-network
+/*
+Package floatingips provides the ability to manage floating ips through the
+Nova API.
+
+This API has been deprecated and will be removed from a future release of the
+Nova API service.
+
+For environements that support this extension, this package can be used
+regardless of if either Neutron or nova-network is used as the cloud's network
+service.
+
+Example to List Floating IPs
+
+	allPages, err := floatingips.List(computeClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allFloatingIPs, err := floatingips.ExtractFloatingIPs(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, fip := range allFloatingIPs {
+		fmt.Printf("%+v\n", fip)
+	}
+
+Example to Create a Floating IP
+
+	createOpts := floatingips.CreateOpts{
+		Pool: "nova",
+	}
+
+	fip, err := floatingips.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Floating IP
+
+	err := floatingips.Delete(computeClient, "floatingip-id").ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Associate a Floating IP With a Server
+
+	associateOpts := floatingips.AssociateOpts{
+		FloatingIP: "10.10.10.2",
+	}
+
+	err := floatingips.AssociateInstance(computeClient, "server-id", associateOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Disassociate a Floating IP From a Server
+
+	disassociateOpts := floatingips.DisassociateOpts{
+		FloatingIP: "10.10.10.2",
+	}
+
+	err := floatingips.DisassociateInstance(computeClient, "server-id", disassociateOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
 package floatingips

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips/requests.go
@@ -12,15 +12,15 @@ func List(client *gophercloud.ServiceClient) pagination.Pager {
 	})
 }
 
-// CreateOptsBuilder describes struct types that can be accepted by the Create call. Notable, the
-// CreateOpts struct in this package does.
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToFloatingIPCreateMap() (map[string]interface{}, error)
 }
 
-// CreateOpts specifies a Floating IP allocation request
+// CreateOpts specifies a Floating IP allocation request.
 type CreateOpts struct {
-	// Pool is the pool of floating IPs to allocate one from
+	// Pool is the pool of Floating IPs to allocate one from.
 	Pool string `json:"pool" required:"true"`
 }
 
@@ -29,7 +29,7 @@ func (opts CreateOpts) ToFloatingIPCreateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "")
 }
 
-// Create requests the creation of a new floating IP
+// Create requests the creation of a new Floating IP.
 func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToFloatingIPCreateMap()
 	if err != nil {
@@ -42,29 +42,30 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	return
 }
 
-// Get returns data about a previously created FloatingIP.
+// Get returns data about a previously created Floating IP.
 func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
 	return
 }
 
-// Delete requests the deletion of a previous allocated FloatingIP.
+// Delete requests the deletion of a previous allocated Floating IP.
 func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, id), nil)
 	return
 }
 
-// AssociateOptsBuilder is the interface types must satfisfy to be used as
-// Associate options
+// AssociateOptsBuilder allows extensions to add additional parameters to the
+// Associate request.
 type AssociateOptsBuilder interface {
 	ToFloatingIPAssociateMap() (map[string]interface{}, error)
 }
 
-// AssociateOpts specifies the required information to associate a floating IP with an instance
+// AssociateOpts specifies the required information to associate a Floating IP with an instance
 type AssociateOpts struct {
-	// FloatingIP is the floating IP to associate with an instance
+	// FloatingIP is the Floating IP to associate with an instance.
 	FloatingIP string `json:"address" required:"true"`
-	// FixedIP is an optional fixed IP address of the server
+
+	// FixedIP is an optional fixed IP address of the server.
 	FixedIP string `json:"fixed_address,omitempty"`
 }
 
@@ -73,7 +74,7 @@ func (opts AssociateOpts) ToFloatingIPAssociateMap() (map[string]interface{}, er
 	return gophercloud.BuildRequestBody(opts, "addFloatingIp")
 }
 
-// AssociateInstance pairs an allocated floating IP with an instance.
+// AssociateInstance pairs an allocated Floating IP with a server.
 func AssociateInstance(client *gophercloud.ServiceClient, serverID string, opts AssociateOptsBuilder) (r AssociateResult) {
 	b, err := opts.ToFloatingIPAssociateMap()
 	if err != nil {
@@ -84,23 +85,24 @@ func AssociateInstance(client *gophercloud.ServiceClient, serverID string, opts 
 	return
 }
 
-// DisassociateOptsBuilder is the interface types must satfisfy to be used as
-// Disassociate options
+// DisassociateOptsBuilder allows extensions to add additional parameters to
+// the Disassociate request.
 type DisassociateOptsBuilder interface {
 	ToFloatingIPDisassociateMap() (map[string]interface{}, error)
 }
 
-// DisassociateOpts specifies the required information to disassociate a floating IP with an instance
+// DisassociateOpts specifies the required information to disassociate a
+// Floating IP with a server.
 type DisassociateOpts struct {
 	FloatingIP string `json:"address" required:"true"`
 }
 
-// ToFloatingIPDisassociateMap constructs a request body from AssociateOpts.
+// ToFloatingIPDisassociateMap constructs a request body from DisassociateOpts.
 func (opts DisassociateOpts) ToFloatingIPDisassociateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "removeFloatingIp")
 }
 
-// DisassociateInstance decouples an allocated floating IP from an instance
+// DisassociateInstance decouples an allocated Floating IP from an instance
 func DisassociateInstance(client *gophercloud.ServiceClient, serverID string, opts DisassociateOptsBuilder) (r DisassociateResult) {
 	b, err := opts.ToFloatingIPDisassociateMap()
 	if err != nil {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips/results.go
@@ -8,21 +8,21 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// A FloatingIP is an IP that can be associated with an instance
+// A FloatingIP is an IP that can be associated with a server.
 type FloatingIP struct {
 	// ID is a unique ID of the Floating IP
 	ID string `json:"-"`
 
-	// FixedIP is the IP of the instance related to the Floating IP
+	// FixedIP is a specific IP on the server to pair the Floating IP with.
 	FixedIP string `json:"fixed_ip,omitempty"`
 
-	// InstanceID is the ID of the instance that is using the Floating IP
+	// InstanceID is the ID of the server that is using the Floating IP.
 	InstanceID string `json:"instance_id"`
 
-	// IP is the actual Floating IP
+	// IP is the actual Floating IP.
 	IP string `json:"ip"`
 
-	// Pool is the pool of floating IPs that this floating IP belongs to
+	// Pool is the pool of Floating IPs that this Floating IP belongs to.
 	Pool string `json:"pool"`
 }
 
@@ -49,8 +49,7 @@ func (r *FloatingIP) UnmarshalJSON(b []byte) error {
 	return err
 }
 
-// FloatingIPPage stores a single, only page of FloatingIPs
-// results from a List call.
+// FloatingIPPage stores a single page of FloatingIPs from a List call.
 type FloatingIPPage struct {
 	pagination.SinglePageBase
 }
@@ -61,8 +60,7 @@ func (page FloatingIPPage) IsEmpty() (bool, error) {
 	return len(va) == 0, err
 }
 
-// ExtractFloatingIPs interprets a page of results as a slice of
-// FloatingIPs.
+// ExtractFloatingIPs interprets a page of results as a slice of FloatingIPs.
 func ExtractFloatingIPs(r pagination.Page) ([]FloatingIP, error) {
 	var s struct {
 		FloatingIPs []FloatingIP `json:"floating_ips"`
@@ -86,32 +84,32 @@ func (r FloatingIPResult) Extract() (*FloatingIP, error) {
 	return s.FloatingIP, err
 }
 
-// CreateResult is the response from a Create operation. Call its Extract method to interpret it
-// as a FloatingIP.
+// CreateResult is the response from a Create operation. Call its Extract method
+// to interpret it as a FloatingIP.
 type CreateResult struct {
 	FloatingIPResult
 }
 
-// GetResult is the response from a Get operation. Call its Extract method to interpret it
-// as a FloatingIP.
+// GetResult is the response from a Get operation. Call its Extract method to
+// interpret it as a FloatingIP.
 type GetResult struct {
 	FloatingIPResult
 }
 
-// DeleteResult is the response from a Delete operation. Call its Extract method to determine if
-// the call succeeded or failed.
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
-// AssociateResult is the response from a Delete operation. Call its Extract method to determine if
-// the call succeeded or failed.
+// AssociateResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
 type AssociateResult struct {
 	gophercloud.ErrResult
 }
 
-// DisassociateResult is the response from a Delete operation. Call its Extract method to determine if
-// the call succeeded or failed.
+// DisassociateResult is the response from a Delete operation. Call its
+// ExtractErr method to determine if the call succeeded or failed.
 type DisassociateResult struct {
 	gophercloud.ErrResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs/doc.go
@@ -1,3 +1,71 @@
-// Package keypairs provides information and interaction with the Keypairs
-// extension for the OpenStack Compute service.
+/*
+Package keypairs provides the ability to manage key pairs as well as create
+servers with a specified key pair.
+
+Example to List Key Pairs
+
+	allPages, err := keypairs.List(computeClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allKeyPairs, err := keypairs.ExtractKeyPairs(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, kp := range allKeyPairs {
+		fmt.Printf("%+v\n", kp)
+	}
+
+Example to Create a Key Pair
+
+	createOpts := keypairs.CreateOpts{
+		Name: "keypair-name",
+	}
+
+	keypair, err := keypairs.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", keypair)
+
+Example to Import a Key Pair
+
+	createOpts := keypairs.CreateOpts{
+		Name:      "keypair-name",
+		PublicKey: "public-key",
+	}
+
+	keypair, err := keypairs.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Key Pair
+
+	err := keypairs.Delete(computeClient, "keypair-name").ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a Server With a Key Pair
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		ImageRef:  "image-uuid",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := keypairs.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		KeyName:           "keypair-name",
+	}
+
+	server, err := servers.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
 package keypairs

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs/requests.go
@@ -9,11 +9,12 @@ import (
 // CreateOptsExt adds a KeyPair option to the base CreateOpts.
 type CreateOptsExt struct {
 	servers.CreateOptsBuilder
+
+	// KeyName is the name of the key pair.
 	KeyName string `json:"key_name,omitempty"`
 }
 
-// ToServerCreateMap adds the key_name and, optionally, key_data options to
-// the base server creation options.
+// ToServerCreateMap adds the key_name to the base server creation options.
 func (opts CreateOptsExt) ToServerCreateMap() (map[string]interface{}, error) {
 	base, err := opts.CreateOptsBuilder.ToServerCreateMap()
 	if err != nil {
@@ -37,18 +38,19 @@ func List(client *gophercloud.ServiceClient) pagination.Pager {
 	})
 }
 
-// CreateOptsBuilder describes struct types that can be accepted by the Create call. Notable, the
-// CreateOpts struct in this package does.
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToKeyPairCreateMap() (map[string]interface{}, error)
 }
 
-// CreateOpts specifies keypair creation or import parameters.
+// CreateOpts specifies KeyPair creation or import parameters.
 type CreateOpts struct {
 	// Name is a friendly name to refer to this KeyPair in other services.
 	Name string `json:"name" required:"true"`
-	// PublicKey [optional] is a pregenerated OpenSSH-formatted public key. If provided, this key
-	// will be imported and no new key will be created.
+
+	// PublicKey [optional] is a pregenerated OpenSSH-formatted public key.
+	// If provided, this key will be imported and no new key will be created.
 	PublicKey string `json:"public_key,omitempty"`
 }
 
@@ -57,8 +59,8 @@ func (opts CreateOpts) ToKeyPairCreateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "keypair")
 }
 
-// Create requests the creation of a new keypair on the server, or to import a pre-existing
-// keypair.
+// Create requests the creation of a new KeyPair on the server, or to import a
+// pre-existing keypair.
 func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToKeyPairCreateMap()
 	if err != nil {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs/results.go
@@ -5,29 +5,33 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// KeyPair is an SSH key known to the OpenStack cluster that is available to be injected into
-// servers.
+// KeyPair is an SSH key known to the OpenStack Cloud that is available to be
+// injected into servers.
 type KeyPair struct {
-	// Name is used to refer to this keypair from other services within this region.
+	// Name is used to refer to this keypair from other services within this
+	// region.
 	Name string `json:"name"`
 
-	// Fingerprint is a short sequence of bytes that can be used to authenticate or validate a longer
-	// public key.
+	// Fingerprint is a short sequence of bytes that can be used to authenticate
+	// or validate a longer public key.
 	Fingerprint string `json:"fingerprint"`
 
-	// PublicKey is the public key from this pair, in OpenSSH format. "ssh-rsa AAAAB3Nz..."
+	// PublicKey is the public key from this pair, in OpenSSH format.
+	// "ssh-rsa AAAAB3Nz..."
 	PublicKey string `json:"public_key"`
 
 	// PrivateKey is the private key from this pair, in PEM format.
-	// "-----BEGIN RSA PRIVATE KEY-----\nMIICXA..." It is only present if this keypair was just
-	// returned from a Create call
+	// "-----BEGIN RSA PRIVATE KEY-----\nMIICXA..."
+	// It is only present if this KeyPair was just returned from a Create call.
 	PrivateKey string `json:"private_key"`
 
-	// UserID is the user who owns this keypair.
+	// UserID is the user who owns this KeyPair.
 	UserID string `json:"user_id"`
 }
 
-// KeyPairPage stores a single, only page of KeyPair results from a List call.
+// KeyPairPage stores a single page of all KeyPair results from a List call.
+// Use the ExtractKeyPairs function to convert the results to a slice of
+// KeyPairs.
 type KeyPairPage struct {
 	pagination.SinglePageBase
 }
@@ -58,7 +62,8 @@ type keyPairResult struct {
 	gophercloud.Result
 }
 
-// Extract is a method that attempts to interpret any KeyPair resource response as a KeyPair struct.
+// Extract is a method that attempts to interpret any KeyPair resource response
+// as a KeyPair struct.
 func (r keyPairResult) Extract() (*KeyPair, error) {
 	var s struct {
 		KeyPair *KeyPair `json:"keypair"`
@@ -67,20 +72,20 @@ func (r keyPairResult) Extract() (*KeyPair, error) {
 	return s.KeyPair, err
 }
 
-// CreateResult is the response from a Create operation. Call its Extract method to interpret it
-// as a KeyPair.
+// CreateResult is the response from a Create operation. Call its Extract method
+// to interpret it as a KeyPair.
 type CreateResult struct {
 	keyPairResult
 }
 
-// GetResult is the response from a Get operation. Call its Extract method to interpret it
-// as a KeyPair.
+// GetResult is the response from a Get operation. Call its Extract method to
+// interpret it as a KeyPair.
 type GetResult struct {
 	keyPairResult
 }
 
-// DeleteResult is the response from a Delete operation. Call its Extract method to determine if
-// the call succeeded or failed.
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups/doc.go
@@ -1,1 +1,112 @@
+/*
+Package secgroups provides the ability to manage security groups through the
+Nova API.
+
+This API has been deprecated and will be removed from a future release of the
+Nova API service.
+
+For environments that support this extension, this package can be used
+regardless of if either Neutron or nova-network is used as the cloud's network
+service.
+
+Example to List Security Groups
+
+	allPages, err := secroups.List(computeClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allSecurityGroups, err := secgroups.ExtractSecurityGroups(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, sg := range allSecurityGroups {
+		fmt.Printf("%+v\n", sg)
+	}
+
+Example to List Security Groups by Server
+
+	serverID := "aab3ad01-9956-4623-a29b-24afc89a7d36"
+
+	allPages, err := secroups.ListByServer(computeClient, serverID).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allSecurityGroups, err := secgroups.ExtractSecurityGroups(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, sg := range allSecurityGroups {
+		fmt.Printf("%+v\n", sg)
+	}
+
+Example to Create a Security Group
+
+	createOpts := secgroups.CreateOpts{
+		Name:        "group_name",
+		Description: "A Security Group",
+	}
+
+	sg, err := secgroups.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a Security Group Rule
+
+	sgID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
+
+	createOpts := secgroups.CreateRuleOpts{
+		ParentGroupID: sgID,
+		FromPort:      22,
+		ToPort:        22,
+		IPProtocol:    "tcp",
+		CIDR:          "0.0.0.0/0",
+	}
+
+	rule, err := secgroups.CreateRule(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Add a Security Group to a Server
+
+	serverID := "aab3ad01-9956-4623-a29b-24afc89a7d36"
+	sgID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
+
+	err := secgroups.AddServer(computeClient, serverID, sgID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Remove a Security Group from a Server
+
+	serverID := "aab3ad01-9956-4623-a29b-24afc89a7d36"
+	sgID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
+
+	err := secgroups.RemoveServer(computeClient, serverID, sgID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Security Group
+
+
+	sgID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
+	err := secgroups.Delete(computeClient, sgID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Security Group Rule
+
+	ruleID := "6221fe3e-383d-46c9-a3a6-845e66c1e8b4"
+	err := secgroups.DeleteRule(computeClient, ruleID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
 package secgroups

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups/requests.go
@@ -36,12 +36,13 @@ type GroupOpts struct {
 // CreateOpts is the struct responsible for creating a security group.
 type CreateOpts GroupOpts
 
-// CreateOptsBuilder builds the create options into a serializable format.
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToSecGroupCreateMap() (map[string]interface{}, error)
 }
 
-// ToSecGroupCreateMap builds the create options into a serializable format.
+// ToSecGroupCreateMap builds a request body from CreateOpts.
 func (opts CreateOpts) ToSecGroupCreateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "security_group")
 }
@@ -62,12 +63,13 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 // UpdateOpts is the struct responsible for updating an existing security group.
 type UpdateOpts GroupOpts
 
-// UpdateOptsBuilder builds the update options into a serializable format.
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToSecGroupUpdateMap() (map[string]interface{}, error)
 }
 
-// ToSecGroupUpdateMap builds the update options into a serializable format.
+// ToSecGroupUpdateMap builds a request body from UpdateOpts.
 func (opts UpdateOpts) ToSecGroupUpdateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "security_group")
 }
@@ -93,7 +95,7 @@ func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 }
 
 // Delete will permanently delete a security group from the project.
-func Delete(client *gophercloud.ServiceClient, id string) (r gophercloud.ErrResult) {
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(resourceURL(client, id), nil)
 	return
 }
@@ -101,31 +103,41 @@ func Delete(client *gophercloud.ServiceClient, id string) (r gophercloud.ErrResu
 // CreateRuleOpts represents the configuration for adding a new rule to an
 // existing security group.
 type CreateRuleOpts struct {
-	// the ID of the group that this rule will be added to.
+	// ID is the ID of the group that this rule will be added to.
 	ParentGroupID string `json:"parent_group_id" required:"true"`
-	// the lower bound of the port range that will be opened.
+
+	// FromPort is the lower bound of the port range that will be opened.
+	// Use -1 to allow all ICMP traffic.
 	FromPort int `json:"from_port"`
-	// the upper bound of the port range that will be opened.
+
+	// ToPort is the upper bound of the port range that will be opened.
+	// Use -1 to allow all ICMP traffic.
 	ToPort int `json:"to_port"`
-	// the protocol type that will be allowed, e.g. TCP.
+
+	// IPProtocol the protocol type that will be allowed, e.g. TCP.
 	IPProtocol string `json:"ip_protocol" required:"true"`
-	// ONLY required if FromGroupID is blank. This represents the IP range that
-	// will be the source of network traffic to your security group. Use
-	// 0.0.0.0/0 to allow all IP addresses.
+
+	// CIDR is the network CIDR to allow traffic from.
+	// This is ONLY required if FromGroupID is blank. This represents the IP
+	// range that will be the source of network traffic to your security group.
+	// Use 0.0.0.0/0 to allow all IP addresses.
 	CIDR string `json:"cidr,omitempty" or:"FromGroupID"`
-	// ONLY required if CIDR is blank. This value represents the ID of a group
-	// that forwards traffic to the parent group. So, instead of accepting
+
+	// FromGroupID represents another security group to allow access.
+	// This is ONLY required if CIDR is blank. This value represents the ID of a
+	// group that forwards traffic to the parent group. So, instead of accepting
 	// network traffic from an entire IP range, you can instead refine the
 	// inbound source by an existing security group.
 	FromGroupID string `json:"group_id,omitempty" or:"CIDR"`
 }
 
-// CreateRuleOptsBuilder builds the create rule options into a serializable format.
+// CreateRuleOptsBuilder allows extensions to add additional parameters to the
+// CreateRule request.
 type CreateRuleOptsBuilder interface {
 	ToRuleCreateMap() (map[string]interface{}, error)
 }
 
-// ToRuleCreateMap builds the create rule options into a serializable format.
+// ToRuleCreateMap builds a request body from CreateRuleOpts.
 func (opts CreateRuleOpts) ToRuleCreateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "security_group_rule")
 }
@@ -146,7 +158,7 @@ func CreateRule(client *gophercloud.ServiceClient, opts CreateRuleOptsBuilder) (
 }
 
 // DeleteRule will permanently delete a rule from a security group.
-func DeleteRule(client *gophercloud.ServiceClient, id string) (r gophercloud.ErrResult) {
+func DeleteRule(client *gophercloud.ServiceClient, id string) (r DeleteRuleResult) {
 	_, r.Err = client.Delete(resourceRuleURL(client, id), nil)
 	return
 }
@@ -159,13 +171,13 @@ func actionMap(prefix, groupName string) map[string]map[string]string {
 
 // AddServer will associate a server and a security group, enforcing the
 // rules of the group on the server.
-func AddServer(client *gophercloud.ServiceClient, serverID, groupName string) (r gophercloud.ErrResult) {
-	_, r.Err = client.Post(serverActionURL(client, serverID), actionMap("add", groupName), &r.Body, nil)
+func AddServer(client *gophercloud.ServiceClient, serverID, groupName string) (r AddServerResult) {
+	_, r.Err = client.Post(serverActionURL(client, serverID), actionMap("add", groupName), nil, nil)
 	return
 }
 
 // RemoveServer will disassociate a server from a security group.
-func RemoveServer(client *gophercloud.ServiceClient, serverID, groupName string) (r gophercloud.ErrResult) {
-	_, r.Err = client.Post(serverActionURL(client, serverID), actionMap("remove", groupName), &r.Body, nil)
+func RemoveServer(client *gophercloud.ServiceClient, serverID, groupName string) (r RemoveServerResult) {
+	_, r.Err = client.Post(serverActionURL(client, serverID), actionMap("remove", groupName), nil, nil)
 	return
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups/results.go
@@ -59,19 +59,19 @@ type Rule struct {
 	// numeric ID. For the sake of consistency, we always cast it to a string.
 	ID string `json:"-"`
 
-	// The lower bound of the port range which this security group should open up
+	// The lower bound of the port range which this security group should open up.
 	FromPort int `json:"from_port"`
 
-	// The upper bound of the port range which this security group should open up
+	// The upper bound of the port range which this security group should open up.
 	ToPort int `json:"to_port"`
 
-	// The IP protocol (e.g. TCP) which the security group accepts
+	// The IP protocol (e.g. TCP) which the security group accepts.
 	IPProtocol string `json:"ip_protocol"`
 
-	// The CIDR IP range whose traffic can be received
+	// The CIDR IP range whose traffic can be received.
 	IPRange IPRange `json:"ip_range"`
 
-	// The security group ID to which this rule belongs
+	// The security group ID to which this rule belongs.
 	ParentGroupID string `json:"parent_group_id"`
 
 	// Not documented.
@@ -126,13 +126,15 @@ type SecurityGroupPage struct {
 	pagination.SinglePageBase
 }
 
-// IsEmpty determines whether or not a page of Security Groups contains any results.
+// IsEmpty determines whether or not a page of Security Groups contains any
+// results.
 func (page SecurityGroupPage) IsEmpty() (bool, error) {
 	users, err := ExtractSecurityGroups(page)
 	return len(users) == 0, err
 }
 
-// ExtractSecurityGroups returns a slice of SecurityGroups contained in a single page of results.
+// ExtractSecurityGroups returns a slice of SecurityGroups contained in a
+// single page of results.
 func ExtractSecurityGroups(r pagination.Page) ([]SecurityGroup, error) {
 	var s struct {
 		SecurityGroups []SecurityGroup `json:"security_groups"`
@@ -145,17 +147,20 @@ type commonResult struct {
 	gophercloud.Result
 }
 
-// CreateResult represents the result of a create operation.
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret the result as a SecurityGroup.
 type CreateResult struct {
 	commonResult
 }
 
-// GetResult represents the result of a get operation.
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret the result as a SecurityGroup.
 type GetResult struct {
 	commonResult
 }
 
-// UpdateResult represents the result of an update operation.
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret the result as a SecurityGroup.
 type UpdateResult struct {
 	commonResult
 }
@@ -170,6 +175,7 @@ func (r commonResult) Extract() (*SecurityGroup, error) {
 }
 
 // CreateRuleResult represents the result when adding rules to a security group.
+// Call its Extract method to interpret the result as a Rule.
 type CreateRuleResult struct {
 	gophercloud.Result
 }
@@ -181,4 +187,28 @@ func (r CreateRuleResult) Extract() (*Rule, error) {
 	}
 	err := r.ExtractInto(&s)
 	return s.Rule, err
+}
+
+// DeleteResult is the response from delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// DeleteRuleResult is the response from a DeleteRule operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteRuleResult struct {
+	gophercloud.ErrResult
+}
+
+// AddServerResult is the response from an AddServer operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type AddServerResult struct {
+	gophercloud.ErrResult
+}
+
+// RemoveServerResult is the response from a RemoveServer operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type RemoveServerResult struct {
+	gophercloud.ErrResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/doc.go
@@ -1,2 +1,40 @@
-// Package servergroups provides the ability to manage server groups
+/*
+Package servergroups provides the ability to manage server groups.
+
+Example to List Server Groups
+
+	allpages, err := servergroups.List(computeClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allServerGroups, err := servergroups.ExtractServerGroups(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, sg := range allServerGroups {
+		fmt.Printf("%#v\n", sg)
+	}
+
+Example to Create a Server Group
+
+	createOpts := servergroups.CreateOpts{
+		Name:     "my_sg",
+		Policies: []string{"anti-affinity"},
+	}
+
+	sg, err := servergroups.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Server Group
+
+	sgID := "7a6f29ad-e34d-4368-951a-58a08f11cfb7"
+	err := servergroups.Delete(computeClient, sgID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
 package servergroups

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/requests.go
@@ -5,23 +5,25 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// List returns a Pager that allows you to iterate over a collection of ServerGroups.
+// List returns a Pager that allows you to iterate over a collection of
+// ServerGroups.
 func List(client *gophercloud.ServiceClient) pagination.Pager {
 	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
 		return ServerGroupPage{pagination.SinglePageBase(r)}
 	})
 }
 
-// CreateOptsBuilder describes struct types that can be accepted by the Create call. Notably, the
-// CreateOpts struct in this package does.
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToServerGroupCreateMap() (map[string]interface{}, error)
 }
 
-// CreateOpts specifies a Server Group allocation request
+// CreateOpts specifies Server Group creation parameters.
 type CreateOpts struct {
 	// Name is the name of the server group
 	Name string `json:"name" required:"true"`
+
 	// Policies are the server group policies
 	Policies []string `json:"policies" required:"true"`
 }
@@ -31,7 +33,7 @@ func (opts CreateOpts) ToServerGroupCreateMap() (map[string]interface{}, error) 
 	return gophercloud.BuildRequestBody(opts, "server_group")
 }
 
-// Create requests the creation of a new Server Group
+// Create requests the creation of a new Server Group.
 func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToServerGroupCreateMap()
 	if err != nil {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/results.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// A ServerGroup creates a policy for instance placement in the cloud
+// A ServerGroup creates a policy for instance placement in the cloud.
 type ServerGroup struct {
 	// ID is the unique ID of the Server Group.
 	ID string `json:"id"`
@@ -14,17 +14,26 @@ type ServerGroup struct {
 	Name string `json:"name"`
 
 	// Polices are the group policies.
+	//
+	// Normally a single policy is applied:
+	//
+	// "affinity" will place all servers within the server group on the
+	// same compute node.
+	//
+	// "anti-affinity" will place servers within the server group on different
+	// compute nodes.
 	Policies []string `json:"policies"`
 
 	// Members are the members of the server group.
 	Members []string `json:"members"`
 
-	// Metadata includes a list of all user-specified key-value pairs attached to the Server Group.
+	// Metadata includes a list of all user-specified key-value pairs attached
+	// to the Server Group.
 	Metadata map[string]interface{}
 }
 
-// ServerGroupPage stores a single, only page of ServerGroups
-// results from a List call.
+// ServerGroupPage stores a single page of all ServerGroups results from a
+// List call.
 type ServerGroupPage struct {
 	pagination.SinglePageBase
 }
@@ -59,20 +68,20 @@ func (r ServerGroupResult) Extract() (*ServerGroup, error) {
 	return s.ServerGroup, err
 }
 
-// CreateResult is the response from a Create operation. Call its Extract method to interpret it
-// as a ServerGroup.
+// CreateResult is the response from a Create operation. Call its Extract method
+// to interpret it as a ServerGroup.
 type CreateResult struct {
 	ServerGroupResult
 }
 
-// GetResult is the response from a Get operation. Call its Extract method to interpret it
-// as a ServerGroup.
+// GetResult is the response from a Get operation. Call its Extract method to
+// interpret it as a ServerGroup.
 type GetResult struct {
 	ServerGroupResult
 }
 
-// DeleteResult is the response from a Delete operation. Call its Extract method to determine if
-// the call succeeded or failed.
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/startstop/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/startstop/doc.go
@@ -1,5 +1,19 @@
 /*
 Package startstop provides functionality to start and stop servers that have
 been provisioned by the OpenStack Compute service.
+
+Example to Stop and Start a Server
+
+	serverID := "47b6b7b7-568d-40e4-868c-d5c41735532e"
+
+	err := startstop.Stop(computeClient, serverID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+	err := startstop.Start(computeClient, serverID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package startstop

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/startstop/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/startstop/requests.go
@@ -7,13 +7,13 @@ func actionURL(client *gophercloud.ServiceClient, id string) string {
 }
 
 // Start is the operation responsible for starting a Compute server.
-func Start(client *gophercloud.ServiceClient, id string) (r gophercloud.ErrResult) {
+func Start(client *gophercloud.ServiceClient, id string) (r StartResult) {
 	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"os-start": nil}, nil, nil)
 	return
 }
 
 // Stop is the operation responsible for stopping a Compute server.
-func Stop(client *gophercloud.ServiceClient, id string) (r gophercloud.ErrResult) {
+func Stop(client *gophercloud.ServiceClient, id string) (r StopResult) {
 	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"os-stop": nil}, nil, nil)
 	return
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/startstop/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/startstop/results.go
@@ -1,0 +1,15 @@
+package startstop
+
+import "github.com/gophercloud/gophercloud"
+
+// StartResult is the response from a Start operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type StartResult struct {
+	gophercloud.ErrResult
+}
+
+// StopResult is the response from Stop operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type StopResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/tenantnetworks/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/tenantnetworks/doc.go
@@ -1,2 +1,26 @@
-// Package tenantnetworks provides the ability for tenants to see information about the networks they have access to
+/*
+Package tenantnetworks provides the ability for tenants to see information
+about the networks they have access to.
+
+This is a deprecated API and will be removed from the Nova API service in a
+future version.
+
+This API works in both Neutron and nova-network based OpenStack clouds.
+
+Example to List Networks Available to a Tenant
+
+	allPages, err := tenantnetworks.List(computeClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allNetworks, err := tenantnetworks.ExtractNetworks(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, network := range allNetworks {
+		fmt.Printf("%+v\n", network)
+	}
+*/
 package tenantnetworks

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/tenantnetworks/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/tenantnetworks/requests.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// List returns a Pager that allows you to iterate over a collection of Network.
+// List returns a Pager that allows you to iterate over a collection of Networks.
 func List(client *gophercloud.ServiceClient) pagination.Pager {
 	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
 		return NetworkPage{pagination.SinglePageBase(r)}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/tenantnetworks/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/tenantnetworks/results.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// A Network represents a nova-network that an instance communicates on
+// A Network represents a network that a server communicates on.
 type Network struct {
 	// CIDR is the IPv4 subnet.
 	CIDR string `json:"cidr"`
@@ -17,8 +17,7 @@ type Network struct {
 	Name string `json:"label"`
 }
 
-// NetworkPage stores a single, only page of Networks
-// results from a List call.
+// NetworkPage stores a single page of all Networks results from a List call.
 type NetworkPage struct {
 	pagination.SinglePageBase
 }
@@ -29,7 +28,7 @@ func (page NetworkPage) IsEmpty() (bool, error) {
 	return len(va) == 0, err
 }
 
-// ExtractNetworks interprets a page of results as a slice of Networks
+// ExtractNetworks interprets a page of results as a slice of Network.
 func ExtractNetworks(r pagination.Page) ([]Network, error) {
 	var s struct {
 		Networks []Network `json:"networks"`
@@ -42,8 +41,8 @@ type NetworkResult struct {
 	gophercloud.Result
 }
 
-// Extract is a method that attempts to interpret any Network resource
-// response as a Network struct.
+// Extract is a method that attempts to interpret any Network resource response
+// as a Network struct.
 func (r NetworkResult) Extract() (*Network, error) {
 	var s struct {
 		Network *Network `json:"network"`
@@ -52,8 +51,8 @@ func (r NetworkResult) Extract() (*Network, error) {
 	return s.Network, err
 }
 
-// GetResult is the response from a Get operation. Call its Extract method to interpret it
-// as a Network.
+// GetResult is the response from a Get operation. Call its Extract method to
+// interpret it as a Network.
 type GetResult struct {
 	NetworkResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach/doc.go
@@ -1,3 +1,30 @@
-// Package volumeattach provides the ability to attach and detach volumes
-// to instances
+/*
+Package volumeattach provides the ability to attach and detach volumes
+from servers.
+
+Example to Attach a Volume
+
+	serverID := "7ac8686c-de71-4acb-9600-ec18b1a1ed6d"
+	volumeID := "87463836-f0e2-4029-abf6-20c8892a3103"
+
+	createOpts := volumeattach.CreateOpts{
+		Device:   "/dev/vdc",
+		VolumeID: volumeID,
+	}
+
+	result, err := volumeattach.Create(computeClient, serverID, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Detach a Volume
+
+	serverID := "7ac8686c-de71-4acb-9600-ec18b1a1ed6d"
+	attachmentID := "ed081613-1c9b-4231-aa5e-ebfd4d87f983"
+
+	err := volumeattach.Delete(computeClient, serverID, attachmentID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
 package volumeattach

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach/requests.go
@@ -5,24 +5,26 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// List returns a Pager that allows you to iterate over a collection of VolumeAttachments.
+// List returns a Pager that allows you to iterate over a collection of
+// VolumeAttachments.
 func List(client *gophercloud.ServiceClient, serverID string) pagination.Pager {
 	return pagination.NewPager(client, listURL(client, serverID), func(r pagination.PageResult) pagination.Page {
 		return VolumeAttachmentPage{pagination.SinglePageBase(r)}
 	})
 }
 
-// CreateOptsBuilder describes struct types that can be accepted by the Create call. Notable, the
-// CreateOpts struct in this package does.
+// CreateOptsBuilder allows extensions to add parameters to the Create request.
 type CreateOptsBuilder interface {
 	ToVolumeAttachmentCreateMap() (map[string]interface{}, error)
 }
 
 // CreateOpts specifies volume attachment creation or import parameters.
 type CreateOpts struct {
-	// Device is the device that the volume will attach to the instance as. Omit for "auto"
+	// Device is the device that the volume will attach to the instance as.
+	// Omit for "auto".
 	Device string `json:"device,omitempty"`
-	// VolumeID is the ID of the volume to attach to the instance
+
+	// VolumeID is the ID of the volume to attach to the instance.
 	VolumeID string `json:"volumeId" required:"true"`
 }
 
@@ -31,7 +33,7 @@ func (opts CreateOpts) ToVolumeAttachmentCreateMap() (map[string]interface{}, er
 	return gophercloud.BuildRequestBody(opts, "volumeAttachment")
 }
 
-// Create requests the creation of a new volume attachment on the server
+// Create requests the creation of a new volume attachment on the server.
 func Create(client *gophercloud.ServiceClient, serverID string, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToVolumeAttachmentCreateMap()
 	if err != nil {
@@ -50,7 +52,8 @@ func Get(client *gophercloud.ServiceClient, serverID, attachmentID string) (r Ge
 	return
 }
 
-// Delete requests the deletion of a previous stored VolumeAttachment from the server.
+// Delete requests the deletion of a previous stored VolumeAttachment from
+// the server.
 func Delete(client *gophercloud.ServiceClient, serverID, attachmentID string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, serverID, attachmentID), nil)
 	return

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach/results.go
@@ -5,35 +5,36 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// VolumeAttachment controls the attachment of a volume to an instance.
+// VolumeAttachment contains attachment information between a volume
+// and server.
 type VolumeAttachment struct {
-	// ID is a unique id of the attachment
+	// ID is a unique id of the attachment.
 	ID string `json:"id"`
 
-	// Device is what device the volume is attached as
+	// Device is what device the volume is attached as.
 	Device string `json:"device"`
 
-	// VolumeID is the ID of the attached volume
+	// VolumeID is the ID of the attached volume.
 	VolumeID string `json:"volumeId"`
 
-	// ServerID is the ID of the instance that has the volume attached
+	// ServerID is the ID of the instance that has the volume attached.
 	ServerID string `json:"serverId"`
 }
 
-// VolumeAttachmentPage stores a single, only page of VolumeAttachments
+// VolumeAttachmentPage stores a single page all of VolumeAttachment
 // results from a List call.
 type VolumeAttachmentPage struct {
 	pagination.SinglePageBase
 }
 
-// IsEmpty determines whether or not a VolumeAttachmentsPage is empty.
+// IsEmpty determines whether or not a VolumeAttachmentPage is empty.
 func (page VolumeAttachmentPage) IsEmpty() (bool, error) {
 	va, err := ExtractVolumeAttachments(page)
 	return len(va) == 0, err
 }
 
 // ExtractVolumeAttachments interprets a page of results as a slice of
-// VolumeAttachments.
+// VolumeAttachment.
 func ExtractVolumeAttachments(r pagination.Page) ([]VolumeAttachment, error) {
 	var s struct {
 		VolumeAttachments []VolumeAttachment `json:"volumeAttachments"`
@@ -57,20 +58,20 @@ func (r VolumeAttachmentResult) Extract() (*VolumeAttachment, error) {
 	return s.VolumeAttachment, err
 }
 
-// CreateResult is the response from a Create operation. Call its Extract method to interpret it
-// as a VolumeAttachment.
+// CreateResult is the response from a Create operation. Call its Extract method
+// to interpret it as a VolumeAttachment.
 type CreateResult struct {
 	VolumeAttachmentResult
 }
 
-// GetResult is the response from a Get operation. Call its Extract method to interpret it
-// as a VolumeAttachment.
+// GetResult is the response from a Get operation. Call its Extract method to
+// interpret it as a VolumeAttachment.
 type GetResult struct {
 	VolumeAttachmentResult
 }
 
-// DeleteResult is the response from a Delete operation. Call its Extract method to determine if
-// the call succeeded or failed.
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/flavors/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/flavors/requests.go
@@ -52,6 +52,14 @@ type ListOpts struct {
 	MinDisk int `q:"minDisk"`
 	MinRAM  int `q:"minRam"`
 
+	// SortDir allows to select sort direction.
+	// It can be "asc" or "desc" (default).
+	SortDir string `q:"sort_dir"`
+
+	// SortKey allows to sort by one of the flavors attributes.
+	// Default is flavorid.
+	SortKey string `q:"sort_key"`
+
 	// Marker and Limit control paging.
 	// Marker instructs List where to start listing from.
 	Marker string `q:"marker"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/images/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/images/doc.go
@@ -1,7 +1,32 @@
-// Package images provides information and interaction with the image API
-// resource in the OpenStack Compute service.
-//
-// An image is a collection of files used to create or rebuild a server.
-// Operators provide a number of pre-built OS images by default. You may also
-// create custom images from cloud servers you have launched.
+/*
+Package images provides information and interaction with the images through
+the OpenStack Compute service.
+
+This API is deprecated and will be removed from a future version of the Nova
+API service.
+
+An image is a collection of files used to create or rebuild a server.
+Operators provide a number of pre-built OS images by default. You may also
+create custom images from cloud servers you have launched.
+
+Example to List Images
+
+	listOpts := images.ListOpts{
+		Limit: 2,
+	}
+
+	allPages, err := images.ListDetail(computeClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allImages, err := images.ExtractImages(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, image := range allImages {
+		fmt.Printf("%+v\n", image)
+	}
+*/
 package images

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/images/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/images/requests.go
@@ -6,26 +6,33 @@ import (
 )
 
 // ListOptsBuilder allows extensions to add additional parameters to the
-// List request.
+// ListDetail request.
 type ListOptsBuilder interface {
 	ToImageListQuery() (string, error)
 }
 
-// ListOpts contain options for limiting the number of Images returned from a call to ListDetail.
+// ListOpts contain options filtering Images returned from a call to ListDetail.
 type ListOpts struct {
-	// When the image last changed status (in date-time format).
+	// ChangesSince filters Images based on the last changed status (in date-time
+	// format).
 	ChangesSince string `q:"changes-since"`
-	// The number of Images to return.
+
+	// Limit limits the number of Images to return.
 	Limit int `q:"limit"`
-	// UUID of the Image at which to set a marker.
+
+	// Mark is an Image UUID at which to set a marker.
 	Marker string `q:"marker"`
-	// The name of the Image.
+
+	// Name is the name of the Image.
 	Name string `q:"name"`
-	// The name of the Server (in URL format).
+
+	// Server is the name of the Server (in URL format).
 	Server string `q:"server"`
-	// The current status of the Image.
+
+	// Status is the current status of the Image.
 	Status string `q:"status"`
-	// The value of the type of image (e.g. BASE, SERVER, ALL)
+
+	// Type is the type of image (e.g. BASE, SERVER, ALL).
 	Type string `q:"type"`
 }
 
@@ -50,8 +57,7 @@ func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) paginat
 	})
 }
 
-// Get acquires additional detail about a specific image by ID.
-// Use ExtractImage() to interpret the result as an openstack Image.
+// Get returns data about a specific image by its ID.
 func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
 	return
@@ -63,7 +69,8 @@ func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	return
 }
 
-// IDFromName is a convienience function that returns an image's ID given its name.
+// IDFromName is a convienience function that returns an image's ID given its
+// name.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/images/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/images/results.go
@@ -5,12 +5,14 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// GetResult temporarily stores a Get response.
+// GetResult is the response from a Get operation. Call its Extract method to
+// interpret it as an Image.
 type GetResult struct {
 	gophercloud.Result
 }
 
-// DeleteResult represents the result of an image.Delete operation.
+// DeleteResult is the result from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
@@ -24,44 +26,53 @@ func (r GetResult) Extract() (*Image, error) {
 	return s.Image, err
 }
 
-// Image is used for JSON (un)marshalling.
-// It provides a description of an OS image.
+// Image represents an Image returned by the Compute API.
 type Image struct {
-	// ID contains the image's unique identifier.
+	// ID is the unique ID of an image.
 	ID string
 
+	// Created is the date when the image was created.
 	Created string
 
-	// MinDisk and MinRAM specify the minimum resources a server must provide to be able to install the image.
+	// MinDisk is the minimum amount of disk a flavor must have to be able
+	// to create a server based on the image, measured in GB.
 	MinDisk int
-	MinRAM  int
+
+	// MinRAM is the minimum amount of RAM a flavor must have to be able
+	// to create a server based on the image, measured in MB.
+	MinRAM int
 
 	// Name provides a human-readable moniker for the OS image.
 	Name string
 
 	// The Progress and Status fields indicate image-creation status.
-	// Any usable image will have 100% progress.
 	Progress int
-	Status   string
 
+	// Status is the current status of the image.
+	Status string
+
+	// Update is the date when the image was updated.
 	Updated string
 
+	// Metadata provides free-form key/value pairs that further describe the
+	// image.
 	Metadata map[string]interface{}
 }
 
-// ImagePage contains a single page of results from a List operation.
-// Use ExtractImages to convert it into a slice of usable structs.
+// ImagePage contains a single page of all Images returne from a ListDetail
+// operation. Use ExtractImages to convert it into a slice of usable structs.
 type ImagePage struct {
 	pagination.LinkedPageBase
 }
 
-// IsEmpty returns true if a page contains no Image results.
+// IsEmpty returns true if an ImagePage contains no Image results.
 func (page ImagePage) IsEmpty() (bool, error) {
 	images, err := ExtractImages(page)
 	return len(images) == 0, err
 }
 
-// NextPageURL uses the response's embedded link reference to navigate to the next page of results.
+// NextPageURL uses the response's embedded link reference to navigate to the
+// next page of results.
 func (page ImagePage) NextPageURL() (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"images_links"`
@@ -73,7 +84,8 @@ func (page ImagePage) NextPageURL() (string, error) {
 	return gophercloud.ExtractNextURL(s.Links)
 }
 
-// ExtractImages converts a page of List results into a slice of usable Image structs.
+// ExtractImages converts a page of List results into a slice of usable Image
+// structs.
 func ExtractImages(r pagination.Page) ([]Image, error) {
 	var s struct {
 		Images []Image `json:"images"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/doc.go
@@ -1,6 +1,115 @@
-// Package servers provides information and interaction with the server API
-// resource in the OpenStack Compute service.
-//
-// A server is a virtual machine instance in the compute system. In order for
-// one to be provisioned, a valid flavor and image are required.
+/*
+Package servers provides information and interaction with the server API
+resource in the OpenStack Compute service.
+
+A server is a virtual machine instance in the compute system. In order for
+one to be provisioned, a valid flavor and image are required.
+
+Example to List Servers
+
+	listOpts := servers.ListOpts{
+		AllTenants: true,
+	}
+
+	allPages, err := servers.List(computeClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allServers, err := servers.ExtractServers(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, server := range allServers {
+		fmt.Printf("%+v\n", server)
+	}
+
+Example to Create a Server
+
+	createOpts := servers.CreateOpts{
+		Name:      "server_name",
+		ImageRef:  "image-uuid",
+		FlavorRef: "flavor-uuid",
+	}
+
+	server, err := servers.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Server
+
+	serverID := "d9072956-1560-487c-97f2-18bdf65ec749"
+	err := servers.Delete(computeClient, serverID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Force Delete a Server
+
+	serverID := "d9072956-1560-487c-97f2-18bdf65ec749"
+	err := servers.ForceDelete(computeClient, serverID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Reboot a Server
+
+	rebootOpts := servers.RebootOpts{
+		Type: servers.SoftReboot,
+	}
+
+	serverID := "d9072956-1560-487c-97f2-18bdf65ec749"
+
+	err := servers.Reboot(computeClient, serverID, rebootOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Rebuild a Server
+
+	rebuildOpts := servers.RebuildOpts{
+		Name:    "new_name",
+		ImageID: "image-uuid",
+	}
+
+	serverID := "d9072956-1560-487c-97f2-18bdf65ec749"
+
+	server, err := servers.Rebuilt(computeClient, serverID, rebuildOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Resize a Server
+
+	resizeOpts := servers.ResizeOpts{
+		FlavorRef: "flavor-uuid",
+	}
+
+	serverID := "d9072956-1560-487c-97f2-18bdf65ec749"
+
+	err := servers.Resize(computeClient, serverID, resizeOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+	err = servers.ConfirmResize(computeClient, serverID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Snapshot a Server
+
+	snapshotOpts := servers.CreateImageOpts{
+		Name: "snapshot_name",
+	}
+
+	serverID := "d9072956-1560-487c-97f2-18bdf65ec749"
+
+	image, err := servers.CreateImage(computeClient, serverID, snapshotOpts).ExtractImageID()
+	if err != nil {
+		panic(err)
+	}
+*/
 package servers

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/requests.go
@@ -21,13 +21,13 @@ type ListOptsBuilder interface {
 // the server attributes you want to see returned. Marker and Limit are used
 // for pagination.
 type ListOpts struct {
-	// A time/date stamp for when the server last changed status.
+	// ChangesSince is a time/date stamp for when the server last changed status.
 	ChangesSince string `q:"changes-since"`
 
-	// Name of the image in URL format.
+	// Image is the name of the image in URL format.
 	Image string `q:"image"`
 
-	// Name of the flavor in URL format.
+	// Flavor is the name of the flavor in URL format.
 	Flavor string `q:"flavor"`
 
 	// Name of the server as a string; can be queried with regular expressions.
@@ -36,20 +36,25 @@ type ListOpts struct {
 	// underlying database server implemented for Compute.
 	Name string `q:"name"`
 
-	// Value of the status of the server so that you can filter on "ACTIVE" for example.
+	// Status is the value of the status of the server so that you can filter on
+	// "ACTIVE" for example.
 	Status string `q:"status"`
 
-	// Name of the host as a string.
+	// Host is the name of the host as a string.
 	Host string `q:"host"`
 
-	// UUID of the server at which you want to set a marker.
+	// Marker is a UUID of the server at which you want to set a marker.
 	Marker string `q:"marker"`
 
-	// Integer value for the limit of values to return.
+	// Limit is an integer value for the limit of values to return.
 	Limit int `q:"limit"`
 
-	// Bool to show all tenants
+	// AllTenants is a bool to show all tenants.
 	AllTenants bool `q:"all_tenants"`
+
+	// TenantID lists servers for a particular tenant.
+	// Setting "AllTenants = true" is required.
+	TenantID string `q:"tenant_id"`
 }
 
 // ToServerListQuery formats a ListOpts into a query string.
@@ -73,15 +78,16 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	})
 }
 
-// CreateOptsBuilder describes struct types that can be accepted by the Create call.
-// The CreateOpts struct in this package does.
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToServerCreateMap() (map[string]interface{}, error)
 }
 
-// Network is used within CreateOpts to control a new server's network attachments.
+// Network is used within CreateOpts to control a new server's network
+// attachments.
 type Network struct {
-	// UUID of a nova-network to attach to the newly provisioned server.
+	// UUID of a network to attach to the newly provisioned server.
 	// Required unless Port is provided.
 	UUID string
 
@@ -89,19 +95,21 @@ type Network struct {
 	// Required unless UUID is provided.
 	Port string
 
-	// FixedIP [optional] specifies a fixed IPv4 address to be used on this network.
+	// FixedIP specifies a fixed IPv4 address to be used on this network.
 	FixedIP string
 }
 
 // Personality is an array of files that are injected into the server at launch.
 type Personality []*File
 
-// File is used within CreateOpts and RebuildOpts to inject a file into the server at launch.
-// File implements the json.Marshaler interface, so when a Create or Rebuild operation is requested,
-// json.Marshal will call File's MarshalJSON method.
+// File is used within CreateOpts and RebuildOpts to inject a file into the
+// server at launch.
+// File implements the json.Marshaler interface, so when a Create or Rebuild
+// operation is requested, json.Marshal will call File's MarshalJSON method.
 type File struct {
-	// Path of the file
+	// Path of the file.
 	Path string
+
 	// Contents of the file. Maximum content size is 255 bytes.
 	Contents []byte
 }
@@ -123,13 +131,13 @@ type CreateOpts struct {
 	// Name is the name to assign to the newly launched server.
 	Name string `json:"name" required:"true"`
 
-	// ImageRef [optional; required if ImageName is not provided] is the ID or full
-	// URL to the image that contains the server's OS and initial state.
+	// ImageRef [optional; required if ImageName is not provided] is the ID or
+	// full URL to the image that contains the server's OS and initial state.
 	// Also optional if using the boot-from-volume extension.
 	ImageRef string `json:"imageRef"`
 
-	// ImageName [optional; required if ImageRef is not provided] is the name of the
-	// image that contains the server's OS and initial state.
+	// ImageName [optional; required if ImageRef is not provided] is the name of
+	// the image that contains the server's OS and initial state.
 	// Also optional if using the boot-from-volume extension.
 	ImageName string `json:"-"`
 
@@ -141,7 +149,8 @@ type CreateOpts struct {
 	// the flavor that describes the server's specs.
 	FlavorName string `json:"-"`
 
-	// SecurityGroups lists the names of the security groups to which this server should belong.
+	// SecurityGroups lists the names of the security groups to which this server
+	// should belong.
 	SecurityGroups []string `json:"-"`
 
 	// UserData contains configuration information or scripts to use upon launch.
@@ -152,10 +161,12 @@ type CreateOpts struct {
 	AvailabilityZone string `json:"availability_zone,omitempty"`
 
 	// Networks dictates how this server will be attached to available networks.
-	// By default, the server will be attached to all isolated networks for the tenant.
+	// By default, the server will be attached to all isolated networks for the
+	// tenant.
 	Networks []Network `json:"-"`
 
-	// Metadata contains key-value pairs (up to 255 bytes each) to attach to the server.
+	// Metadata contains key-value pairs (up to 255 bytes each) to attach to the
+	// server.
 	Metadata map[string]string `json:"metadata,omitempty"`
 
 	// Personality includes files to inject into the server at launch.
@@ -166,7 +177,7 @@ type CreateOpts struct {
 	ConfigDrive *bool `json:"config_drive,omitempty"`
 
 	// AdminPass sets the root user password. If not set, a randomly-generated
-	// password will be created and returned in the rponse.
+	// password will be created and returned in the response.
 	AdminPass string `json:"adminPass,omitempty"`
 
 	// AccessIPv4 specifies an IPv4 address for the instance.
@@ -180,7 +191,8 @@ type CreateOpts struct {
 	ServiceClient *gophercloud.ServiceClient `json:"-"`
 }
 
-// ToServerCreateMap assembles a request body based on the contents of a CreateOpts.
+// ToServerCreateMap assembles a request body based on the contents of a
+// CreateOpts.
 func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
 	sc := opts.ServiceClient
 	opts.ServiceClient = nil
@@ -274,13 +286,14 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	return
 }
 
-// Delete requests that a server previously provisioned be removed from your account.
+// Delete requests that a server previously provisioned be removed from your
+// account.
 func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, id), nil)
 	return
 }
 
-// ForceDelete forces the deletion of a server
+// ForceDelete forces the deletion of a server.
 func ForceDelete(client *gophercloud.ServiceClient, id string) (r ActionResult) {
 	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"forceDelete": ""}, nil, nil)
 	return
@@ -294,12 +307,14 @@ func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
-// UpdateOptsBuilder allows extensions to add additional attributes to the Update request.
+// UpdateOptsBuilder allows extensions to add additional attributes to the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToServerUpdateMap() (map[string]interface{}, error)
 }
 
-// UpdateOpts specifies the base attributes that may be updated on an existing server.
+// UpdateOpts specifies the base attributes that may be updated on an existing
+// server.
 type UpdateOpts struct {
 	// Name changes the displayed name of the server.
 	// The server host name will *not* change.
@@ -331,7 +346,8 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder
 	return
 }
 
-// ChangeAdminPassword alters the administrator or root password for a specified server.
+// ChangeAdminPassword alters the administrator or root password for a specified
+// server.
 func ChangeAdminPassword(client *gophercloud.ServiceClient, id, newPassword string) (r ActionResult) {
 	b := map[string]interface{}{
 		"changePassword": map[string]string{
@@ -354,33 +370,38 @@ const (
 	PowerCycle              = HardReboot
 )
 
-// RebootOptsBuilder is an interface that options must satisfy in order to be
-// used when rebooting a server instance
+// RebootOptsBuilder allows extensions to add additional parameters to the
+// reboot request.
 type RebootOptsBuilder interface {
 	ToServerRebootMap() (map[string]interface{}, error)
 }
 
-// RebootOpts satisfies the RebootOptsBuilder interface
+// RebootOpts provides options to the reboot request.
 type RebootOpts struct {
+	// Type is the type of reboot to perform on the server.
 	Type RebootMethod `json:"type" required:"true"`
 }
 
-// ToServerRebootMap allows RebootOpts to satisfiy the RebootOptsBuilder
-// interface
-func (opts *RebootOpts) ToServerRebootMap() (map[string]interface{}, error) {
+// ToServerRebootMap builds a body for the reboot request.
+func (opts RebootOpts) ToServerRebootMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "reboot")
 }
 
-// Reboot requests that a given server reboot.
-// Two methods exist for rebooting a server:
-//
-// HardReboot (aka PowerCycle) starts the server instance by physically cutting power to the machine, or if a VM,
-// terminating it at the hypervisor level.
-// It's done. Caput. Full stop.
-// Then, after a brief while, power is rtored or the VM instance rtarted.
-//
-// SoftReboot (aka OSReboot) simply tells the OS to rtart under its own procedur.
-// E.g., in Linux, asking it to enter runlevel 6, or executing "sudo shutdown -r now", or by asking Windows to rtart the machine.
+/*
+	Reboot requests that a given server reboot.
+
+	Two methods exist for rebooting a server:
+
+	HardReboot (aka PowerCycle) starts the server instance by physically cutting
+	power to the machine, or if a VM, terminating it at the hypervisor level.
+	It's done. Caput. Full stop.
+	Then, after a brief while, power is rtored or the VM instance restarted.
+
+	SoftReboot (aka OSReboot) simply tells the OS to restart under its own
+	procedure.
+	E.g., in Linux, asking it to enter runlevel 6, or executing
+	"sudo shutdown -r now", or by asking Windows to rtart the machine.
+*/
 func Reboot(client *gophercloud.ServiceClient, id string, opts RebootOptsBuilder) (r ActionResult) {
 	b, err := opts.ToServerRebootMap()
 	if err != nil {
@@ -391,31 +412,43 @@ func Reboot(client *gophercloud.ServiceClient, id string, opts RebootOptsBuilder
 	return
 }
 
-// RebuildOptsBuilder is an interface that allows extensions to override the
-// default behaviour of rebuild options
+// RebuildOptsBuilder allows extensions to provide additional parameters to the
+// rebuild request.
 type RebuildOptsBuilder interface {
 	ToServerRebuildMap() (map[string]interface{}, error)
 }
 
 // RebuildOpts represents the configuration options used in a server rebuild
-// operation
+// operation.
 type RebuildOpts struct {
-	// The server's admin password
+	// AdminPass is the server's admin password
 	AdminPass string `json:"adminPass,omitempty"`
-	// The ID of the image you want your server to be provisioned on
-	ImageID   string `json:"imageRef"`
+
+	// ImageID is the ID of the image you want your server to be provisioned on.
+	ImageID string `json:"imageRef"`
+
+	// ImageName is readable name of an image.
 	ImageName string `json:"-"`
+
 	// Name to set the server to
 	Name string `json:"name,omitempty"`
+
 	// AccessIPv4 [optional] provides a new IPv4 address for the instance.
 	AccessIPv4 string `json:"accessIPv4,omitempty"`
+
 	// AccessIPv6 [optional] provides a new IPv6 address for the instance.
 	AccessIPv6 string `json:"accessIPv6,omitempty"`
-	// Metadata [optional] contains key-value pairs (up to 255 bytes each) to attach to the server.
+
+	// Metadata [optional] contains key-value pairs (up to 255 bytes each)
+	// to attach to the server.
 	Metadata map[string]string `json:"metadata,omitempty"`
+
 	// Personality [optional] includes files to inject into the server at launch.
 	// Rebuild will base64-encode file contents for you.
-	Personality   Personality                `json:"personality,omitempty"`
+	Personality Personality `json:"personality,omitempty"`
+
+	// ServiceClient will allow calls to be made to retrieve an image or
+	// flavor ID by name.
 	ServiceClient *gophercloud.ServiceClient `json:"-"`
 }
 
@@ -458,31 +491,34 @@ func Rebuild(client *gophercloud.ServiceClient, id string, opts RebuildOptsBuild
 	return
 }
 
-// ResizeOptsBuilder is an interface that allows extensions to override the default structure of
-// a Resize request.
+// ResizeOptsBuilder allows extensions to add additional parameters to the
+// resize request.
 type ResizeOptsBuilder interface {
 	ToServerResizeMap() (map[string]interface{}, error)
 }
 
-// ResizeOpts represents the configuration options used to control a Resize operation.
+// ResizeOpts represents the configuration options used to control a Resize
+// operation.
 type ResizeOpts struct {
 	// FlavorRef is the ID of the flavor you wish your server to become.
 	FlavorRef string `json:"flavorRef" required:"true"`
 }
 
-// ToServerResizeMap formats a ResizeOpts as a map that can be used as a JSON request body for the
-// Resize request.
+// ToServerResizeMap formats a ResizeOpts as a map that can be used as a JSON
+// request body for the Resize request.
 func (opts ResizeOpts) ToServerResizeMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "resize")
 }
 
 // Resize instructs the provider to change the flavor of the server.
+//
 // Note that this implies rebuilding it.
+//
 // Unfortunately, one cannot pass rebuild parameters to the resize function.
-// When the resize completes, the server will be in RESIZE_VERIFY state.
-// While in this state, you can explore the use of the new server's configuration.
-// If you like it, call ConfirmResize() to commit the resize permanently.
-// Otherwise, call RevertResize() to restore the old configuration.
+// When the resize completes, the server will be in VERIFY_RESIZE state.
+// While in this state, you can explore the use of the new server's
+// configuration. If you like it, call ConfirmResize() to commit the resize
+// permanently. Otherwise, call RevertResize() to restore the old configuration.
 func Resize(client *gophercloud.ServiceClient, id string, opts ResizeOptsBuilder) (r ActionResult) {
 	b, err := opts.ToServerResizeMap()
 	if err != nil {
@@ -509,41 +545,8 @@ func RevertResize(client *gophercloud.ServiceClient, id string) (r ActionResult)
 	return
 }
 
-// RescueOptsBuilder is an interface that allows extensions to override the
-// default structure of a Rescue request.
-type RescueOptsBuilder interface {
-	ToServerRescueMap() (map[string]interface{}, error)
-}
-
-// RescueOpts represents the configuration options used to control a Rescue
-// option.
-type RescueOpts struct {
-	// AdminPass is the desired administrative password for the instance in
-	// RESCUE mode. If it's left blank, the server will generate a password.
-	AdminPass string `json:"adminPass,omitempty"`
-}
-
-// ToServerRescueMap formats a RescueOpts as a map that can be used as a JSON
-// request body for the Rescue request.
-func (opts RescueOpts) ToServerRescueMap() (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, "rescue")
-}
-
-// Rescue instructs the provider to place the server into RESCUE mode.
-func Rescue(client *gophercloud.ServiceClient, id string, opts RescueOptsBuilder) (r RescueResult) {
-	b, err := opts.ToServerRescueMap()
-	if err != nil {
-		r.Err = err
-		return
-	}
-	_, r.Err = client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
-		OkCodes: []int{200},
-	})
-	return
-}
-
-// ResetMetadataOptsBuilder allows extensions to add additional parameters to the
-// Reset request.
+// ResetMetadataOptsBuilder allows extensions to add additional parameters to
+// the Reset request.
 type ResetMetadataOptsBuilder interface {
 	ToMetadataResetMap() (map[string]interface{}, error)
 }
@@ -551,20 +554,23 @@ type ResetMetadataOptsBuilder interface {
 // MetadataOpts is a map that contains key-value pairs.
 type MetadataOpts map[string]string
 
-// ToMetadataResetMap assembles a body for a Reset request based on the contents of a MetadataOpts.
+// ToMetadataResetMap assembles a body for a Reset request based on the contents
+// of a MetadataOpts.
 func (opts MetadataOpts) ToMetadataResetMap() (map[string]interface{}, error) {
 	return map[string]interface{}{"metadata": opts}, nil
 }
 
-// ToMetadataUpdateMap assembles a body for an Update request based on the contents of a MetadataOpts.
+// ToMetadataUpdateMap assembles a body for an Update request based on the
+// contents of a MetadataOpts.
 func (opts MetadataOpts) ToMetadataUpdateMap() (map[string]interface{}, error) {
 	return map[string]interface{}{"metadata": opts}, nil
 }
 
-// ResetMetadata will create multiple new key-value pairs for the given server ID.
-// Note: Using this operation will erase any already-existing metadata and create
-// the new metadata provided. To keep any already-existing metadata, use the
-// UpdateMetadatas or UpdateMetadata function.
+// ResetMetadata will create multiple new key-value pairs for the given server
+// ID.
+// Note: Using this operation will erase any already-existing metadata and
+// create the new metadata provided. To keep any already-existing metadata,
+// use the UpdateMetadatas or UpdateMetadata function.
 func ResetMetadata(client *gophercloud.ServiceClient, id string, opts ResetMetadataOptsBuilder) (r ResetMetadataResult) {
 	b, err := opts.ToMetadataResetMap()
 	if err != nil {
@@ -583,15 +589,15 @@ func Metadata(client *gophercloud.ServiceClient, id string) (r GetMetadataResult
 	return
 }
 
-// UpdateMetadataOptsBuilder allows extensions to add additional parameters to the
-// Create request.
+// UpdateMetadataOptsBuilder allows extensions to add additional parameters to
+// the Create request.
 type UpdateMetadataOptsBuilder interface {
 	ToMetadataUpdateMap() (map[string]interface{}, error)
 }
 
-// UpdateMetadata updates (or creates) all the metadata specified by opts for the given server ID.
-// This operation does not affect already-existing metadata that is not specified
-// by opts.
+// UpdateMetadata updates (or creates) all the metadata specified by opts for
+// the given server ID. This operation does not affect already-existing metadata
+// that is not specified by opts.
 func UpdateMetadata(client *gophercloud.ServiceClient, id string, opts UpdateMetadataOptsBuilder) (r UpdateMetadataResult) {
 	b, err := opts.ToMetadataUpdateMap()
 	if err != nil {
@@ -613,7 +619,8 @@ type MetadatumOptsBuilder interface {
 // MetadatumOpts is a map of length one that contains a key-value pair.
 type MetadatumOpts map[string]string
 
-// ToMetadatumCreateMap assembles a body for a Create request based on the contents of a MetadataumOpts.
+// ToMetadatumCreateMap assembles a body for a Create request based on the
+// contents of a MetadataumOpts.
 func (opts MetadatumOpts) ToMetadatumCreateMap() (map[string]interface{}, string, error) {
 	if len(opts) != 1 {
 		err := gophercloud.ErrInvalidInput{}
@@ -629,7 +636,8 @@ func (opts MetadatumOpts) ToMetadatumCreateMap() (map[string]interface{}, string
 	return metadatum, key, nil
 }
 
-// CreateMetadatum will create or update the key-value pair with the given key for the given server ID.
+// CreateMetadatum will create or update the key-value pair with the given key
+// for the given server ID.
 func CreateMetadatum(client *gophercloud.ServiceClient, id string, opts MetadatumOptsBuilder) (r CreateMetadatumResult) {
 	b, key, err := opts.ToMetadatumCreateMap()
 	if err != nil {
@@ -642,53 +650,60 @@ func CreateMetadatum(client *gophercloud.ServiceClient, id string, opts Metadatu
 	return
 }
 
-// Metadatum requests the key-value pair with the given key for the given server ID.
+// Metadatum requests the key-value pair with the given key for the given
+// server ID.
 func Metadatum(client *gophercloud.ServiceClient, id, key string) (r GetMetadatumResult) {
 	_, r.Err = client.Get(metadatumURL(client, id, key), &r.Body, nil)
 	return
 }
 
-// DeleteMetadatum will delete the key-value pair with the given key for the given server ID.
+// DeleteMetadatum will delete the key-value pair with the given key for the
+// given server ID.
 func DeleteMetadatum(client *gophercloud.ServiceClient, id, key string) (r DeleteMetadatumResult) {
 	_, r.Err = client.Delete(metadatumURL(client, id, key), nil)
 	return
 }
 
-// ListAddresses makes a request against the API to list the servers IP addresses.
+// ListAddresses makes a request against the API to list the servers IP
+// addresses.
 func ListAddresses(client *gophercloud.ServiceClient, id string) pagination.Pager {
 	return pagination.NewPager(client, listAddressesURL(client, id), func(r pagination.PageResult) pagination.Page {
 		return AddressPage{pagination.SinglePageBase(r)}
 	})
 }
 
-// ListAddressesByNetwork makes a request against the API to list the servers IP addresses
-// for the given network.
+// ListAddressesByNetwork makes a request against the API to list the servers IP
+// addresses for the given network.
 func ListAddressesByNetwork(client *gophercloud.ServiceClient, id, network string) pagination.Pager {
 	return pagination.NewPager(client, listAddressesByNetworkURL(client, id, network), func(r pagination.PageResult) pagination.Page {
 		return NetworkAddressPage{pagination.SinglePageBase(r)}
 	})
 }
 
-// CreateImageOptsBuilder is the interface types must satisfy in order to be
-// used as CreateImage options
+// CreateImageOptsBuilder allows extensions to add additional parameters to the
+// CreateImage request.
 type CreateImageOptsBuilder interface {
 	ToServerCreateImageMap() (map[string]interface{}, error)
 }
 
-// CreateImageOpts satisfies the CreateImageOptsBuilder
+// CreateImageOpts provides options to pass to the CreateImage request.
 type CreateImageOpts struct {
-	// Name of the image/snapshot
+	// Name of the image/snapshot.
 	Name string `json:"name" required:"true"`
-	// Metadata contains key-value pairs (up to 255 bytes each) to attach to the created image.
+
+	// Metadata contains key-value pairs (up to 255 bytes each) to attach to
+	// the created image.
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
-// ToServerCreateImageMap formats a CreateImageOpts structure into a request body.
+// ToServerCreateImageMap formats a CreateImageOpts structure into a request
+// body.
 func (opts CreateImageOpts) ToServerCreateImageMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "createImage")
 }
 
-// CreateImage makes a request against the nova API to schedule an image to be created of the server
+// CreateImage makes a request against the nova API to schedule an image to be
+// created of the server
 func CreateImage(client *gophercloud.ServiceClient, id string, opts CreateImageOptsBuilder) (r CreateImageResult) {
 	b, err := opts.ToServerCreateImageMap()
 	if err != nil {
@@ -703,11 +718,17 @@ func CreateImage(client *gophercloud.ServiceClient, id string, opts CreateImageO
 	return
 }
 
-// IDFromName is a convienience function that returns a server's ID given its name.
+// IDFromName is a convienience function that returns a server's ID given its
+// name.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""
-	allPages, err := List(client, nil).AllPages()
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	allPages, err := List(client, listOpts).AllPages()
 	if err != nil {
 		return "", err
 	}
@@ -734,8 +755,40 @@ func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) 
 	}
 }
 
-// GetPassword makes a request against the nova API to get the encrypted administrative password.
+// GetPassword makes a request against the nova API to get the encrypted
+// administrative password.
 func GetPassword(client *gophercloud.ServiceClient, serverId string) (r GetPasswordResult) {
 	_, r.Err = client.Get(passwordURL(client, serverId), &r.Body, nil)
+	return
+}
+
+// ShowConsoleOutputOptsBuilder is the interface types must satisfy in order to be
+// used as ShowConsoleOutput options
+type ShowConsoleOutputOptsBuilder interface {
+	ToServerShowConsoleOutputMap() (map[string]interface{}, error)
+}
+
+// ShowConsoleOutputOpts satisfies the ShowConsoleOutputOptsBuilder
+type ShowConsoleOutputOpts struct {
+	// The number of lines to fetch from the end of console log.
+	// All lines will be returned if this is not specified.
+	Length int `json:"length,omitempty"`
+}
+
+// ToServerShowConsoleOutputMap formats a ShowConsoleOutputOpts structure into a request body.
+func (opts ShowConsoleOutputOpts) ToServerShowConsoleOutputMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "os-getConsoleOutput")
+}
+
+// ShowConsoleOutput makes a request against the nova API to get console log from the server
+func ShowConsoleOutput(client *gophercloud.ServiceClient, id string, opts ShowConsoleOutputOptsBuilder) (r ShowConsoleOutputResult) {
+	b, err := opts.ToServerShowConsoleOutputMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
 	return
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/results.go
@@ -32,54 +32,73 @@ func ExtractServersInto(r pagination.Page, v interface{}) error {
 	return r.(ServerPage).Result.ExtractIntoSlicePtr(v, "servers")
 }
 
-// CreateResult temporarily contains the response from a Create call.
+// CreateResult is the response from a Create operation. Call its Extract
+// method to interpret it as a Server.
 type CreateResult struct {
 	serverResult
 }
 
-// GetResult temporarily contains the response from a Get call.
+// GetResult is the response from a Get operation. Call its Extract
+// method to interpret it as a Server.
 type GetResult struct {
 	serverResult
 }
 
-// UpdateResult temporarily contains the response from an Update call.
+// UpdateResult is the response from an Update operation. Call its Extract
+// method to interpret it as a Server.
 type UpdateResult struct {
 	serverResult
 }
 
-// DeleteResult temporarily contains the response from a Delete call.
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
-// RebuildResult temporarily contains the response from a Rebuild call.
+// RebuildResult is the response from a Rebuild operation. Call its Extract
+// method to interpret it as a Server.
 type RebuildResult struct {
 	serverResult
 }
 
-// ActionResult represents the result of server action operations, like reboot
+// ActionResult represents the result of server action operations, like reboot.
+// Call its ExtractErr method to determine if the action succeeded or failed.
 type ActionResult struct {
 	gophercloud.ErrResult
 }
 
-// RescueResult represents the result of a server rescue operation
-type RescueResult struct {
-	ActionResult
-}
-
-// CreateImageResult represents the result of an image creation operation
+// CreateImageResult is the response from a CreateImage operation. Call its
+// ExtractImageID method to retrieve the ID of the newly created image.
 type CreateImageResult struct {
 	gophercloud.Result
 }
 
+// ShowConsoleOutputResult represents the result of console output from a server
+type ShowConsoleOutputResult struct {
+	gophercloud.Result
+}
+
+// Extract will return the console output from a ShowConsoleOutput request.
+func (r ShowConsoleOutputResult) Extract() (string, error) {
+	var s struct {
+		Output string `json:"output"`
+	}
+
+	err := r.ExtractInto(&s)
+	return s.Output, err
+}
+
 // GetPasswordResult represent the result of a get os-server-password operation.
+// Call its ExtractPassword method to retrieve the password.
 type GetPasswordResult struct {
 	gophercloud.Result
 }
 
 // ExtractPassword gets the encrypted password.
 // If privateKey != nil the password is decrypted with the private key.
-// If privateKey == nil the encrypted password is returned and can be decrypted with:
+// If privateKey == nil the encrypted password is returned and can be decrypted
+// with:
 //   echo '<pwd>' | base64 -D | openssl rsautl -decrypt -inkey <private_key>
 func (r GetPasswordResult) ExtractPassword(privateKey *rsa.PrivateKey) (string, error) {
 	var s struct {
@@ -107,7 +126,7 @@ func decryptPassword(encryptedPassword string, privateKey *rsa.PrivateKey) (stri
 	return string(password), nil
 }
 
-// ExtractImageID gets the ID of the newly created server image from the header
+// ExtractImageID gets the ID of the newly created server image from the header.
 func (r CreateImageResult) ExtractImageID() (string, error) {
 	if r.Err != nil {
 		return "", r.Err
@@ -124,54 +143,84 @@ func (r CreateImageResult) ExtractImageID() (string, error) {
 	return imageID, nil
 }
 
-// Extract interprets any RescueResult as an AdminPass, if possible.
-func (r RescueResult) Extract() (string, error) {
-	var s struct {
-		AdminPass string `json:"adminPass"`
-	}
-	err := r.ExtractInto(&s)
-	return s.AdminPass, err
-}
-
-// Server exposes only the standard OpenStack fields corresponding to a given server on the user's account.
+// Server represents a server/instance in the OpenStack cloud.
 type Server struct {
-	// ID uniquely identifies this server amongst all other servers, including those not accessible to the current tenant.
+	// ID uniquely identifies this server amongst all other servers,
+	// including those not accessible to the current tenant.
 	ID string `json:"id"`
+
 	// TenantID identifies the tenant owning this server resource.
 	TenantID string `json:"tenant_id"`
+
 	// UserID uniquely identifies the user account owning the tenant.
 	UserID string `json:"user_id"`
+
 	// Name contains the human-readable name for the server.
 	Name string `json:"name"`
-	// Updated and Created contain ISO-8601 timestamps of when the state of the server last changed, and when it was created.
+
+	// Updated and Created contain ISO-8601 timestamps of when the state of the
+	// server last changed, and when it was created.
 	Updated time.Time `json:"updated"`
 	Created time.Time `json:"created"`
-	HostID  string    `json:"hostid"`
-	// Status contains the current operational status of the server, such as IN_PROGRESS or ACTIVE.
+
+	// HostID is the host where the server is located in the cloud.
+	HostID string `json:"hostid"`
+
+	// Status contains the current operational status of the server,
+	// such as IN_PROGRESS or ACTIVE.
 	Status string `json:"status"`
+
 	// Progress ranges from 0..100.
 	// A request made against the server completes only once Progress reaches 100.
 	Progress int `json:"progress"`
-	// AccessIPv4 and AccessIPv6 contain the IP addresses of the server, suitable for remote access for administration.
+
+	// AccessIPv4 and AccessIPv6 contain the IP addresses of the server,
+	// suitable for remote access for administration.
 	AccessIPv4 string `json:"accessIPv4"`
 	AccessIPv6 string `json:"accessIPv6"`
-	// Image refers to a JSON object, which itself indicates the OS image used to deploy the server.
+
+	// Image refers to a JSON object, which itself indicates the OS image used to
+	// deploy the server.
 	Image map[string]interface{} `json:"-"`
-	// Flavor refers to a JSON object, which itself indicates the hardware configuration of the deployed server.
+
+	// Flavor refers to a JSON object, which itself indicates the hardware
+	// configuration of the deployed server.
 	Flavor map[string]interface{} `json:"flavor"`
-	// Addresses includes a list of all IP addresses assigned to the server, keyed by pool.
+
+	// Addresses includes a list of all IP addresses assigned to the server,
+	// keyed by pool.
 	Addresses map[string]interface{} `json:"addresses"`
-	// Metadata includes a list of all user-specified key-value pairs attached to the server.
+
+	// Metadata includes a list of all user-specified key-value pairs attached
+	// to the server.
 	Metadata map[string]string `json:"metadata"`
-	// Links includes HTTP references to the itself, useful for passing along to other APIs that might want a server reference.
+
+	// Links includes HTTP references to the itself, useful for passing along to
+	// other APIs that might want a server reference.
 	Links []interface{} `json:"links"`
+
 	// KeyName indicates which public key was injected into the server on launch.
 	KeyName string `json:"key_name"`
-	// AdminPass will generally be empty ("").  However, it will contain the administrative password chosen when provisioning a new server without a set AdminPass setting in the first place.
+
+	// AdminPass will generally be empty ("").  However, it will contain the
+	// administrative password chosen when provisioning a new server without a
+	// set AdminPass setting in the first place.
 	// Note that this is the ONLY time this field will be valid.
 	AdminPass string `json:"adminPass"`
-	// SecurityGroups includes the security groups that this instance has applied to it
+
+	// SecurityGroups includes the security groups that this instance has applied
+	// to it.
 	SecurityGroups []map[string]interface{} `json:"security_groups"`
+
+	// Fault contains failure information about a server.
+	Fault Fault `json:"fault"`
+}
+
+type Fault struct {
+	Code    int       `json:"code"`
+	Created time.Time `json:"created"`
+	Details string    `json:"details"`
+	Message string    `json:"message"`
 }
 
 func (r *Server) UnmarshalJSON(b []byte) error {
@@ -200,9 +249,10 @@ func (r *Server) UnmarshalJSON(b []byte) error {
 	return err
 }
 
-// ServerPage abstracts the raw results of making a List() request against the API.
-// As OpenStack extensions may freely alter the response bodies of structures returned to the client, you may only safely access the
-// data provided through the ExtractServers call.
+// ServerPage abstracts the raw results of making a List() request against
+// the API. As OpenStack extensions may freely alter the response bodies of
+// structures returned to the client, you may only safely access the data
+// provided through the ExtractServers call.
 type ServerPage struct {
 	pagination.LinkedPageBase
 }
@@ -213,7 +263,8 @@ func (r ServerPage) IsEmpty() (bool, error) {
 	return len(s) == 0, err
 }
 
-// NextPageURL uses the response's embedded link reference to navigate to the next page of results.
+// NextPageURL uses the response's embedded link reference to navigate to the
+// next page of results.
 func (r ServerPage) NextPageURL() (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"servers_links"`
@@ -225,49 +276,59 @@ func (r ServerPage) NextPageURL() (string, error) {
 	return gophercloud.ExtractNextURL(s.Links)
 }
 
-// ExtractServers interprets the results of a single page from a List() call, producing a slice of Server entities.
+// ExtractServers interprets the results of a single page from a List() call,
+// producing a slice of Server entities.
 func ExtractServers(r pagination.Page) ([]Server, error) {
 	var s []Server
 	err := ExtractServersInto(r, &s)
 	return s, err
 }
 
-// MetadataResult contains the result of a call for (potentially) multiple key-value pairs.
+// MetadataResult contains the result of a call for (potentially) multiple
+// key-value pairs. Call its Extract method to interpret it as a
+// map[string]interface.
 type MetadataResult struct {
 	gophercloud.Result
 }
 
-// GetMetadataResult temporarily contains the response from a metadata Get call.
+// GetMetadataResult contains the result of a Get operation. Call its Extract
+// method to interpret it as a map[string]interface.
 type GetMetadataResult struct {
 	MetadataResult
 }
 
-// ResetMetadataResult temporarily contains the response from a metadata Reset call.
+// ResetMetadataResult contains the result of a Reset operation. Call its
+// Extract method to interpret it as a map[string]interface.
 type ResetMetadataResult struct {
 	MetadataResult
 }
 
-// UpdateMetadataResult temporarily contains the response from a metadata Update call.
+// UpdateMetadataResult contains the result of an Update operation. Call its
+// Extract method to interpret it as a map[string]interface.
 type UpdateMetadataResult struct {
 	MetadataResult
 }
 
-// MetadatumResult contains the result of a call for individual a single key-value pair.
+// MetadatumResult contains the result of a call for individual a single
+// key-value pair.
 type MetadatumResult struct {
 	gophercloud.Result
 }
 
-// GetMetadatumResult temporarily contains the response from a metadatum Get call.
+// GetMetadatumResult contains the result of a Get operation. Call its Extract
+// method to interpret it as a map[string]interface.
 type GetMetadatumResult struct {
 	MetadatumResult
 }
 
-// CreateMetadatumResult temporarily contains the response from a metadatum Create call.
+// CreateMetadatumResult contains the result of a Create operation. Call its
+// Extract method to interpret it as a map[string]interface.
 type CreateMetadatumResult struct {
 	MetadatumResult
 }
 
-// DeleteMetadatumResult temporarily contains the response from a metadatum Delete call.
+// DeleteMetadatumResult contains the result of a Delete operation. Call its
+// ExtractErr method to determine if the call succeeded or failed.
 type DeleteMetadatumResult struct {
 	gophercloud.ErrResult
 }
@@ -296,9 +357,10 @@ type Address struct {
 	Address string `json:"addr"`
 }
 
-// AddressPage abstracts the raw results of making a ListAddresses() request against the API.
-// As OpenStack extensions may freely alter the response bodies of structures returned
-// to the client, you may only safely access the data provided through the ExtractAddresses call.
+// AddressPage abstracts the raw results of making a ListAddresses() request
+// against the API. As OpenStack extensions may freely alter the response bodies
+// of structures returned to the client, you may only safely access the data
+// provided through the ExtractAddresses call.
 type AddressPage struct {
 	pagination.SinglePageBase
 }
@@ -309,8 +371,8 @@ func (r AddressPage) IsEmpty() (bool, error) {
 	return len(addresses) == 0, err
 }
 
-// ExtractAddresses interprets the results of a single page from a ListAddresses() call,
-// producing a map of addresses.
+// ExtractAddresses interprets the results of a single page from a
+// ListAddresses() call, producing a map of addresses.
 func ExtractAddresses(r pagination.Page) (map[string][]Address, error) {
 	var s struct {
 		Addresses map[string][]Address `json:"addresses"`
@@ -319,9 +381,11 @@ func ExtractAddresses(r pagination.Page) (map[string][]Address, error) {
 	return s.Addresses, err
 }
 
-// NetworkAddressPage abstracts the raw results of making a ListAddressesByNetwork() request against the API.
-// As OpenStack extensions may freely alter the response bodies of structures returned
-// to the client, you may only safely access the data provided through the ExtractAddresses call.
+// NetworkAddressPage abstracts the raw results of making a
+// ListAddressesByNetwork() request against the API.
+// As OpenStack extensions may freely alter the response bodies of structures
+// returned to the client, you may only safely access the data provided through
+// the ExtractAddresses call.
 type NetworkAddressPage struct {
 	pagination.SinglePageBase
 }
@@ -332,8 +396,8 @@ func (r NetworkAddressPage) IsEmpty() (bool, error) {
 	return len(addresses) == 0, err
 }
 
-// ExtractNetworkAddresses interprets the results of a single page from a ListAddressesByNetwork() call,
-// producing a slice of addresses.
+// ExtractNetworkAddresses interprets the results of a single page from a
+// ListAddressesByNetwork() call, producing a slice of addresses.
 func ExtractNetworkAddresses(r pagination.Page) ([]Address, error) {
 	var s map[string][]Address
 	err := (r.(NetworkAddressPage)).ExtractInto(&s)

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/util.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/util.go
@@ -2,8 +2,9 @@ package servers
 
 import "github.com/gophercloud/gophercloud"
 
-// WaitForStatus will continually poll a server until it successfully transitions to a specified
-// status. It will do this for at most the number of seconds specified.
+// WaitForStatus will continually poll a server until it successfully
+// transitions to a specified status. It will do this for at most the number
+// of seconds specified.
 func WaitForStatus(c *gophercloud.ServiceClient, id, status string, secs int) error {
 	return gophercloud.WaitFor(secs, func() (bool, error) {
 		current, err := Get(c, id).Extract()

--- a/vendor/github.com/gophercloud/gophercloud/openstack/db/v1/instances/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/db/v1/instances/results.go
@@ -26,6 +26,36 @@ type Flavor struct {
 	Links []gophercloud.Link
 }
 
+// Fault describes the fault reason in more detail when a database instance has errored
+type Fault struct {
+	// Indicates the time when the fault occured
+	Created time.Time `json:"-"`
+
+	// A message describing the fault reason
+	Message string
+
+	// More details about the fault, for example a stack trace. Only filled
+	// in for admin users.
+	Details string
+}
+
+func (r *Fault) UnmarshalJSON(b []byte) error {
+	type tmp Fault
+	var s struct {
+		tmp
+		Created gophercloud.JSONRFC3339NoZ `json:"created"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Fault(s.tmp)
+
+	r.Created = time.Time(s.Created)
+
+	return nil
+}
+
 // Instance represents a remote MySQL instance.
 type Instance struct {
 	// Indicates the datetime that the instance was created
@@ -60,6 +90,9 @@ type Instance struct {
 
 	// The build status of the instance.
 	Status string
+
+	// Fault information (only available when the instance has errored)
+	Fault *Fault
 
 	// Information about the attached volume of the instance.
 	Volume Volume

--- a/vendor/github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets/doc.go
@@ -1,6 +1,54 @@
-// Package recordsets provides information and interaction with the zone API
-// resource for the OpenStack DNS service.
-//
-// For more information, see:
-// http://developer.openstack.org/api-ref/dns/#recordsets
+/*
+Package recordsets provides information and interaction with the zone API
+resource for the OpenStack DNS service.
+
+Example to List RecordSets by Zone
+
+	listOpts := recordsets.ListOpts{
+		Type: "A",
+	}
+
+	zoneID := "fff121f5-c506-410a-a69e-2d73ef9cbdbd"
+
+	allPages, err := recordsets.ListByZone(dnsClient, zoneID, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allRRs, err := recordsets.ExtractRecordSets(allPages()
+	if err != nil {
+		panic(err)
+	}
+
+	for _, rr := range allRRs {
+		fmt.Printf("%+v\n", rr)
+	}
+
+Example to Create a RecordSet
+
+	createOpts := recordsets.CreateOpts{
+		Name:        "example.com.",
+		Type:        "A",
+		TTL:         3600,
+		Description: "This is a recordset.",
+		Records:     []string{"10.1.0.2"},
+	}
+
+	zoneID := "fff121f5-c506-410a-a69e-2d73ef9cbdbd"
+
+	rr, err := recordsets.Create(dnsClient, zoneID, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a RecordSet
+
+	zoneID := "fff121f5-c506-410a-a69e-2d73ef9cbdbd"
+	recordsetID := "d96ed01a-b439-4eb8-9b90-7a9f71017f7b"
+
+	err := recordsets.Delete(dnsClient, zoneID, recordsetID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
 package recordsets

--- a/vendor/github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets/requests.go
@@ -55,18 +55,20 @@ func ListByZone(client *gophercloud.ServiceClient, zoneID string, opts ListOptsB
 	})
 }
 
-// Get implements the recordset get request.
+// Get implements the recordset Get request.
 func Get(client *gophercloud.ServiceClient, zoneID string, rrsetID string) (r GetResult) {
 	_, r.Err = client.Get(rrsetURL(client, zoneID, rrsetID), &r.Body, nil)
 	return
 }
 
-// CreateOptsBuilder allows extensions to add additional attributes to the Create request.
+// CreateOptsBuilder allows extensions to add additional attributes to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToRecordSetCreateMap() (map[string]interface{}, error)
 }
 
-// CreateOpts specifies the base attributes that may be used to create a RecordSet.
+// CreateOpts specifies the base attributes that may be used to create a
+// RecordSet.
 type CreateOpts struct {
 	// Name is the name of the RecordSet.
 	Name string `json:"name" required:"true"`
@@ -107,16 +109,23 @@ func Create(client *gophercloud.ServiceClient, zoneID string, opts CreateOptsBui
 	return
 }
 
-// UpdateOptsBuilder allows extensions to add additional attributes to the Update request.
+// UpdateOptsBuilder allows extensions to add additional attributes to the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToRecordSetUpdateMap() (map[string]interface{}, error)
 }
 
-// UpdateOpts specifies the base attributes that may be updated on an existing RecordSet.
+// UpdateOpts specifies the base attributes that may be updated on an existing
+// RecordSet.
 type UpdateOpts struct {
-	Description string   `json:"description,omitempty"`
-	TTL         int      `json:"ttl,omitempty"`
-	Records     []string `json:"records,omitempty"`
+	// Description is a description of the RecordSet.
+	Description string `json:"description,omitempty"`
+
+	// TTL is the time to live of the RecordSet.
+	TTL int `json:"ttl,omitempty"`
+
+	// Records are the DNS records of the RecordSet.
+	Records []string `json:"records,omitempty"`
 }
 
 // ToRecordSetUpdateMap formats an UpdateOpts structure into a request body.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets/results.go
@@ -12,7 +12,7 @@ type commonResult struct {
 	gophercloud.Result
 }
 
-// Extract interprets a GetResult, CreateResult or UpdateResult as a concrete RecordSet.
+// Extract interprets a GetResult, CreateResult or UpdateResult as a RecordSet.
 // An error is returned if the original call or the extraction failed.
 func (r commonResult) Extract() (*RecordSet, error) {
 	var s *RecordSet
@@ -20,12 +20,14 @@ func (r commonResult) Extract() (*RecordSet, error) {
 	return s, err
 }
 
-// CreateResult is the deferred result of a Create call.
+// CreateResult is the result of a Create operation. Call its Extract method to
+// interpret the result as a RecordSet.
 type CreateResult struct {
 	commonResult
 }
 
-// GetResult is the deferred result of a Get call.
+// GetResult is the result of a Get operation. Call its Extract method to
+// interpret the result as a RecordSet.
 type GetResult struct {
 	commonResult
 }
@@ -35,12 +37,14 @@ type RecordSetPage struct {
 	pagination.LinkedPageBase
 }
 
-// UpdateResult is the deferred result of an Update call.
+// UpdateResult is result of an Update operation. Call its Extract method to
+// interpret the result as a RecordSet.
 type UpdateResult struct {
 	commonResult
 }
 
-// DeleteResult is the deferred result of an Delete call.
+// DeleteResult is result of a Delete operation. Call its ExtractErr method to
+// determine if the operation succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
@@ -51,7 +55,7 @@ func (r RecordSetPage) IsEmpty() (bool, error) {
 	return len(s) == 0, err
 }
 
-// ExtractRecordSets extracts a slice of RecordSets from a Collection acquired from List.
+// ExtractRecordSets extracts a slice of RecordSets from a List result.
 func ExtractRecordSets(r pagination.Page) ([]RecordSet, error) {
 	var s struct {
 		RecordSets []RecordSet `json:"recordsets"`
@@ -60,6 +64,7 @@ func ExtractRecordSets(r pagination.Page) ([]RecordSet, error) {
 	return s.RecordSets, err
 }
 
+// RecordSet represents a DNS Record Set.
 type RecordSet struct {
 	// ID is the unique ID of the recordset
 	ID string `json:"id"`
@@ -95,7 +100,7 @@ type RecordSet struct {
 	Description string `json:"description"`
 
 	// Version is the revision of the recordset.
-	Version int `json:version"`
+	Version int `json:"version"`
 
 	// CreatedAt is the date when the recordset was created.
 	CreatedAt time.Time `json:"-"`
@@ -104,7 +109,8 @@ type RecordSet struct {
 	UpdatedAt time.Time `json:"-"`
 
 	// Links includes HTTP references to the itself,
-	// useful for passing along to other APIs that might want a recordset reference.
+	// useful for passing along to other APIs that might want a recordset
+	// reference.
 	Links []gophercloud.Link `json:"-"`
 }
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/dns/v2/zones/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/dns/v2/zones/doc.go
@@ -1,6 +1,48 @@
-// Package tokens provides information and interaction with the zone API
-// resource for the OpenStack DNS service.
-//
-// For more information, see:
-// http://developer.openstack.org/api-ref/dns/#zone
+/*
+Package zones provides information and interaction with the zone API
+resource for the OpenStack DNS service.
+
+Example to List Zones
+
+	listOpts := zones.ListOpts{
+		Email: "jdoe@example.com",
+	}
+
+	allPages, err := zones.List(dnsClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allZones, err := zones.ExtractZones(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, zone := range allZones {
+		fmt.Printf("%+v\n", zone)
+	}
+
+Example to Create a Zone
+
+	createOpts := zones.CreateOpts{
+		Name:        "example.com.",
+		Email:       "jdoe@example.com",
+		Type:        "PRIMARY",
+		TTL:         7200,
+		Description: "This is a zone.",
+	}
+
+	zone, err := zones.Create(dnsClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Zone
+
+	zoneID := "99d10f68-5623-4491-91a0-6daafa32b60e"
+	err := zones.Delete(dnsClient, zoneID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
 package zones

--- a/vendor/github.com/gophercloud/gophercloud/openstack/dns/v2/zones/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/dns/v2/zones/requests.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
+// ListOptsBuilder allows extensions to add parameters to the List request.
 type ListOptsBuilder interface {
 	ToZoneListQuery() (string, error)
 }
@@ -31,11 +32,13 @@ type ListOpts struct {
 	Type        string `q:"type"`
 }
 
+// ToZoneListQuery formats a ListOpts into a query string.
 func (opts ListOpts) ToZoneListQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
 	return q.String(), err
 }
 
+// List implements a zone List request.
 func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := baseURL(client)
 	if opts != nil {
@@ -50,18 +53,19 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	})
 }
 
-// Get returns additional information about a zone, given its ID.
+// Get returns information about a zone, given its ID.
 func Get(client *gophercloud.ServiceClient, zoneID string) (r GetResult) {
 	_, r.Err = client.Get(zoneURL(client, zoneID), &r.Body, nil)
 	return
 }
 
-// CreateOptsBuilder allows extensions to add additional attributes to the Update request.
+// CreateOptsBuilder allows extensions to add additional attributes to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToZoneCreateMap() (map[string]interface{}, error)
 }
 
-// CreateOpts specifies the base attributes used to create a zone.
+// CreateOpts specifies the attributes used to create a zone.
 type CreateOpts struct {
 	// Attributes are settings that supply hints and filters for the zone.
 	Attributes map[string]string `json:"attributes,omitempty"`
@@ -73,7 +77,7 @@ type CreateOpts struct {
 	Description string `json:"description,omitempty"`
 
 	// Name of the zone.
-	Name string `json:"name,required"`
+	Name string `json:"name" required:"true"`
 
 	// Masters specifies zone masters if this is a secondary zone.
 	Masters []string `json:"masters,omitempty"`
@@ -99,7 +103,7 @@ func (opts CreateOpts) ToZoneCreateMap() (map[string]interface{}, error) {
 	return b, nil
 }
 
-// Create a zone
+// Create implements a zone create request.
 func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToZoneCreateMap()
 	if err != nil {
@@ -112,17 +116,25 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	return
 }
 
-// UpdateOptsBuilder allows extensions to add additional attributes to the Update request.
+// UpdateOptsBuilder allows extensions to add additional attributes to the
+// Update request.
 type UpdateOptsBuilder interface {
 	ToZoneUpdateMap() (map[string]interface{}, error)
 }
 
-// UpdateOpts specifies the base attributes to update a zone.
+// UpdateOpts specifies the attributes to update a zone.
 type UpdateOpts struct {
-	Email       string   `json:"email,omitempty"`
-	TTL         int      `json:"-"`
-	Masters     []string `json:"masters,omitempty"`
-	Description string   `json:"description,omitempty"`
+	// Email contact of the zone.
+	Email string `json:"email,omitempty"`
+
+	// TTL is the time to live of the zone.
+	TTL int `json:"-"`
+
+	// Masters specifies zone masters if this is a secondary zone.
+	Masters []string `json:"masters,omitempty"`
+
+	// Description of the zone.
+	Description string `json:"description,omitempty"`
 }
 
 // ToZoneUpdateMap formats an UpdateOpts structure into a request body.
@@ -139,7 +151,7 @@ func (opts UpdateOpts) ToZoneUpdateMap() (map[string]interface{}, error) {
 	return b, nil
 }
 
-// Update a zone.
+// Update implements a zone update request.
 func Update(client *gophercloud.ServiceClient, zoneID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToZoneUpdateMap()
 	if err != nil {
@@ -152,7 +164,7 @@ func Update(client *gophercloud.ServiceClient, zoneID string, opts UpdateOptsBui
 	return
 }
 
-// Delete a zone.
+// Delete implements a zone delete request.
 func Delete(client *gophercloud.ServiceClient, zoneID string) (r DeleteResult) {
 	_, r.Err = client.Delete(zoneURL(client, zoneID), &gophercloud.RequestOpts{
 		OkCodes:      []int{202},

--- a/vendor/github.com/gophercloud/gophercloud/openstack/dns/v2/zones/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/dns/v2/zones/results.go
@@ -13,7 +13,7 @@ type commonResult struct {
 	gophercloud.Result
 }
 
-// Extract interprets a GetResult, CreateResult or UpdateResult as a concrete Zone.
+// Extract interprets a GetResult, CreateResult or UpdateResult as a Zone.
 // An error is returned if the original call or the extraction failed.
 func (r commonResult) Extract() (*Zone, error) {
 	var s *Zone
@@ -21,22 +21,26 @@ func (r commonResult) Extract() (*Zone, error) {
 	return s, err
 }
 
-// CreateResult is the deferred result of a Create call.
+// CreateResult is the result of a Create request. Call its Extract method
+// to interpret the result as a Zone.
 type CreateResult struct {
 	commonResult
 }
 
-// GetResult is the deferred result of a Get call.
+// GetResult is the result of a Get request. Call its Extract method
+// to interpret the result as a Zone.
 type GetResult struct {
 	commonResult
 }
 
-// UpdateResult is the deferred result of an Update call.
+// UpdateResult is the result of an Update request. Call its Extract method
+// to interpret the result as a Zone.
 type UpdateResult struct {
 	commonResult
 }
 
-// DeleteResult is the deferred result of an Delete call.
+// DeleteResult is the result of a Delete request. Call its ExtractErr method
+// to determine if the request succeeded or failed.
 type DeleteResult struct {
 	commonResult
 }
@@ -52,7 +56,7 @@ func (r ZonePage) IsEmpty() (bool, error) {
 	return len(s) == 0, err
 }
 
-// ExtractZones extracts a slice of Services from a Collection acquired from List.
+// ExtractZones extracts a slice of Zones from a List result.
 func ExtractZones(r pagination.Page) ([]Zone, error) {
 	var s struct {
 		Zones []Zone `json:"zones"`
@@ -63,7 +67,8 @@ func ExtractZones(r pagination.Page) ([]Zone, error) {
 
 // Zone represents a DNS zone.
 type Zone struct {
-	// ID uniquely identifies this zone amongst all other zones, including those not accessible to the current tenant.
+	// ID uniquely identifies this zone amongst all other zones, including those
+	// not accessible to the current tenant.
 	ID string `json:"id"`
 
 	// PoolID is the ID for the pool hosting this zone.
@@ -113,10 +118,12 @@ type Zone struct {
 	// UpdatedAt is the date when the last change was made to the zone.
 	UpdatedAt time.Time `json:"-"`
 
-	// TransferredAt is the last time an update was retrieved from the master servers.
+	// TransferredAt is the last time an update was retrieved from the
+	// master servers.
 	TransferredAt time.Time `json:"-"`
 
-	// Links includes HTTP references to the itself, useful for passing along to other APIs that might want a server reference.
+	// Links includes HTTP references to the itself, useful for passing along
+	// to other APIs that might want a server reference.
 	Links map[string]interface{} `json:"links"`
 }
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v2/tenants/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v2/tenants/doc.go
@@ -1,7 +1,65 @@
-// Package tenants provides information and interaction with the
-// tenants API resource for the OpenStack Identity service.
-//
-// See http://developer.openstack.org/api-ref-identity-v2.html#identity-auth-v2
-// and http://developer.openstack.org/api-ref-identity-v2.html#admin-tenants
-// for more information.
+/*
+Package tenants provides information and interaction with the
+tenants API resource for the OpenStack Identity service.
+
+See http://developer.openstack.org/api-ref-identity-v2.html#identity-auth-v2
+and http://developer.openstack.org/api-ref-identity-v2.html#admin-tenants
+for more information.
+
+Example to List Tenants
+
+	listOpts := tenants.ListOpts{
+		Limit: 2,
+	}
+
+	allPages, err := tenants.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allTenants, err := tenants.ExtractTenants(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, tenant := range allTenants {
+		fmt.Printf("%+v\n", tenant)
+	}
+
+Example to Create a Tenant
+
+	createOpts := tenants.CreateOpts{
+		Name:        "tenant_name",
+		Description: "this is a tenant",
+		Enabled:     gophercloud.Enabled,
+	}
+
+	tenant, err := tenants.Create(identityClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Tenant
+
+	tenantID := "e6db6ed6277c461a853458589063b295"
+
+	updateOpts := tenants.UpdateOpts{
+		Description: "this is a new description",
+		Enabled:     gophercloud.Disabled,
+	}
+
+	tenant, err := tenants.Update(identityClient, tenantID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Tenant
+
+	tenantID := "e6db6ed6277c461a853458589063b295"
+
+	err := tenants.Delete(identitYClient, tenantID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
 package tenants

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v2/tenants/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v2/tenants/requests.go
@@ -9,6 +9,7 @@ import (
 type ListOpts struct {
 	// Marker is the ID of the last Tenant on the previous page.
 	Marker string `q:"marker"`
+
 	// Limit specifies the page size.
 	Limit int `q:"limit"`
 }
@@ -26,4 +27,90 @@ func List(client *gophercloud.ServiceClient, opts *ListOpts) pagination.Pager {
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return TenantPage{pagination.LinkedPageBase{PageResult: r}}
 	})
+}
+
+// CreateOpts represents the options needed when creating new tenant.
+type CreateOpts struct {
+	// Name is the name of the tenant.
+	Name string `json:"name" required:"true"`
+
+	// Description is the description of the tenant.
+	Description string `json:"description,omitempty"`
+
+	// Enabled sets the tenant status to enabled or disabled.
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// CreateOptsBuilder enables extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToTenantCreateMap() (map[string]interface{}, error)
+}
+
+// ToTenantCreateMap assembles a request body based on the contents of
+// a CreateOpts.
+func (opts CreateOpts) ToTenantCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "tenant")
+}
+
+// Create is the operation responsible for creating new tenant.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToTenantCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201},
+	})
+	return
+}
+
+// Get requests details on a single tenant by ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToTenantUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts specifies the base attributes that may be updated on an existing
+// tenant.
+type UpdateOpts struct {
+	// Name is the name of the tenant.
+	Name string `json:"name,omitempty"`
+
+	// Description is the description of the tenant.
+	Description string `json:"description,omitempty"`
+
+	// Enabled sets the tenant status to enabled or disabled.
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// ToTenantUpdateMap formats an UpdateOpts structure into a request body.
+func (opts UpdateOpts) ToTenantUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "tenant")
+}
+
+// Update is the operation responsible for updating exist tenants by their TenantID.
+func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToTenantUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateURL(client, id), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete is the operation responsible for permanently deleting a tenant.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v2/tenants/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v2/tenants/results.go
@@ -43,11 +43,49 @@ func (r TenantPage) NextPageURL() (string, error) {
 	return gophercloud.ExtractNextURL(s.Links)
 }
 
-// ExtractTenants returns a slice of Tenants contained in a single page of results.
+// ExtractTenants returns a slice of Tenants contained in a single page of
+// results.
 func ExtractTenants(r pagination.Page) ([]Tenant, error) {
 	var s struct {
 		Tenants []Tenant `json:"tenants"`
 	}
 	err := (r.(TenantPage)).ExtractInto(&s)
 	return s.Tenants, err
+}
+
+type tenantResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any tenantResults as a Tenant.
+func (r tenantResult) Extract() (*Tenant, error) {
+	var s struct {
+		Tenant *Tenant `json:"tenant"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Tenant, err
+}
+
+// GetResult is the response from a Get request. Call its Extract method to
+// interpret it as a Tenant.
+type GetResult struct {
+	tenantResult
+}
+
+// CreateResult is the response from a Create request. Call its Extract method
+// to interpret it as a Tenant.
+type CreateResult struct {
+	tenantResult
+}
+
+// DeleteResult is the response from a Get request. Call its ExtractErr method
+// to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// UpdateResult is the response from a Update request. Call its Extract method
+// to interpret it as a Tenant.
+type UpdateResult struct {
+	tenantResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v2/tenants/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v2/tenants/urls.go
@@ -5,3 +5,19 @@ import "github.com/gophercloud/gophercloud"
 func listURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("tenants")
 }
+
+func getURL(client *gophercloud.ServiceClient, tenantID string) string {
+	return client.ServiceURL("tenants", tenantID)
+}
+
+func createURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("tenants")
+}
+
+func deleteURL(client *gophercloud.ServiceClient, tenantID string) string {
+	return client.ServiceURL("tenants", tenantID)
+}
+
+func updateURL(client *gophercloud.ServiceClient, tenantID string) string {
+	return client.ServiceURL("tenants", tenantID)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v2/tokens/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v2/tokens/doc.go
@@ -1,5 +1,46 @@
-// Package tokens provides information and interaction with the token API
-// resource for the OpenStack Identity service.
-// For more information, see:
-// http://developer.openstack.org/api-ref-identity-v2.html#identity-auth-v2
+/*
+Package tokens provides information and interaction with the token API
+resource for the OpenStack Identity service.
+
+For more information, see:
+http://developer.openstack.org/api-ref-identity-v2.html#identity-auth-v2
+
+Example to Create an Unscoped Token from a Password
+
+	authOpts := gophercloud.AuthOptions{
+		Username: "user",
+		Password: "pass"
+	}
+
+	token, err := tokens.Create(identityClient, authOpts).ExtractToken()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a Token from a Tenant ID and Password
+
+	authOpts := gophercloud.AuthOptions{
+		Username: "user",
+		Password: "password",
+		TenantID: "fc394f2ab2df4114bde39905f800dc57"
+	}
+
+	token, err := tokens.Create(identityClient, authOpts).ExtractToken()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a Token from a Tenant Name and Password
+
+	authOpts := gophercloud.AuthOptions{
+		Username:   "user",
+		Password:   "password",
+		TenantName: "tenantname"
+	}
+
+	token, err := tokens.Create(identityClient, authOpts).ExtractToken()
+	if err != nil {
+		panic(err)
+	}
+*/
 package tokens

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v2/tokens/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v2/tokens/requests.go
@@ -2,17 +2,21 @@ package tokens
 
 import "github.com/gophercloud/gophercloud"
 
+// PasswordCredentialsV2 represents the required options to authenticate
+// with a username and password.
 type PasswordCredentialsV2 struct {
 	Username string `json:"username" required:"true"`
 	Password string `json:"password" required:"true"`
 }
 
+// TokenCredentialsV2 represents the required options to authenticate
+// with a token.
 type TokenCredentialsV2 struct {
 	ID string `json:"id,omitempty" required:"true"`
 }
 
-// AuthOptionsV2 wraps a gophercloud AuthOptions in order to adhere to the AuthOptionsBuilder
-// interface.
+// AuthOptionsV2 wraps a gophercloud AuthOptions in order to adhere to the
+// AuthOptionsBuilder interface.
 type AuthOptionsV2 struct {
 	PasswordCredentials *PasswordCredentialsV2 `json:"passwordCredentials,omitempty" xor:"TokenCredentials"`
 
@@ -23,15 +27,16 @@ type AuthOptionsV2 struct {
 	TenantID   string `json:"tenantId,omitempty"`
 	TenantName string `json:"tenantName,omitempty"`
 
-	// TokenCredentials allows users to authenticate (possibly as another user) with an
-	// authentication token ID.
+	// TokenCredentials allows users to authenticate (possibly as another user)
+	// with an authentication token ID.
 	TokenCredentials *TokenCredentialsV2 `json:"token,omitempty" xor:"PasswordCredentials"`
 }
 
-// AuthOptionsBuilder describes any argument that may be passed to the Create call.
+// AuthOptionsBuilder allows extensions to add additional parameters to the
+// token create request.
 type AuthOptionsBuilder interface {
-	// ToTokenCreateMap assembles the Create request body, returning an error if parameters are
-	// missing or inconsistent.
+	// ToTokenCreateMap assembles the Create request body, returning an error
+	// if parameters are missing or inconsistent.
 	ToTokenV2CreateMap() (map[string]interface{}, error)
 }
 
@@ -47,8 +52,7 @@ type AuthOptions struct {
 	TokenID          string
 }
 
-// ToTokenV2CreateMap allows AuthOptions to satisfy the AuthOptionsBuilder
-// interface in the v2 tokens package
+// ToTokenV2CreateMap builds a token request body from the given AuthOptions.
 func (opts AuthOptions) ToTokenV2CreateMap() (map[string]interface{}, error) {
 	v2Opts := AuthOptionsV2{
 		TenantID:   opts.TenantID,
@@ -74,9 +78,9 @@ func (opts AuthOptions) ToTokenV2CreateMap() (map[string]interface{}, error) {
 }
 
 // Create authenticates to the identity service and attempts to acquire a Token.
-// If successful, the CreateResult
-// Generally, rather than interact with this call directly, end users should call openstack.AuthenticatedClient(),
-// which abstracts all of the gory details about navigating service catalogs and such.
+// Generally, rather than interact with this call directly, end users should
+// call openstack.AuthenticatedClient(), which abstracts all of the gory details
+// about navigating service catalogs and such.
 func Create(client *gophercloud.ServiceClient, auth AuthOptionsBuilder) (r CreateResult) {
 	b, err := auth.ToTokenV2CreateMap()
 	if err != nil {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v2/tokens/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v2/tokens/results.go
@@ -7,20 +7,24 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/identity/v2/tenants"
 )
 
-// Token provides only the most basic information related to an authentication token.
+// Token provides only the most basic information related to an authentication
+// token.
 type Token struct {
 	// ID provides the primary means of identifying a user to the OpenStack API.
-	// OpenStack defines this field as an opaque value, so do not depend on its content.
-	// It is safe, however, to compare for equality.
+	// OpenStack defines this field as an opaque value, so do not depend on its
+	// content. It is safe, however, to compare for equality.
 	ID string
 
-	// ExpiresAt provides a timestamp in ISO 8601 format, indicating when the authentication token becomes invalid.
-	// After this point in time, future API requests made using this authentication token will respond with errors.
-	// Either the caller will need to reauthenticate manually, or more preferably, the caller should exploit automatic re-authentication.
+	// ExpiresAt provides a timestamp in ISO 8601 format, indicating when the
+	// authentication token becomes invalid. After this point in time, future
+	// API requests made using this  authentication token will respond with
+	// errors. Either the caller will need to reauthenticate manually, or more
+	// preferably, the caller should exploit automatic re-authentication.
 	// See the AuthOptions structure for more details.
 	ExpiresAt time.Time
 
-	// Tenant provides information about the tenant to which this token grants access.
+	// Tenant provides information about the tenant to which this token grants
+	// access.
 	Tenant tenants.Tenant
 }
 
@@ -38,13 +42,17 @@ type User struct {
 }
 
 // Endpoint represents a single API endpoint offered by a service.
-// It provides the public and internal URLs, if supported, along with a region specifier, again if provided.
+// It provides the public and internal URLs, if supported, along with a region
+// specifier, again if provided.
+//
 // The significance of the Region field will depend upon your provider.
 //
-// In addition, the interface offered by the service will have version information associated with it
-// through the VersionId, VersionInfo, and VersionList fields, if provided or supported.
+// In addition, the interface offered by the service will have version
+// information associated with it through the VersionId, VersionInfo, and
+// VersionList fields, if provided or supported.
 //
-// In all cases, fields which aren't supported by the provider and service combined will assume a zero-value ("").
+// In all cases, fields which aren't supported by the provider and service
+// combined will assume a zero-value ("").
 type Endpoint struct {
 	TenantID    string `json:"tenantId"`
 	PublicURL   string `json:"publicURL"`
@@ -56,38 +64,44 @@ type Endpoint struct {
 	VersionList string `json:"versionList"`
 }
 
-// CatalogEntry provides a type-safe interface to an Identity API V2 service catalog listing.
-// Each class of service, such as cloud DNS or block storage services, will have a single
-// CatalogEntry representing it.
+// CatalogEntry provides a type-safe interface to an Identity API V2 service
+// catalog listing.
 //
-// Note: when looking for the desired service, try, whenever possible, to key off the type field.
-// Otherwise, you'll tie the representation of the service to a specific provider.
+// Each class of service, such as cloud DNS or block storage services, will have
+// a single CatalogEntry representing it.
+//
+// Note: when looking for the desired service, try, whenever possible, to key
+// off the type field. Otherwise, you'll tie the representation of the service
+// to a specific provider.
 type CatalogEntry struct {
 	// Name will contain the provider-specified name for the service.
 	Name string `json:"name"`
 
-	// Type will contain a type string if OpenStack defines a type for the service.
-	// Otherwise, for provider-specific services, the provider may assign their own type strings.
+	// Type will contain a type string if OpenStack defines a type for the
+	// service. Otherwise, for provider-specific services, the provider may assign
+	// their own type strings.
 	Type string `json:"type"`
 
-	// Endpoints will let the caller iterate over all the different endpoints that may exist for
-	// the service.
+	// Endpoints will let the caller iterate over all the different endpoints that
+	// may exist for the service.
 	Endpoints []Endpoint `json:"endpoints"`
 }
 
-// ServiceCatalog provides a view into the service catalog from a previous, successful authentication.
+// ServiceCatalog provides a view into the service catalog from a previous,
+// successful authentication.
 type ServiceCatalog struct {
 	Entries []CatalogEntry
 }
 
-// CreateResult defers the interpretation of a created token.
-// Use ExtractToken() to interpret it as a Token, or ExtractServiceCatalog() to interpret it as a service catalog.
+// CreateResult is the response from a Create request. Use ExtractToken() to
+// interpret it as a Token, or ExtractServiceCatalog() to interpret it as a
+// service catalog.
 type CreateResult struct {
 	gophercloud.Result
 }
 
-// GetResult is the deferred response from a Get call, which is the same with a Created token.
-// Use ExtractUser() to interpret it as a User.
+// GetResult is the deferred response from a Get call, which is the same with a
+// Created token. Use ExtractUser() to interpret it as a User.
 type GetResult struct {
 	CreateResult
 }
@@ -121,7 +135,8 @@ func (r CreateResult) ExtractToken() (*Token, error) {
 	}, nil
 }
 
-// ExtractServiceCatalog returns the ServiceCatalog that was generated along with the user's Token.
+// ExtractServiceCatalog returns the ServiceCatalog that was generated along
+// with the user's Token.
 func (r CreateResult) ExtractServiceCatalog() (*ServiceCatalog, error) {
 	var s struct {
 		Access struct {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/projects/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/projects/doc.go
@@ -1,0 +1,58 @@
+/*
+Package projects manages and retrieves Projects in the OpenStack Identity
+Service.
+
+Example to List Projects
+
+	listOpts := projects.ListOpts{
+		Enabled: gophercloud.Enabled,
+	}
+
+	allPages, err := projects.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allProjects, err := projects.ExtractProjects(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, project := range allProjects {
+		fmt.Printf("%+v\n", project)
+	}
+
+Example to Create a Project
+
+	createOpts := projects.CreateOpts{
+		Name:        "project_name",
+		Description: "Project Description"
+	}
+
+	project, err := projects.Create(identityClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Project
+
+	projectID := "966b3c7d36a24facaf20b7e458bf2192"
+
+	updateOpts := projects.UpdateOpts{
+		Enabled: gophercloud.Disabled,
+	}
+
+	project, err := projects.Update(identityClient, projectID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Project
+
+	projectID := "966b3c7d36a24facaf20b7e458bf2192"
+	err := projects.Delete(identityClient, projectID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package projects

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/projects/errors.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/projects/errors.go
@@ -1,0 +1,17 @@
+package projects
+
+import "fmt"
+
+// InvalidListFilter is returned by the ToUserListQuery method when validation of
+// a filter does not pass
+type InvalidListFilter struct {
+	FilterName string
+}
+
+func (e InvalidListFilter) Error() string {
+	s := fmt.Sprintf(
+		"Invalid filter name [%s]: it must be in format of NAME__COMPARATOR",
+		e.FilterName,
+	)
+	return s
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/projects/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/projects/results.go
@@ -9,27 +9,31 @@ type projectResult struct {
 	gophercloud.Result
 }
 
-// GetResult temporarily contains the response from the Get call.
+// GetResult is the result of a Get request. Call its Extract method to
+// interpret it as a Project.
 type GetResult struct {
 	projectResult
 }
 
-// CreateResult temporarily contains the reponse from the Create call.
+// CreateResult is the result of a Create request. Call its Extract method to
+// interpret it as a Project.
 type CreateResult struct {
 	projectResult
 }
 
-// DeleteResult temporarily contains the response from the Delete call.
+// DeleteResult is the result of a Delete request. Call its ExtractErr method to
+// determine if the request succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
-// UpdateResult temporarily contains the response from the Update call.
+// UpdateResult is the result of an Update request. Call its Extract method to
+// interpret it as a Project.
 type UpdateResult struct {
 	projectResult
 }
 
-// Project is a base unit of ownership.
+// Project represents an OpenStack Identity Project.
 type Project struct {
 	// IsDomain indicates whether the project is a domain.
 	IsDomain bool `json:"is_domain"`
@@ -79,7 +83,8 @@ func (r ProjectPage) NextPageURL() (string, error) {
 	return s.Links.Next, err
 }
 
-// ExtractProjects returns a slice of Projects contained in a single page of results.
+// ExtractProjects returns a slice of Projects contained in a single page of
+// results.
 func ExtractProjects(r pagination.Page) ([]Project, error) {
 	var s struct {
 		Projects []Project `json:"projects"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/doc.go
@@ -79,6 +79,29 @@ Example to List Role Assignments
 		fmt.Printf("%+v\n", role)
 	}
 
+Example to List Role Assignments for a User on a Project
+
+	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"
+	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
+	listAssignmentsOnResourceOpts := roles.ListAssignmentsOnResourceOpts{
+		UserID:    userID,
+		ProjectID: projectID,
+	}
+
+	allPages, err := roles.ListAssignmentsOnResource(identityClient, listAssignmentsOnResourceOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allRoles, err := roles.ExtractRoles(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, role := range allRoles {
+		fmt.Printf("%+v\n", role)
+	}
+
 Example to Assign a Role to a User in a Project
 
 	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/errors.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/errors.go
@@ -1,0 +1,17 @@
+package roles
+
+import "fmt"
+
+// InvalidListFilter is returned by the ToUserListQuery method when validation of
+// a filter does not pass
+type InvalidListFilter struct {
+	FilterName string
+}
+
+func (e InvalidListFilter) Error() string {
+	s := fmt.Sprintf(
+		"Invalid filter name [%s]: it must be in format of NAME__COMPARATOR",
+		e.FilterName,
+	)
+	return s
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/urls.go
@@ -30,6 +30,10 @@ func listAssignmentsURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("role_assignments")
 }
 
+func listAssignmentsOnResourceURL(client *gophercloud.ServiceClient, targetType, targetID, actorType, actorID string) string {
+	return client.ServiceURL(targetType, targetID, actorType, actorID, rolePath)
+}
+
 func assignURL(client *gophercloud.ServiceClient, targetType, targetID, actorType, actorID, roleID string) string {
 	return client.ServiceURL(targetType, targetID, actorType, actorID, rolePath, roleID)
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/tokens/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/tokens/requests.go
@@ -133,7 +133,7 @@ func Get(c *gophercloud.ServiceClient, token string) (r GetResult) {
 
 // Validate determines if a specified token is valid or not.
 func Validate(c *gophercloud.ServiceClient, token string) (bool, error) {
-	resp, err := c.Request("HEAD", tokenURL(c), &gophercloud.RequestOpts{
+	resp, err := c.Head(tokenURL(c), &gophercloud.RequestOpts{
 		MoreHeaders: subjectTokenHeaders(c, token),
 		OkCodes:     []int{200, 204, 404},
 	})

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata/doc.go
@@ -16,6 +16,21 @@ Example to Upload Image Data
 		panic(err)
 	}
 
+Example to Stage Image Data
+
+  imageID := "da3b75d9-3f4a-40e7-8a2c-bfab23927dea"
+
+  imageData, err := os.Open("/path/to/image/file")
+  if err != nil {
+    panic(err)
+  }
+  defer imageData.Close()
+
+  err = imagedata.Stage(imageClient, imageID, imageData).ExtractErr()
+  if err != nil {
+    panic(err)
+  }
+
 Example to Download Image Data
 
 	imageID := "da3b75d9-3f4a-40e7-8a2c-bfab23927dea"

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata/requests.go
@@ -16,6 +16,17 @@ func Upload(client *gophercloud.ServiceClient, id string, data io.Reader) (r Upl
 	return
 }
 
+// Stage performs PUT call on the existing image object in the Imageservice with
+// the provided file.
+// Existing image object must be in the "queued" status.
+func Stage(client *gophercloud.ServiceClient, id string, data io.Reader) (r StageResult) {
+	_, r.Err = client.Put(stageURL(client, id), data, nil, &gophercloud.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/octet-stream"},
+		OkCodes:     []int{204},
+	})
+	return
+}
+
 // Download retrieves an image.
 func Download(client *gophercloud.ServiceClient, id string) (r DownloadResult) {
 	var resp *http.Response

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata/results.go
@@ -13,6 +13,12 @@ type UploadResult struct {
 	gophercloud.ErrResult
 }
 
+// StageResult is the result of a stage image operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type StageResult struct {
+	gophercloud.ErrResult
+}
+
 // DownloadResult is the result of a download image operation. Call its Extract
 // method to gain access to the image data.
 type DownloadResult struct {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata/urls.go
@@ -2,10 +2,20 @@ package imagedata
 
 import "github.com/gophercloud/gophercloud"
 
+const (
+	rootPath   = "images"
+	uploadPath = "file"
+	stagePath  = "stage"
+)
+
 // `imageDataURL(c,i)` is the URL for the binary image data for the
 // image identified by ID `i` in the service `c`.
 func uploadURL(c *gophercloud.ServiceClient, imageID string) string {
-	return c.ServiceURL("images", imageID, "file")
+	return c.ServiceURL(rootPath, imageID, uploadPath)
+}
+
+func stageURL(c *gophercloud.ServiceClient, imageID string) string {
+	return c.ServiceURL(rootPath, imageID, stagePath)
 }
 
 func downloadURL(c *gophercloud.ServiceClient, imageID string) string {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/requests.go
@@ -129,7 +129,12 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 		url += query
 	}
 	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
-		return ImagePage{pagination.LinkedPageBase{PageResult: r}}
+		imagePage := ImagePage{
+			serviceURL:     c.ServiceURL(),
+			LinkedPageBase: pagination.LinkedPageBase{PageResult: r},
+		}
+
+		return imagePage
 	})
 }
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/results.go
@@ -162,6 +162,7 @@ type DeleteResult struct {
 
 // ImagePage represents the results of a List request.
 type ImagePage struct {
+	serviceURL string
 	pagination.LinkedPageBase
 }
 
@@ -186,7 +187,7 @@ func (r ImagePage) NextPageURL() (string, error) {
 		return "", nil
 	}
 
-	return nextPageURL(r.URL.String(), s.Next)
+	return nextPageURL(r.serviceURL, s.Next)
 }
 
 // ExtractImages interprets the results of a single page from a List() call,

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners/results.go
@@ -54,6 +54,10 @@ type Listener struct {
 
 	// Pools are the pools which are part of this listener.
 	Pools []pools.Pool `json:"pools"`
+
+	// The provisioning status of the listener.
+	// This value is ACTIVE, PENDING_* or ERROR.
+	ProvisioningStatus string `json:"provisioning_status"`
 }
 
 // ListenerPage is the page returned by a pager when traversing over a

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/monitors/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/monitors/results.go
@@ -70,6 +70,10 @@ type Monitor struct {
 
 	// List of pools that are associated with the health monitor.
 	Pools []PoolID `json:"pools"`
+
+	// The provisioning status of the monitor.
+	// This value is ACTIVE, PENDING_* or ERROR.
+	ProvisioningStatus string `json:"provisioning_status"`
 }
 
 // MonitorPage is the page returned by a pager when traversing over a

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools/results.go
@@ -92,6 +92,10 @@ type Pool struct {
 
 	// The Monitor associated with this Pool.
 	Monitor monitors.Monitor `json:"healthmonitor"`
+
+	// The provisioning status of the pool.
+	// This value is ACTIVE, PENDING_* or ERROR.
+	ProvisioningStatus string `json:"provisioning_status"`
 }
 
 // PoolPage is the page returned by a pager when traversing over a
@@ -196,6 +200,10 @@ type Member struct {
 
 	// The unique ID for the Member.
 	ID string `json:"id"`
+
+	// The provisioning status of the member.
+	// This value is ACTIVE, PENDING_* or ERROR.
+	ProvisioningStatus string `json:"provisioning_status"`
 }
 
 // MemberPage is the page returned by a pager when traversing over a

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/requests.go
@@ -128,7 +128,12 @@ func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""
-	pages, err := List(client, ListOpts{}).AllPages()
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/doc.go
@@ -29,9 +29,11 @@ Example to Show the details of a specific IPSec policy by ID
 
 Example to Update an IPSec policy
 
+	name := "updatedname"
+	description := "updated policy"
 	updateOpts := ipsecpolicies.UpdateOpts{
-		Name:        "updatedname",
-		Description: "updated policy",
+		Name:        &name,
+		Description: &description,
 	}
 	updatedPolicy, err := ipsecpolicies.Update(client, "5c561d9d-eaea-45f6-ae3e-08d1a7080828", updateOpts).Extract()
 	if err != nil {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/requests.go
@@ -140,7 +140,12 @@ func Delete(c *gophercloud.ServiceClient, networkID string) (r DeleteResult) {
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""
-	pages, err := List(client, nil).AllPages()
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/requests.go
@@ -151,7 +151,12 @@ func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""
-	pages, err := List(client, nil).AllPages()
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/requests.go
@@ -221,7 +221,12 @@ func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""
-	pages, err := List(client, nil).AllPages()
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts/requests.go
@@ -35,7 +35,7 @@ func Get(c *gophercloud.ServiceClient, opts GetOptsBuilder) (r GetResult) {
 			h[k] = v
 		}
 	}
-	resp, err := c.Request("HEAD", getURL(c), &gophercloud.RequestOpts{
+	resp, err := c.Head(getURL(c), &gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{204},
 	})

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts/results.go
@@ -63,6 +63,7 @@ func (r UpdateResult) Extract() (*UpdateHeader, error) {
 // GetHeader represents the headers returned in the response from a Get request.
 type GetHeader struct {
 	BytesUsed      int64     `json:"-"`
+	QuotaBytes     *int64    `json:"-"`
 	ContainerCount int64     `json:"-"`
 	ContentLength  int64     `json:"-"`
 	ObjectCount    int64     `json:"-"`
@@ -78,6 +79,7 @@ func (r *GetHeader) UnmarshalJSON(b []byte) error {
 	var s struct {
 		tmp
 		BytesUsed      string `json:"X-Account-Bytes-Used"`
+		QuotaBytes     string `json:"X-Account-Meta-Quota-Bytes"`
 		ContentLength  string `json:"Content-Length"`
 		ContainerCount string `json:"X-Account-Container-Count"`
 		ObjectCount    string `json:"X-Account-Object-Count"`
@@ -98,6 +100,17 @@ func (r *GetHeader) UnmarshalJSON(b []byte) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	switch s.QuotaBytes {
+	case "":
+		r.QuotaBytes = nil
+	default:
+		v, err := strconv.ParseInt(s.QuotaBytes, 10, 64)
+		if err != nil {
+			return err
+		}
+		r.QuotaBytes = &v
 	}
 
 	switch s.ContentLength {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/doc.go
@@ -1,8 +1,92 @@
-// Package containers contains functionality for working with Object Storage
-// container resources. A container serves as a logical namespace for objects
-// that are placed inside it - an object with the same name in two different
-// containers represents two different objects.
-//
-// In addition to containing objects, you can also use the container to control
-// access to objects by using an access control list (ACL).
+/*
+Package containers contains functionality for working with Object Storage
+container resources. A container serves as a logical namespace for objects
+that are placed inside it - an object with the same name in two different
+containers represents two different objects.
+
+In addition to containing objects, you can also use the container to control
+access to objects by using an access control list (ACL).
+
+Note: When referencing the Object Storage API docs, some of the API actions
+are listed under "accounts" rather than "containers". This was an intentional
+design in Gophercloud to make some container actions feel more natural.
+
+Example to List Containers
+
+	listOpts := containers.ListOpts{
+		Full: true,
+	}
+
+	allPages, err := containers.List(objectStorageClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allContainers, err := containers.ExtractInfo(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, container := range allContainers {
+		fmt.Printf("%+v\n", container)
+	}
+
+Example to List Only Container Names
+
+	listOpts := containers.ListOpts{
+		Full: false,
+	}
+
+	allPages, err := containers.List(objectStorageClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allContainers, err := containers.ExtractNames(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, container := range allContainers {
+		fmt.Printf("%+v\n", container)
+	}
+
+Example to Create a Container
+
+	createOpts := containers.CreateOpts{
+		ContentType: "application/json",
+		Metadata: map[string]string{
+			"foo": "bar",
+		},
+	}
+
+	container, err := containers.Create(objectStorageClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Container
+
+	containerName := "my_container"
+
+	updateOpts := containers.UpdateOpts{
+		Metadata: map[string]string{
+			"bar": "baz",
+		},
+	}
+
+	container, err := containers.Update(objectStorageClient, containerName, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Container
+
+	containerName := "my_container"
+
+	container, err := containers.Delete(objectStorageClient, containerName).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
 package containers

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/requests.go
@@ -107,6 +107,7 @@ func Create(c *gophercloud.ServiceClient, containerName string, opts CreateOptsB
 	})
 	if resp != nil {
 		r.Header = resp.Header
+		resp.Body.Close()
 	}
 	r.Err = err
 	return
@@ -138,7 +139,7 @@ type UpdateOpts struct {
 	VersionsLocation       string `h:"X-Versions-Location"`
 }
 
-// ToContainerUpdateMap formats a CreateOpts into a map of headers.
+// ToContainerUpdateMap formats a UpdateOpts into a map of headers.
 func (opts UpdateOpts) ToContainerUpdateMap() (map[string]string, error) {
 	h, err := gophercloud.BuildHeaders(opts)
 	if err != nil {
@@ -176,12 +177,41 @@ func Update(c *gophercloud.ServiceClient, containerName string, opts UpdateOptsB
 	return
 }
 
+// GetOptsBuilder allows extensions to add additional parameters to the Get
+// request.
+type GetOptsBuilder interface {
+	ToContainerGetMap() (map[string]string, error)
+}
+
+// GetOpts is a structure that holds options for listing containers.
+type GetOpts struct {
+	Newest bool `h:"X-Newest"`
+}
+
+// ToContainerGetMap formats a GetOpts into a map of headers.
+func (opts GetOpts) ToContainerGetMap() (map[string]string, error) {
+	return gophercloud.BuildHeaders(opts)
+}
+
 // Get is a function that retrieves the metadata of a container. To extract just
 // the custom metadata, pass the GetResult response to the ExtractMetadata
 // function.
-func Get(c *gophercloud.ServiceClient, containerName string) (r GetResult) {
-	resp, err := c.Request("HEAD", getURL(c, containerName), &gophercloud.RequestOpts{
-		OkCodes: []int{200, 204},
+func Get(c *gophercloud.ServiceClient, containerName string, opts GetOptsBuilder) (r GetResult) {
+	h := make(map[string]string)
+	if opts != nil {
+		headers, err := opts.ToContainerGetMap()
+		if err != nil {
+			r.Err = err
+			return
+		}
+
+		for k, v := range headers {
+			h[k] = v
+		}
+	}
+	resp, err := c.Head(getURL(c, containerName), &gophercloud.RequestOpts{
+		MoreHeaders: h,
+		OkCodes:     []int{200, 204},
 	})
 	if resp != nil {
 		r.Header = resp.Header

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/results.go
@@ -47,14 +47,16 @@ func (r ContainerPage) LastMarker() (string, error) {
 	return names[len(names)-1], nil
 }
 
-// ExtractInfo is a function that takes a ListResult and returns the containers' information.
+// ExtractInfo is a function that takes a ListResult and returns the
+// containers' information.
 func ExtractInfo(r pagination.Page) ([]Container, error) {
 	var s []Container
 	err := (r.(ContainerPage)).ExtractInto(&s)
 	return s, err
 }
 
-// ExtractNames is a function that takes a ListResult and returns the containers' names.
+// ExtractNames is a function that takes a ListResult and returns the
+// containers' names.
 func ExtractNames(page pagination.Page) ([]string, error) {
 	casted := page.(ContainerPage)
 	ct := casted.Header.Get("Content-Type")
@@ -99,6 +101,7 @@ type GetHeader struct {
 	TransID          string    `json:"X-Trans-Id"`
 	VersionsLocation string    `json:"X-Versions-Location"`
 	Write            []string  `json:"-"`
+	StoragePolicy    string    `json:"X-Storage-Policy"`
 }
 
 func (r *GetHeader) UnmarshalJSON(b []byte) error {
@@ -162,15 +165,14 @@ type GetResult struct {
 	gophercloud.HeaderResult
 }
 
-// Extract will return a struct of headers returned from a call to Get. To obtain
-// a map of headers, call the ExtractHeader method on the GetResult.
+// Extract will return a struct of headers returned from a call to Get.
 func (r GetResult) Extract() (*GetHeader, error) {
 	var s *GetHeader
 	err := r.ExtractInto(&s)
 	return s, err
 }
 
-// ExtractMetadata is a function that takes a GetResult (of type *stts.Response)
+// ExtractMetadata is a function that takes a GetResult (of type *http.Response)
 // and returns the custom metadata associated with the container.
 func (r GetResult) ExtractMetadata() (map[string]string, error) {
 	if r.Err != nil {
@@ -186,7 +188,8 @@ func (r GetResult) ExtractMetadata() (map[string]string, error) {
 	return metadata, nil
 }
 
-// CreateHeader represents the headers returned in the response from a Create request.
+// CreateHeader represents the headers returned in the response from a Create
+// request.
 type CreateHeader struct {
 	ContentLength int64     `json:"-"`
 	ContentType   string    `json:"Content-Type"`
@@ -224,21 +227,21 @@ func (r *CreateHeader) UnmarshalJSON(b []byte) error {
 }
 
 // CreateResult represents the result of a create operation. To extract the
-// the headers from the HTTP response, you can invoke the 'ExtractHeader'
-// method on the result struct.
+// the headers from the HTTP response, call its Extract method.
 type CreateResult struct {
 	gophercloud.HeaderResult
 }
 
-// Extract will return a struct of headers returned from a call to Create. To obtain
-// a map of headers, call the ExtractHeader method on the CreateResult.
+// Extract will return a struct of headers returned from a call to Create.
+// To extract the headers from the HTTP response, call its Extract method.
 func (r CreateResult) Extract() (*CreateHeader, error) {
 	var s *CreateHeader
 	err := r.ExtractInto(&s)
 	return s, err
 }
 
-// UpdateHeader represents the headers returned in the response from a Update request.
+// UpdateHeader represents the headers returned in the response from a Update
+// request.
 type UpdateHeader struct {
 	ContentLength int64     `json:"-"`
 	ContentType   string    `json:"Content-Type"`
@@ -276,21 +279,20 @@ func (r *UpdateHeader) UnmarshalJSON(b []byte) error {
 }
 
 // UpdateResult represents the result of an update operation. To extract the
-// the headers from the HTTP response, you can invoke the 'ExtractHeader'
-// method on the result struct.
+// the headers from the HTTP response, call its Extract method.
 type UpdateResult struct {
 	gophercloud.HeaderResult
 }
 
-// Extract will return a struct of headers returned from a call to Update. To obtain
-// a map of headers, call the ExtractHeader method on the UpdateResult.
+// Extract will return a struct of headers returned from a call to Update.
 func (r UpdateResult) Extract() (*UpdateHeader, error) {
 	var s *UpdateHeader
 	err := r.ExtractInto(&s)
 	return s, err
 }
 
-// DeleteHeader represents the headers returned in the response from a Delete request.
+// DeleteHeader represents the headers returned in the response from a Delete
+// request.
 type DeleteHeader struct {
 	ContentLength int64     `json:"-"`
 	ContentType   string    `json:"Content-Type"`
@@ -328,14 +330,12 @@ func (r *DeleteHeader) UnmarshalJSON(b []byte) error {
 }
 
 // DeleteResult represents the result of a delete operation. To extract the
-// the headers from the HTTP response, you can invoke the 'ExtractHeader'
-// method on the result struct.
+// the headers from the HTTP response, call its Extract method.
 type DeleteResult struct {
 	gophercloud.HeaderResult
 }
 
-// Extract will return a struct of headers returned from a call to Delete. To obtain
-// a map of headers, call the ExtractHeader method on the DeleteResult.
+// Extract will return a struct of headers returned from a call to Delete.
 func (r DeleteResult) Extract() (*DeleteHeader, error) {
 	var s *DeleteHeader
 	err := r.ExtractInto(&s)

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/doc.go
@@ -4,6 +4,10 @@ object resources. An object is a resource that represents and contains data
 - such as documents, images, and so on. You can also store custom metadata
 with an object.
 
+Note: When referencing the Object Storage API docs, some of the API actions
+are listed under "containers" rather than "objects". This was an intentional
+design in Gophercloud to make some object actions feel more natural.
+
 Example to List Objects
 
 	containerName := "my_container"

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/swauth/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/swauth/doc.go
@@ -1,0 +1,16 @@
+/*
+Package swauth implements Swift's built-in authentication.
+
+Example to Authenticate with swauth
+
+	authOpts := swauth.AuthOpts{
+		User: "project:user",
+		Key:  "password",
+	}
+
+	swiftClient, err := swauth.NewObjectStorageV1(providerClient, authOpts)
+	if err != nil {
+		panic(err)
+	}
+*/
+package swauth

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/swauth/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/swauth/requests.go
@@ -3,7 +3,6 @@ package swauth
 import "github.com/gophercloud/gophercloud"
 
 // AuthOptsBuilder describes struct types that can be accepted by the Auth call.
-// The AuthOpts struct in this package does.
 type AuthOptsBuilder interface {
 	ToAuthOptsMap() (map[string]string, error)
 }
@@ -12,6 +11,7 @@ type AuthOptsBuilder interface {
 type AuthOpts struct {
 	// User is an Swauth-based username in username:tenant format.
 	User string `h:"X-Auth-User" required:"true"`
+
 	// Key is a secret/password to authenticate the User with.
 	Key string `h:"X-Auth-Key" required:"true"`
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/swauth/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/swauth/results.go
@@ -4,8 +4,8 @@ import (
 	"github.com/gophercloud/gophercloud"
 )
 
-// GetAuthResult temporarily contains the response from a Swauth
-// authentication call.
+// GetAuthResult contains the response from the Auth request. Call its Extract
+// method to interpret it as an AuthResult.
 type GetAuthResult struct {
 	gophercloud.HeaderResult
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/utils/base_endpoint.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/utils/base_endpoint.go
@@ -9,21 +9,20 @@ import (
 // BaseEndpoint will return a URL without the /vX.Y
 // portion of the URL.
 func BaseEndpoint(endpoint string) (string, error) {
-	var base string
-
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		return base, err
+		return "", err
 	}
 
 	u.RawQuery, u.Fragment = "", ""
 
+	path := u.Path
 	versionRe := regexp.MustCompile("v[0-9.]+/?")
-	if version := versionRe.FindString(u.Path); version != "" {
-		base = strings.Replace(u.String(), version, "", -1)
-	} else {
-		base = u.String()
+
+	if version := versionRe.FindString(path); version != "" {
+		versionIndex := strings.Index(path, version)
+		u.Path = path[:versionIndex]
 	}
 
-	return base, nil
+	return u.String(), nil
 }

--- a/vendor/github.com/gophercloud/gophercloud/pagination/http.go
+++ b/vendor/github.com/gophercloud/gophercloud/pagination/http.go
@@ -55,6 +55,6 @@ func PageResultFromParsed(resp *http.Response, body interface{}) PageResult {
 func Request(client *gophercloud.ServiceClient, headers map[string]string, url string) (*http.Response, error) {
 	return client.Get(url, nil, &gophercloud.RequestOpts{
 		MoreHeaders: headers,
-		OkCodes:     []int{200, 204},
+		OkCodes:     []int{200, 204, 300},
 	})
 }

--- a/vendor/github.com/gophercloud/gophercloud/pagination/pager.go
+++ b/vendor/github.com/gophercloud/gophercloud/pagination/pager.go
@@ -22,7 +22,6 @@ var (
 // Depending on the pagination strategy of a particular resource, there may be an additional subinterface that the result type
 // will need to implement.
 type Page interface {
-
 	// NextPageURL generates the URL for the page of data that follows this collection.
 	// Return "" if no such page exists.
 	NextPageURL() (string, error)
@@ -41,6 +40,8 @@ type Pager struct {
 	initialURL string
 
 	createPage func(r PageResult) Page
+
+	firstPage Page
 
 	Err error
 
@@ -90,9 +91,18 @@ func (p Pager) EachPage(handler func(Page) (bool, error)) error {
 	}
 	currentURL := p.initialURL
 	for {
-		currentPage, err := p.fetchNextPage(currentURL)
-		if err != nil {
-			return err
+		var currentPage Page
+
+		// if first page has already been fetched, no need to fetch it again
+		if p.firstPage != nil {
+			currentPage = p.firstPage
+			p.firstPage = nil
+		} else {
+			var err error
+			currentPage, err = p.fetchNextPage(currentURL)
+			if err != nil {
+				return err
+			}
 		}
 
 		empty, err := currentPage.IsEmpty()
@@ -129,23 +139,26 @@ func (p Pager) AllPages() (Page, error) {
 	// body will contain the final concatenated Page body.
 	var body reflect.Value
 
-	// Grab a test page to ascertain the page body type.
-	testPage, err := p.fetchNextPage(p.initialURL)
+	// Grab a first page to ascertain the page body type.
+	firstPage, err := p.fetchNextPage(p.initialURL)
 	if err != nil {
 		return nil, err
 	}
 	// Store the page type so we can use reflection to create a new mega-page of
 	// that type.
-	pageType := reflect.TypeOf(testPage)
+	pageType := reflect.TypeOf(firstPage)
 
-	// if it's a single page, just return the testPage (first page)
+	// if it's a single page, just return the firstPage (first page)
 	if _, found := pageType.FieldByName("SinglePageBase"); found {
-		return testPage, nil
+		return firstPage, nil
 	}
+
+	// store the first page to avoid getting it twice
+	p.firstPage = firstPage
 
 	// Switch on the page body type. Recognized types are `map[string]interface{}`,
 	// `[]byte`, and `[]interface{}`.
-	switch pb := testPage.GetBody().(type) {
+	switch pb := firstPage.GetBody().(type) {
 	case map[string]interface{}:
 		// key is the map key for the page body if the body type is `map[string]interface{}`.
 		var key string

--- a/vendor/github.com/gophercloud/gophercloud/provider_client.go
+++ b/vendor/github.com/gophercloud/gophercloud/provider_client.go
@@ -378,7 +378,7 @@ func defaultOkCodes(method string) []int {
 	case method == "PUT":
 		return []int{201, 202}
 	case method == "PATCH":
-		return []int{200, 204}
+		return []int{200, 202, 204}
 	case method == "DELETE":
 		return []int{202, 204}
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -313,418 +313,418 @@
 			"revisionTime": "2018-03-28T16:31:53Z"
 		},
 		{
-			"checksumSHA1": "8yXacRqh4LK7u/1r6qxrUS2oACs=",
+			"checksumSHA1": "8JWIqF7PJvZ9FYr5XD84M3GiFwI=",
 			"path": "github.com/gophercloud/gophercloud",
-			"revision": "aac68cb146cb045a2c7c76ea060c81c9318f3dcd",
-			"revisionTime": "2018-07-06T03:57:03Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "YDNvjFNQS+UxqZMLm/shFs7aLNU=",
+			"checksumSHA1": "ppjFEV8Pp7Eo6s949bo7pgLuHoo=",
 			"path": "github.com/gophercloud/gophercloud/openstack",
-			"revision": "2c66bd8ca7ef07d4d0c38ed75457121c3f24aac8",
-			"revisionTime": "2018-05-10T02:17:00Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "8YtBD+Um7I8ee1Xf1ZAWu74eP7w=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions",
-			"revision": "1ba3c5196d701270954c957d8696695713db199b",
-			"revisionTime": "2018-05-11T04:49:20Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "9DTfNt/B4aZWXEmTNqXU5rNrrDc=",
+			"checksumSHA1": "ULM+8z6I3O1uJlPKgy1K2Rt7si0=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v1/volumes",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "B4IXSmq364HcBruvvV0QjDFxZgc=",
+			"checksumSHA1": "AXL8Rf/vvEUlxCyy6vEgkA9E7VI=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "vqXNCd2My0y/5tPC/Bs79uf6Q4E=",
+			"checksumSHA1": "FUK/Wy9Q3iz8rVFZS7ukjT7afq0=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes",
-			"revision": "86621fc7f55fde56303d29e49517a160f132714a",
-			"revisionTime": "2018-05-12T01:38:14Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "y49Ur726Juznj85+23ZgqMvehgg=",
+			"checksumSHA1": "nQlviweyWynvpsXf1Ms0AecMzO8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "w2wHF5eEBE89ZYlkS9GAJsSIq9U=",
+			"checksumSHA1": "La8c0H0Eds4MmAKJ9lPdDgJDjSk=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "e7AW3YDVYJPKUjpqsB4AL9RRlTw=",
+			"checksumSHA1": "vFS5BwnCdQIfKm1nNWrR+ijsAZA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "RWwUliHD65cWApdEo4ckOcPSArg=",
+			"checksumSHA1": "lAQuKIqTuQ9JuMgN0pPkNtRH2RM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "+hlElX7o8ULWTc0r7oGyDlOnwWM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints",
-			"revision": "3b177406222d4b76d93e90d6ab412e7b7dc160f4",
-			"revisionTime": "2018-02-02T23:12:48Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "jNrUTQf+9dYfaD7YqvKwC+kGvyY=",
+			"checksumSHA1": "u3edl33HpYpxHJjBN3KRtjMHmZg=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "ci4gzd7Uy9JC4NcQ2ms19pjtW6s=",
+			"checksumSHA1": "PWbrce9A6LMWIGr0fK04AEEuQec=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "qBpGbX7LQMPATdO8XyQmU7IXDiI=",
+			"checksumSHA1": "qfVZltu1fYTYXS97WbjeLuLPgUc=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/startstop",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "5JuziAp9BSRA/z+8pTjVLTWeTw4=",
+			"checksumSHA1": "+Gif+WFd0WVjefjvmlR7jyTrdzQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/tenantnetworks",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "2VNgU0F9PDax5VKClvMLmbzuksw=",
+			"checksumSHA1": "TMkBTIrYeL78yJ6wZNJQqG0tHR4=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "1/1G6O0CUVYyTFF/IqzWThGyuPQ=",
+			"checksumSHA1": "7Umzfke8pOKkGe+DiqQLEpq0xVk=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/flavors",
-			"revision": "fcbd26878ebed8c18cd1aca798e1a9b145d6a30b",
-			"revisionTime": "2018-02-14T03:59:15Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "Rnzx2YgOD41k8KoPA08tR992PxQ=",
+			"checksumSHA1": "CSnfH01hSas0bdc/3m/f5Rt6SFY=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/images",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "IjCvcaNnRW++hclt21WUkMYinaA=",
+			"checksumSHA1": "gxNCsaZKNT2SUIUtirxfEcLn9jw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/servers",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "paRHLRizEZWL2sm/vG38zr+DQRM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/configurations",
-			"revision": "955c2f50b357c1b6352c031203183190951ba55b",
-			"revisionTime": "2017-12-05T04:13:40Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "jdKwC7fxB11ACuo8CUH2VoleJao=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/databases",
-			"revision": "c7551a666c4fee120cc314dce91ba3d0663a86f3",
-			"revisionTime": "2017-10-29T05:30:20Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "sQjGBGkPPevEYcyWz/7BN7inFbo=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/datastores",
-			"revision": "c7551a666c4fee120cc314dce91ba3d0663a86f3",
-			"revisionTime": "2017-10-29T05:30:20Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "qfGm1J6bFl+CIYTby8YRYQdEbJo=",
+			"checksumSHA1": "OufByUxj+IvLN5K7XcVVziy28Pw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/instances",
-			"revision": "955c2f50b357c1b6352c031203183190951ba55b",
-			"revisionTime": "2017-12-05T04:13:40Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "62KZtZ4VoCLsOrXxcFTpp0qJEgw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/users",
-			"revision": "c7551a666c4fee120cc314dce91ba3d0663a86f3",
-			"revisionTime": "2017-10-29T05:30:20Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "Mugw0ROrabHNN4nG9YlimPbyENk=",
+			"checksumSHA1": "hBVpoXsfRy6beVIhE6tcmtvgx+s=",
 			"path": "github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets",
-			"revision": "5a6e13341e63bd202a0da558a2a7187720042676",
-			"revisionTime": "2017-05-22T01:35:44Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "OGb3suDcMij0bnu0r/eQgWAX5Ho=",
+			"checksumSHA1": "VxvzmFE0VrKXbmVvSN5dZ+w2zPE=",
 			"path": "github.com/gophercloud/gophercloud/openstack/dns/v2/zones",
-			"revision": "c5dfe1bc7b150a98b1578bb32f7c138ff9568f1d",
-			"revisionTime": "2017-05-15T02:07:51Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "1sVqsZBZBNhDXLY9XzjMkcOkcbg=",
+			"checksumSHA1": "oOJkelRgWx0NzUmxuI3kTS27gM0=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v2/tenants",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "AvUU5En9YpG25iLlcAPDgcQODjI=",
+			"checksumSHA1": "z5NsqMZX3TLMzpmwzOOXE4M5D9w=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "Qzlv/69tlr+1r6W28WrOEEqT9EU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints",
-			"revision": "d25795ac360dec1265fd9c09b2172f8e74444899",
-			"revisionTime": "2018-07-27T00:43:57Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "obpfSV89ht0YMt3WYLFmQj1rWLE=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/groups",
-			"revision": "a27e54c3801dfe3970de492059cd088aef65064c",
-			"revisionTime": "2018-08-02T04:17:03Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "3W2lBfZVEu3kf9Nq3KFnBwG76nw=",
+			"checksumSHA1": "jfmxyd2jfyxLIBHiNwHURX/9RSQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/projects",
-			"revision": "062f2739aef0b03a8e68cd94865c34d416d753e0",
-			"revisionTime": "2017-07-14T02:05:18Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "KXCCoDbSLSiwN+WCicZxWTBeaRY=",
+			"checksumSHA1": "ZG+k94WuW6QA8ttJMRvNT5kqI9g=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/roles",
-			"revision": "6da026c32e2d622cc242d32984259c77237aefe1",
-			"revisionTime": "2018-02-10T02:43:43Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "qOc+KYPka86DtcDnpvBuKdCb8jk=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/services",
-			"revision": "d25795ac360dec1265fd9c09b2172f8e74444899",
-			"revisionTime": "2018-07-27T00:43:57Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "rOjTAohd61Ldwf1cZxbuwbZK998=",
+			"checksumSHA1": "2PYxD2MOrbp4JCWy5794sEtDYD4=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
-			"revision": "020d890c61002325cdb4c2ab15db01b62bf3e00d",
-			"revisionTime": "2018-04-17T17:58:24Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "I7QtHxTYPCZybsi+u/J5AQaNxxQ=",
+			"checksumSHA1": "4Ci0F5SJgiJCXyDuxTQZYvwA00s=",
 			"path": "github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata",
-			"revision": "e02a6935a9a628ff8694e6072b9d0aac22623abd",
-			"revisionTime": "2018-04-17T21:29:20Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "Pop8rylL583hCZ0RjO+9TkrScCo=",
+			"checksumSHA1": "AuuUJz7wcVw9oaFslxf/tgtp6RM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/imageservice/v2/images",
-			"revision": "e02a6935a9a628ff8694e6072b9d0aac22623abd",
-			"revisionTime": "2018-04-17T21:29:20Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "x6lD4wQOZc1rtm6kMaUBMwLxAlA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external",
-			"revision": "9e34f46860442c3331b0f5456500004abcea71db",
-			"revisionTime": "2018-06-29T21:59:09Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "a++vnjXX0eXWLylR29L3z8dcxwU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "bqEG939LJ5te1hZuZXRxy1CLMyw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "FDgt1WaVGbp8w6vyCJbtkbsbWBc=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/routerinsertion",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "uZ5/gCROQHaiHpXfoLrfisRzbAU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "K4VAatvB/jywsU+g/mU7bnSaVaI=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "tvOf0FGjKmpz9vZD0ZBHtcMFpwI=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "HiGzZXGIxrItijPCH+L7EbbCb9w=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/members",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "KZJLk70d5SX8TQO1q0MLAxGEBCU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/monitors",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "KXKo/TByIHelRDES1IB01nlQMoM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/pools",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "3QfwJnsJHohoYV16/BOtDXpNEYI=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/vips",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "HOmjWn7LqpHWJMpGIR7xbSffGbU=",
+			"checksumSHA1": "ObFcwdTfyGmVsVE3OspHtaUbsSQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "CgrfM+dEvV3q3iFcw5CZnljw3xg=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "M3lTM04nSdVMnOINImf96Xi2NP8=",
+			"checksumSHA1": "iCgTFonxOlW7f2b3KUJjKGFNaJk=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/monitors",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "D6G0MvbxDffUT0G9S5wrL5N3cNE=",
+			"checksumSHA1": "UMHh7JpSwn5PX4kxK8YDgqpasL4=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "eUvwdXvz/Zkckr/isvP+2nXY2J8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/provider",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "ONshdaKbzuBzG+tvpRQ6FS6DHRA=",
+			"checksumSHA1": "nRwN9RkBXzcnWHngcfGmKK/Y31E=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "RYd8K6FLhidexFNm9iqPXrStnZM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "nbFJZRXhTvv4g0LK+FCzG0W11G4=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "grviOYvybawC80v7Fmw0XOBwr0A=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/endpointgroups",
-			"revision": "c51806d07f1d12dc4786b792fb9610679e96f549",
-			"revisionTime": "2018-04-20T19:30:33Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "HhRP7Hw7cS7RM4cxGmQYk/vI8uM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/ikepolicies",
-			"revision": "c51806d07f1d12dc4786b792fb9610679e96f549",
-			"revisionTime": "2018-04-20T19:30:33Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "X6dtgVLZ6JZfuZ8dVIqROlRhNjQ=",
+			"checksumSHA1": "NRvuezUVg0gU4CIZkWHnMhIYXx8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/ipsecpolicies",
-			"revision": "3aef8e417612ddbdd8f7a76004af4307296cd1b6",
-			"revisionTime": "2018-03-21T00:01:40Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "RnSw4UFgNNxmOuobe7c0GxGWwKM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/services",
-			"revision": "c51806d07f1d12dc4786b792fb9610679e96f549",
-			"revisionTime": "2018-04-20T19:30:33Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "4H6GsYh9zKxk8Z/Gs8NdMtMCVvQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/siteconnections",
-			"revision": "c51806d07f1d12dc4786b792fb9610679e96f549",
-			"revisionTime": "2018-04-20T19:30:33Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "XEVvG2f/dqATN4aCluZlPylW+9A=",
+			"checksumSHA1": "MjflHgd/Zq1cs8MRCPG+of5FGVs=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/networks",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "/4nBrtUCcHILgmPwOwBKoebKnMY=",
+			"checksumSHA1": "sD5ZxU4ikiAs/rXwtedSu5jm1yw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/ports",
-			"revision": "482bcee3e503006779c2c99437c0613881160de1",
-			"revisionTime": "2018-04-18T04:52:34Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "oSLCi+kQy0xYTkWi6NalsQKKxn4=",
+			"checksumSHA1": "3Y+x/QZYUvpoDeARw3UYVcYeYHM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets",
-			"revision": "a3512ad52c42eeed0f51163174ed4cb8f7e8d2ce",
-			"revisionTime": "2018-05-04T15:57:42Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "Q9VHGSztw2B4PmN4kyvY9TcJD6c=",
+			"checksumSHA1": "v0EdYYIyrzR6j8tAiVkl2AQzmao=",
 			"path": "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts",
-			"revision": "e7fa81ec4cbb506026fa90fe7deeb9b7548a0728",
-			"revisionTime": "2017-11-01T04:49:27Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "1lwXcRrM5A7iCfekbn3bpfNLe3g=",
+			"checksumSHA1": "X231/CMtP5XQTvQmkcsaGuKrGms=",
 			"path": "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "aQ+OjOThpmPUF1KgniHIM37eaN8=",
+			"checksumSHA1": "Lv2KnJs4MiNowr8/vmRt01alM7s=",
 			"path": "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects",
-			"revision": "10244f9e8a6751d9c0ac1656edb8d56aaaf97c32",
-			"revisionTime": "2018-04-21T02:00:55Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "roxPPVwS2CjJhf0CApHNQxAX7EA=",
+			"checksumSHA1": "aODoF15ZwA4XJOWciguaAJRq/6o=",
 			"path": "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/swauth",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "8KE4bJzhbFZKsYMxcRg6xLqqfTg=",
+			"checksumSHA1": "nkRXTSQyEk7yy+4u4/yC1kdvpaE=",
 			"path": "github.com/gophercloud/gophercloud/openstack/utils",
-			"revision": "2c66bd8ca7ef07d4d0c38ed75457121c3f24aac8",
-			"revisionTime": "2018-05-10T02:17:00Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
-			"checksumSHA1": "FNy075ydQZXvnL2bNNIOCmy/ghs=",
+			"checksumSHA1": "/Wkc4WKxF/P87dOmUh5XUXcfmz8=",
 			"path": "github.com/gophercloud/gophercloud/pagination",
-			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
-			"revisionTime": "2017-03-10T01:59:53Z"
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "eNZBK2/EosbOp40tcw2iu1lkdXM=",


### PR DESCRIPTION
Projects that use dep (https://github.com/golang/dep/) such as pulumi (https://github.com/pulumi) can't use terraform-provider-openstack as a dependency due to a limitation in dep.

dep only supports one revision per project (i.e. git repo). Currently terraform-provider-openstack uses a lots of different revisions from gophercloud depending on which package is being imported. 

vgo (https://github.com/golang/vgo), which looks to be the successor to dep and will be in go 1.11, also only supports one revision per module. By default the whole repo is the module, so projects using vgo would also not be able to depend on terraform-provider-openstack and it's use of multiple revisions of gophercloud.

This PR simply unifies them all to the same revision 19abc56a8cd8d3630ab9735173cb92c0bf635f33, and fixes up one type mismatch in openstack/resource_openstack_compute_instance_v2.go due to the update.