### PR TITLE
Acc Tests: Allow Octavia to be Tested

### DIFF
--- a/openstack/provider_test.go
+++ b/openstack/provider_test.go
@@ -30,6 +30,7 @@ var (
 	OS_LB_ENVIRONMENT         = os.Getenv("OS_LB_ENVIRONMENT")
 	OS_FW_ENVIRONMENT         = os.Getenv("OS_FW_ENVIRONMENT")
 	OS_VPN_ENVIRONMENT        = os.Getenv("OS_VPN_ENVIRONMENT")
+	OS_USE_OCTAVIA            = os.Getenv("OS_USE_OCTAVIA")
 )
 
 var testAccProviders map[string]terraform.ResourceProvider

--- a/openstack/resource_openstack_lb_listener_v2_test.go
+++ b/openstack/resource_openstack_lb_listener_v2_test.go
@@ -40,9 +40,9 @@ func TestAccLBV2Listener_basic(t *testing.T) {
 
 func testAccCheckLBV2ListenerDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+	lbClient, err := chooseLBV2AccTestClient(config, OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+		return fmt.Errorf("Error creating OpenStack load balancing client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -50,7 +50,7 @@ func testAccCheckLBV2ListenerDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := listeners.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := listeners.Get(lbClient, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("Listener still exists: %s", rs.Primary.ID)
 		}
@@ -71,12 +71,12 @@ func testAccCheckLBV2ListenerExists(n string, listener *listeners.Listener) reso
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		lbClient, err := chooseLBV2AccTestClient(config, OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+			return fmt.Errorf("Error creating OpenStack load balancing client: %s", err)
 		}
 
-		found, err := listeners.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err := listeners.Get(lbClient, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}

--- a/openstack/resource_openstack_lb_member_v2_test.go
+++ b/openstack/resource_openstack_lb_member_v2_test.go
@@ -38,9 +38,9 @@ func TestAccLBV2Member_basic(t *testing.T) {
 
 func testAccCheckLBV2MemberDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+	lbClient, err := chooseLBV2AccTestClient(config, OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+		return fmt.Errorf("Error creating OpenStack load balancing client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -49,7 +49,7 @@ func testAccCheckLBV2MemberDestroy(s *terraform.State) error {
 		}
 
 		poolId := rs.Primary.Attributes["pool_id"]
-		_, err := pools.GetMember(networkingClient, poolId, rs.Primary.ID).Extract()
+		_, err := pools.GetMember(lbClient, poolId, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("Member still exists: %s", rs.Primary.ID)
 		}
@@ -70,13 +70,13 @@ func testAccCheckLBV2MemberExists(n string, member *pools.Member) resource.TestC
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		lbClient, err := chooseLBV2AccTestClient(config, OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+			return fmt.Errorf("Error creating OpenStack load balancing client: %s", err)
 		}
 
 		poolId := rs.Primary.Attributes["pool_id"]
-		found, err := pools.GetMember(networkingClient, poolId, rs.Primary.ID).Extract()
+		found, err := pools.GetMember(lbClient, poolId, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}

--- a/openstack/resource_openstack_lb_monitor_v2_test.go
+++ b/openstack/resource_openstack_lb_monitor_v2_test.go
@@ -38,9 +38,9 @@ func TestAccLBV2Monitor_basic(t *testing.T) {
 
 func testAccCheckLBV2MonitorDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+	lbClient, err := chooseLBV2AccTestClient(config, OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+		return fmt.Errorf("Error creating OpenStack load balancing client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -48,7 +48,7 @@ func testAccCheckLBV2MonitorDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := monitors.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := monitors.Get(lbClient, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("Monitor still exists: %s", rs.Primary.ID)
 		}
@@ -69,12 +69,12 @@ func testAccCheckLBV2MonitorExists(t *testing.T, n string, monitor *monitors.Mon
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		lbClient, err := chooseLBV2AccTestClient(config, OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+			return fmt.Errorf("Error creating OpenStack load balancing client: %s", err)
 		}
 
-		found, err := monitors.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err := monitors.Get(lbClient, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}

--- a/openstack/resource_openstack_lb_pool_v2_test.go
+++ b/openstack/resource_openstack_lb_pool_v2_test.go
@@ -35,9 +35,9 @@ func TestAccLBV2Pool_basic(t *testing.T) {
 
 func testAccCheckLBV2PoolDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+	lbClient, err := chooseLBV2AccTestClient(config, OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+		return fmt.Errorf("Error creating OpenStack load balancing client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -45,7 +45,7 @@ func testAccCheckLBV2PoolDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := pools.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := pools.Get(lbClient, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("Pool still exists: %s", rs.Primary.ID)
 		}
@@ -66,12 +66,12 @@ func testAccCheckLBV2PoolExists(n string, pool *pools.Pool) resource.TestCheckFu
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		lbClient, err := chooseLBV2AccTestClient(config, OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+			return fmt.Errorf("Error creating OpenStack load balancing client: %s", err)
 		}
 
-		found, err := pools.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err := pools.Get(lbClient, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This commit enables the Octavia Load Balancing service to be tested by
making the proper modifications to the existing Neutron LBaaSv2 code.

Fixes #355 

/cc @kiwik 

I tested this on an Octavia-enabled cloud and one which still has Neutron LBaaSv2 and both passed.