### PR TITLE
Allow proxy procotol on lb pool v2

### DIFF
--- a/openstack/resource_openstack_lb_pool_v2.go
+++ b/openstack/resource_openstack_lb_pool_v2.go
@@ -55,9 +55,9 @@ func resourcePoolV2() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
-					if value != "TCP" && value != "HTTP" && value != "HTTPS" {
+					if value != "TCP" && value != "HTTP" && value != "HTTPS" && value != "PROXY" {
 						errors = append(errors, fmt.Errorf(
-							"Only 'TCP', 'HTTP', and 'HTTPS' are supported values for 'protocol'"))
+							"Only 'TCP', 'HTTP','HTTPS', and 'PROXY' are supported values for 'protocol'"))
 					}
 					return
 				},

--- a/website/docs/r/lb_pool_v2.html.markdown
+++ b/website/docs/r/lb_pool_v2.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `description` - (Optional) Human-readable description for the pool.
 
-* `protocol` = (Required) The protocol - can either be TCP, HTTP or HTTPS.
+* `protocol` = (Required) The protocol - can either be TCP, HTTP, HTTPS or PROXY.
     Changing this creates a new pool.
 
 * `loadbalancer_id` - (Optional) The load balancer on which to provision this


### PR DESCRIPTION


Hello,

I want to create lbaas pool with PROXY protocol on Octavia. But terraform output following error message:

    Error: openstack_lb_pool_v2.octavia_test: Only 'TCP', 'HTTP', and 'HTTPS' are supported values for 'protocol'

Octavia lbaas pool support PROXY protocol since API 1.0 (Release Pike), so I allow to specify PROXY.

reference:

- https://developer.openstack.org/api-ref/load-balancer/v2/#create-pool



Thanks!
