### PR TITLE
Return the default network uuid on instance create

### DIFF
--- a/openstack/compute_instance_v2_networking.go
+++ b/openstack/compute_instance_v2_networking.go
@@ -415,6 +415,15 @@ func flattenInstanceNetworks(
 					"fixed_ip_v6": instanceNIC.FixedIPv6,
 					"mac":         instanceNIC.MAC,
 				}
+
+				// Use the same method as getAllInstanceNetworks to get the network uuid
+				networkInfo, err := getInstanceNetworkInfo(d, meta, "name", instanceAddresses.NetworkName)
+				if err != nil {
+					log.Printf("[WARN] Error getting default network uuid: %s", err)
+				} else {
+					v["uuid"] = networkInfo["uuid"].(string)
+				}
+
 				networks = append(networks, v)
 			}
 		}


### PR DESCRIPTION
Currently when an instance has no "network" blocks it's assumed it will
connect to the default network, worked out by inspecting the instance
addresses and taking the network name from that. This doesn't return the
network uuid, but the first refresh will pick the uuid up because the
resource now has a network block (with the default network name).

This commit simply copies some of the logic used in
getAllInstanceNetworks to work out network uuids from network names to
do the same with the default network name. Thus instances have a full
network block returned with name and uuid on create.