### PR TITLE
Allow one to obtain a specific floating IP to associate with a loadbalancer

### DIFF
--- a/openstack/resource_openstack_networking_floatingip_v2.go
+++ b/openstack/resource_openstack_networking_floatingip_v2.go
@@ -38,7 +38,9 @@ func resourceNetworkingFloatingIPV2() *schema.Resource {
 			},
 			"address": &schema.Schema{
 				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"pool": &schema.Schema{
 				Type:        schema.TypeString,
@@ -92,6 +94,7 @@ func resourceNetworkFloatingIPV2Create(d *schema.ResourceData, meta interface{})
 	createOpts := FloatingIPCreateOpts{
 		floatingips.CreateOpts{
 			FloatingNetworkID: poolID,
+			FloatingIP:        d.Get("address").(string),
 			PortID:            d.Get("port_id").(string),
 			TenantID:          d.Get("tenant_id").(string),
 			FixedIP:           d.Get("fixed_ip").(string),

--- a/website/docs/r/networking_floatingip_v2.html.markdown
+++ b/website/docs/r/networking_floatingip_v2.html.markdown
@@ -42,6 +42,8 @@ The following arguments are supported:
     belongs to the same tenant. Changing this creates a new floating IP (which
     may or may not have a different address)
 
+* `address` - (Optional) The actual/specific floating IP to obtain.
+
 * `fixed_ip` - Fixed IP of the port to associate with this floating IP. Required if
     the port has multiple fixed IPs.
 

--- a/website/docs/r/networking_floatingip_v2.html.markdown
+++ b/website/docs/r/networking_floatingip_v2.html.markdown
@@ -42,7 +42,10 @@ The following arguments are supported:
     belongs to the same tenant. Changing this creates a new floating IP (which
     may or may not have a different address)
 
-* `address` - (Optional) The actual/specific floating IP to obtain.
+* `address` - (Optional) The actual/specific floating IP to obtain. By default,
+    non-admin users are not able to specify a floating IP, so you must either be 
+    an admin user or have had a custom policy or role applied to your OpenStack 
+    user or project.
 
 * `fixed_ip` - Fixed IP of the port to associate with this floating IP. Required if
     the port has multiple fixed IPs.


### PR DESCRIPTION
Since a load balancer is often the entry point to the rest of your infrastructure it's common to use a stable/fixed IP as the VIP of your load balancer. The OpenStack REST API supports this, but the Terraform OpenStack provider currently doesn't. 

This PR adds the ability to obtain a _specific_ networking floating IP from the pool in order to associate it with the VIP of a load balancer. E.g:
```
resource "openstack_networking_floatingip_v2" "https_lb_float_ip" {
  pool = "mypool"
  address = "192.0.2.0"
}
```

Also credits to @jagter for helping out with this PR.