### PR TITLE
Object Storage v1: ETag Changes

### DIFF
--- a/openstack/resource_openstack_objectstorage_object_v1.go
+++ b/openstack/resource_openstack_objectstorage_object_v1.go
@@ -14,9 +14,9 @@ import (
 
 func resourceObjectStorageObjectV1() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceObjectStorageObjectV1Put,
+		Create: resourceObjectStorageObjectV1Create,
 		Read:   resourceObjectStorageObjectV1Read,
-		Update: resourceObjectStorageObjectV1Put,
+		Update: resourceObjectStorageObjectV1Update,
 		Delete: resourceObjectStorageObjectV1Delete,
 
 		Schema: map[string]*schema.Schema{
@@ -140,7 +140,7 @@ func resourceObjectStorageObjectV1() *schema.Resource {
 	}
 }
 
-func resourceObjectStorageObjectV1Put(d *schema.ResourceData, meta interface{}) error {
+func resourceObjectStorageObjectV1Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	objectStorageClient, err := config.objectStorageV1Client(GetRegion(d, config))
 	if err != nil {
@@ -158,23 +158,14 @@ func resourceObjectStorageObjectV1Put(d *schema.ResourceData, meta interface{}) 
 	var isValid bool
 	if v, ok := d.GetOk("source"); ok {
 		isValid = true
-		source := v.(string)
-		path, err := homedir.Expand(source)
+		file, size, err := resourceObjectSourceV1(v.(string))
 		if err != nil {
-			return fmt.Errorf("Error expanding homedir in source (%s): %s", source, err)
-		}
-		file, err := os.Open(path)
-		defer file.Close()
-		if err != nil {
-			return fmt.Errorf("Error opening openstack swift object source (%s): %s", source, err)
-		}
-		fileinfo, err := file.Stat()
-		if err != nil {
-			return fmt.Errorf("Error opening openstack swift object source (%s): %s", source, err)
+			return err
 		}
 
 		createOpts.Content = file
-		createOpts.ContentLength = fileinfo.Size()
+		createOpts.ContentLength = size
+		defer file.Close()
 	}
 
 	if v, ok := d.GetOk("content"); ok {
@@ -229,28 +220,15 @@ func resourceObjectStorageObjectV1Put(d *schema.ResourceData, meta interface{}) 
 		createOpts.DetectContentType = "true"
 	}
 
-	// this attribute is used to trigger resource updates if the file content is changed
 	if v, ok := d.GetOk("etag"); ok {
 		createOpts.ETag = v.(string)
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
-	result, err := objects.Create(objectStorageClient, cn, name, createOpts).Extract()
+	_, err = objects.Create(objectStorageClient, cn, name, createOpts).Extract()
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack container object: %s", err)
 	}
-	log.Printf("[INFO] Object %s has been added to container : %s", name, cn)
-
-	d.Set("etag", result.ETag)
-	d.Set("content_length", result.ContentLength)
-	d.Set("content_type", result.ContentType)
-	if result.Date.Unix() > 0 {
-		d.Set("date", result.Date.Format(time.RFC3339))
-	}
-	if result.LastModified.Unix() > 0 {
-		d.Set("last_modified", result.LastModified.Format(time.RFC3339))
-	}
-	d.Set("trans_id", result.TransID)
 
 	// Store the ID now
 	d.SetId(fmt.Sprintf("%s/%s", cn, name))
@@ -282,7 +260,8 @@ func resourceObjectStorageObjectV1Read(d *schema.ResourceData, meta interface{})
 	if err != nil {
 		return fmt.Errorf("Error getting OpenStack container object: %s", err)
 	}
-	log.Printf("[INFO] Object %s has been added to container : %s", name, cn)
+
+	log.Printf("[DEBUG] Retrieved OpenStack Object Storage Object: %#v", result)
 
 	d.Set("etag", result.ETag)
 	d.Set("content_disposition", result.ContentDisposition)
@@ -302,6 +281,99 @@ func resourceObjectStorageObjectV1Read(d *schema.ResourceData, meta interface{})
 	d.Set("trans_id", result.TransID)
 
 	return nil
+}
+
+func resourceObjectStorageObjectV1Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	objectStorageClient, err := config.objectStorageV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack object storage client: %s", err)
+	}
+
+	name := d.Get("name").(string)
+	cn := d.Get("container_name").(string)
+
+	// This is not a typo. Reusing CreateOpts for the update.
+	createOpts := &objects.CreateOpts{
+		NoETag:           true,
+		TransferEncoding: "chunked",
+	}
+
+	if d.HasChange("metadata") {
+		createOpts.Metadata = resourceObjectMetadataV1(d)
+	}
+
+	if d.HasChange("source") {
+		v := d.Get("source").(string)
+		file, size, err := resourceObjectSourceV1(v)
+		if err != nil {
+			return err
+		}
+
+		createOpts.Content = file
+		createOpts.ContentLength = size
+		defer file.Close()
+	}
+
+	if d.HasChange("content") {
+		v := d.Get("content").(string)
+		createOpts.Content = bytes.NewReader([]byte(v))
+		createOpts.ContentLength = int64(len(v))
+	}
+
+	if d.HasChange("copy_from") {
+		v := d.Get("copy_from").(string)
+		createOpts.CopyFrom = v
+		createOpts.Content = bytes.NewReader([]byte(""))
+	}
+
+	if d.HasChange("object_manifest") {
+		v := d.Get("object_manifest").(string)
+		createOpts.ObjectManifest = v
+		createOpts.Content = bytes.NewReader([]byte(""))
+	}
+
+	if v, ok := d.GetOk("content_disposition"); ok {
+		createOpts.ContentDisposition = v.(string)
+	}
+
+	if v, ok := d.GetOk("content_encoding"); ok {
+		createOpts.ContentEncoding = v.(string)
+	}
+
+	if v, ok := d.GetOk("content_type"); ok {
+		createOpts.ContentType = v.(string)
+	}
+
+	if v, ok := d.GetOk("delete_after"); ok {
+		createOpts.DeleteAfter = v.(int)
+	}
+
+	if v, ok := d.GetOk("delete_at"); ok && v != "" {
+		t, err := time.Parse(time.RFC3339, fmt.Sprintf("%s", v))
+		if err != nil {
+			return fmt.Errorf("Error Parsing Swift Object Lifecycle Expiration Date: %s, %s", err.Error(), v)
+		}
+
+		createOpts.DeleteAt = int(t.Unix())
+	}
+
+	if v, ok := d.GetOk("detect_content_type"); ok && v.(bool) {
+		createOpts.DetectContentType = "true"
+	}
+
+	if d.HasChange("etag") {
+		createOpts.NoETag = false
+		createOpts.ETag = d.Get("etag").(string)
+	}
+
+	log.Printf("[DEBUG] Update Options: %#v", createOpts)
+	_, err = objects.Create(objectStorageClient, cn, name, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error updating OpenStack container object: %s", err)
+	}
+
+	return resourceObjectStorageObjectV1Read(d, meta)
 }
 
 func resourceObjectStorageObjectV1Delete(d *schema.ResourceData, meta interface{}) error {
@@ -328,4 +400,23 @@ func resourceObjectMetadataV1(d *schema.ResourceData) map[string]string {
 		m[key] = val.(string)
 	}
 	return m
+}
+
+func resourceObjectSourceV1(source string) (*os.File, int64, error) {
+	path, err := homedir.Expand(source)
+	if err != nil {
+		return nil, 0, fmt.Errorf("Error expanding homedir in source (%s): %s", source, err)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, 0, fmt.Errorf("Error opening openstack swift object source (%s): %s", source, err)
+	}
+
+	fileinfo, err := file.Stat()
+	if err != nil {
+		return nil, 0, fmt.Errorf("Error opening openstack swift object source (%s): %s", source, err)
+	}
+
+	return file, fileinfo.Size(), nil
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/requests.go
@@ -145,6 +145,7 @@ type CreateOptsBuilder interface {
 type CreateOpts struct {
 	Content            io.Reader
 	Metadata           map[string]string
+	NoETag             bool
 	CacheControl       string `h:"Cache-Control"`
 	ContentDisposition string `h:"Content-Disposition"`
 	ContentEncoding    string `h:"Content-Encoding"`
@@ -177,6 +178,15 @@ func (opts CreateOpts) ToObjectCreateParams() (io.Reader, map[string]string, str
 
 	for k, v := range opts.Metadata {
 		h["X-Object-Meta-"+k] = v
+	}
+
+	if opts.NoETag {
+		delete(h, "etag")
+		return opts.Content, h, q.String(), nil
+	}
+
+	if h["ETag"] != "" {
+		return opts.Content, h, q.String(), nil
 	}
 
 	hash := md5.New()

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/results.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -30,6 +31,9 @@ type Object struct {
 
 	// Name is the unique name for the object.
 	Name string `json:"name"`
+
+	// Subdir denotes if the result contains a subdir.
+	Subdir string `json:"subdir"`
 }
 
 func (r *Object) UnmarshalJSON(b []byte) error {
@@ -66,14 +70,7 @@ func (r ObjectPage) IsEmpty() (bool, error) {
 
 // LastMarker returns the last object name in a ListResult.
 func (r ObjectPage) LastMarker() (string, error) {
-	names, err := ExtractNames(r)
-	if err != nil {
-		return "", err
-	}
-	if len(names) == 0 {
-		return "", nil
-	}
-	return names[len(names)-1], nil
+	return extractLastMarker(r)
 }
 
 // ExtractInfo is a function that takes a page of objects and returns their
@@ -98,7 +95,11 @@ func ExtractNames(r pagination.Page) ([]string, error) {
 
 		names := make([]string, 0, len(parsed))
 		for _, object := range parsed {
-			names = append(names, object.Name)
+			if object.Subdir != "" {
+				names = append(names, object.Subdir)
+			} else {
+				names = append(names, object.Name)
+			}
 		}
 
 		return names, nil
@@ -133,7 +134,7 @@ type DownloadHeader struct {
 	ETag               string    `json:"Etag"`
 	LastModified       time.Time `json:"-"`
 	ObjectManifest     string    `json:"X-Object-Manifest"`
-	StaticLargeObject  bool      `json:"X-Static-Large-Object"`
+	StaticLargeObject  bool      `json:"-"`
 	TransID            string    `json:"X-Trans-Id"`
 }
 
@@ -141,10 +142,11 @@ func (r *DownloadHeader) UnmarshalJSON(b []byte) error {
 	type tmp DownloadHeader
 	var s struct {
 		tmp
-		ContentLength string                  `json:"Content-Length"`
-		Date          gophercloud.JSONRFC1123 `json:"Date"`
-		DeleteAt      gophercloud.JSONUnix    `json:"X-Delete-At"`
-		LastModified  gophercloud.JSONRFC1123 `json:"Last-Modified"`
+		ContentLength     string                  `json:"Content-Length"`
+		Date              gophercloud.JSONRFC1123 `json:"Date"`
+		DeleteAt          gophercloud.JSONUnix    `json:"X-Delete-At"`
+		LastModified      gophercloud.JSONRFC1123 `json:"Last-Modified"`
+		StaticLargeObject interface{}             `json:"X-Static-Large-Object"`
 	}
 	err := json.Unmarshal(b, &s)
 	if err != nil {
@@ -161,6 +163,15 @@ func (r *DownloadHeader) UnmarshalJSON(b []byte) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	switch t := s.StaticLargeObject.(type) {
+	case string:
+		if t == "True" || t == "true" {
+			r.StaticLargeObject = true
+		}
+	case bool:
+		r.StaticLargeObject = t
 	}
 
 	r.Date = time.Time(s.Date)
@@ -213,7 +224,7 @@ type GetHeader struct {
 	ETag               string    `json:"Etag"`
 	LastModified       time.Time `json:"-"`
 	ObjectManifest     string    `json:"X-Object-Manifest"`
-	StaticLargeObject  bool      `json:"X-Static-Large-Object"`
+	StaticLargeObject  bool      `json:"-"`
 	TransID            string    `json:"X-Trans-Id"`
 }
 
@@ -221,10 +232,11 @@ func (r *GetHeader) UnmarshalJSON(b []byte) error {
 	type tmp GetHeader
 	var s struct {
 		tmp
-		ContentLength string                  `json:"Content-Length"`
-		Date          gophercloud.JSONRFC1123 `json:"Date"`
-		DeleteAt      gophercloud.JSONUnix    `json:"X-Delete-At"`
-		LastModified  gophercloud.JSONRFC1123 `json:"Last-Modified"`
+		ContentLength     string                  `json:"Content-Length"`
+		Date              gophercloud.JSONRFC1123 `json:"Date"`
+		DeleteAt          gophercloud.JSONUnix    `json:"X-Delete-At"`
+		LastModified      gophercloud.JSONRFC1123 `json:"Last-Modified"`
+		StaticLargeObject interface{}             `json:"X-Static-Large-Object"`
 	}
 	err := json.Unmarshal(b, &s)
 	if err != nil {
@@ -241,6 +253,15 @@ func (r *GetHeader) UnmarshalJSON(b []byte) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	switch t := s.StaticLargeObject.(type) {
+	case string:
+		if t == "True" || t == "true" {
+			r.StaticLargeObject = true
+		}
+	case bool:
+		r.StaticLargeObject = t
 	}
 
 	r.Date = time.Time(s.Date)
@@ -493,4 +514,60 @@ func (r CopyResult) Extract() (*CopyHeader, error) {
 	var s *CopyHeader
 	err := r.ExtractInto(&s)
 	return s, err
+}
+
+// extractLastMarker is a function that takes a page of objects and returns the
+// marker for the page. This can either be a subdir or the last object's name.
+func extractLastMarker(r pagination.Page) (string, error) {
+	casted := r.(ObjectPage)
+
+	// If a delimiter was requested, check if a subdir exists.
+	queryParams, err := url.ParseQuery(casted.URL.RawQuery)
+	if err != nil {
+		return "", err
+	}
+
+	var delimeter bool
+	if v, ok := queryParams["delimiter"]; ok && len(v) > 0 {
+		delimeter = true
+	}
+
+	ct := casted.Header.Get("Content-Type")
+	switch {
+	case strings.HasPrefix(ct, "application/json"):
+		parsed, err := ExtractInfo(r)
+		if err != nil {
+			return "", err
+		}
+
+		var lastObject Object
+		if len(parsed) > 0 {
+			lastObject = parsed[len(parsed)-1]
+		}
+
+		if !delimeter {
+			return lastObject.Name, nil
+		}
+
+		if lastObject.Name != "" {
+			return lastObject.Name, nil
+		}
+
+		return lastObject.Subdir, nil
+	case strings.HasPrefix(ct, "text/plain"):
+		names := make([]string, 0, 50)
+
+		body := string(r.(ObjectPage).Body.([]uint8))
+		for _, name := range strings.Split(body, "\n") {
+			if len(name) > 0 {
+				names = append(names, name)
+			}
+		}
+
+		return names[len(names)-1], err
+	case strings.HasPrefix(ct, "text/html"):
+		return "", nil
+	default:
+		return "", fmt.Errorf("Cannot extract names from response with content-type: [%s]", ct)
+	}
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -685,10 +685,10 @@
 			"revisionTime": "2017-03-10T01:59:53Z"
 		},
 		{
-			"checksumSHA1": "F1gaBPZj2MGwEF7u8GARRa6XlvQ=",
+			"checksumSHA1": "aQ+OjOThpmPUF1KgniHIM37eaN8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects",
-			"revision": "e7fa81ec4cbb506026fa90fe7deeb9b7548a0728",
-			"revisionTime": "2017-11-01T04:49:27Z"
+			"revision": "10244f9e8a6751d9c0ac1656edb8d56aaaf97c32",
+			"revisionTime": "2018-04-21T02:00:55Z"
 		},
 		{
 			"checksumSHA1": "roxPPVwS2CjJhf0CApHNQxAX7EA=",


### PR DESCRIPTION
Gophercloud now allows the etag to be specified and omitted. This caused
the openstack_objecstorage_object_v1 resource to break because it was
sending the old etag with new content. This commit fixes this by
creating a separate Update function and conditionally sending the etag.

This should not break existing deployments.

Related to: #359 

/cc @yanndegat 