### PR TITLE
Add data openstack_identity_endpoint_v3

### DIFF
--- a/openstack/data_source_openstack_identity_endpoint_v3.go
+++ b/openstack/data_source_openstack_identity_endpoint_v3.go
@@ -1,0 +1,129 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/services"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceIdentityEndpointV3() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceIdentityEndpointV3Read,
+
+		Schema: map[string]*schema.Schema{
+			"service_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"service_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"interface": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"url": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+// dataSourceIdentityEndpointV3Read performs the endpoint lookup.
+func dataSourceIdentityEndpointV3Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	availability := gophercloud.AvailabilityPublic
+	switch d.Get("interface") {
+	case "internal":
+		availability = gophercloud.AvailabilityInternal
+	case "admin":
+		availability = gophercloud.AvailabilityAdmin
+	}
+
+	listOpts := endpoints.ListOpts{
+		Availability: availability,
+		ServiceID:    d.Get("service_id").(string),
+	}
+
+	log.Printf("[DEBUG] List Options: %#v", listOpts)
+
+	var endpoint endpoints.Endpoint
+	allPages, err := endpoints.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		return fmt.Errorf("Unable to query endpoints: %s", err)
+	}
+
+	allEndpoints, err := endpoints.ExtractEndpoints(allPages)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve endpoints: %s", err)
+	}
+
+	if len(allEndpoints) > 1 && d.Get("service_name") != "" {
+		var filteredEndpoints []endpoints.Endpoint
+		for _, endpoint := range allEndpoints {
+			service, err := services.Get(identityClient, endpoint.ServiceID).Extract()
+			if err != nil {
+				continue
+			}
+			if service.Extra["name"] == d.Get("service_name") {
+				endpoint.Name = service.Extra["name"].(string)
+				filteredEndpoints = append(filteredEndpoints, endpoint)
+			}
+		}
+		allEndpoints = filteredEndpoints
+	}
+
+	if len(allEndpoints) < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	if len(allEndpoints) > 1 {
+		log.Printf("[DEBUG] Multiple results found: %#v", allEndpoints)
+		return fmt.Errorf("Your query returned more than one result")
+	}
+	endpoint = allEndpoints[0]
+
+	log.Printf("[DEBUG] Single endpoint found: %s", endpoint.ID)
+	return dataSourceIdentityEndpointV3Attributes(d, &endpoint)
+}
+
+// dataSourceIdentityEndpointV3Attributes populates the fields of an Endpoint resource.
+func dataSourceIdentityEndpointV3Attributes(d *schema.ResourceData, endpoint *endpoints.Endpoint) error {
+	log.Printf("[DEBUG] openstack_identity_endpoint_v3 details: %#v", endpoint)
+
+	d.SetId(endpoint.ID)
+	d.Set("interface", endpoint.Availability)
+	d.Set("name", endpoint.Name)
+	d.Set("region", endpoint.Region)
+	d.Set("service_id", endpoint.ServiceID)
+	d.Set("service_name", endpoint.Name)
+	d.Set("url", endpoint.URL)
+
+	return nil
+}

--- a/openstack/data_source_openstack_identity_endpoint_v3_test.go
+++ b/openstack/data_source_openstack_identity_endpoint_v3_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAccOpenStackIdentityV3EndpointDataSource_basic(t *testing.T) {
-	endpointName := "swift"
+	endpointName := "identity"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -23,7 +23,7 @@ func TestAccOpenStackIdentityV3EndpointDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityEndpointV3DataSourceID("data.openstack_identity_endpoint_v3.endpoint_1"),
 					resource.TestCheckResourceAttr(
-						"data.openstack_identity_endpoint_v3.endpoint_1", "name", endpointName),
+						"data.openstack_identity_endpoint_v3.endpoint_1", "service_name", endpointName),
 				),
 			},
 		},
@@ -48,7 +48,7 @@ func testAccCheckIdentityEndpointV3DataSourceID(n string) resource.TestCheckFunc
 func testAccOpenStackIdentityEndpointV3DataSource_basic(name, iface string) string {
 	return fmt.Sprintf(`
 	data "openstack_identity_endpoint_v3" "endpoint_1" {
-      service_name = %s
+      service_name = "%s"
       interface = "%s"
 	}
 `, name, iface)

--- a/openstack/data_source_openstack_identity_endpoint_v3_test.go
+++ b/openstack/data_source_openstack_identity_endpoint_v3_test.go
@@ -1,0 +1,55 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccOpenStackIdentityV3EndpointDataSource_basic(t *testing.T) {
+	endpointName := "swift"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOpenStackIdentityEndpointV3DataSource_basic(endpointName, "public"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityEndpointV3DataSourceID("data.openstack_identity_endpoint_v3.endpoint_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_identity_endpoint_v3.endpoint_1", "name", endpointName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIdentityEndpointV3DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find endpoint data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Endpoint data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccOpenStackIdentityEndpointV3DataSource_basic(name, iface string) string {
+	return fmt.Sprintf(`
+	data "openstack_identity_endpoint_v3" "endpoint_1" {
+      service_name = %s
+      interface = "%s"
+	}
+`, name, iface)
+}

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -198,6 +198,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_identity_project_v3":      dataSourceIdentityProjectV3(),
 			"openstack_identity_user_v3":         dataSourceIdentityUserV3(),
 			"openstack_identity_auth_scope_v3":   dataSourceIdentityAuthScopeV3(),
+			"openstack_identity_endpoint_v3":     dataSourceIdentityEndpointV3(),
 			"openstack_images_image_v2":          dataSourceImagesImageV2(),
 			"openstack_networking_network_v2":    dataSourceNetworkingNetworkV2(),
 			"openstack_networking_subnet_v2":     dataSourceNetworkingSubnetV2(),

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints/doc.go
@@ -1,0 +1,69 @@
+/*
+Package endpoints provides information and interaction with the service
+endpoints API resource in the OpenStack Identity service.
+
+For more information, see:
+http://developer.openstack.org/api-ref-identity-v3.html#endpoints-v3
+
+Example to List Endpoints
+
+	serviceID := "e629d6e599d9489fb3ae5d9cc12eaea3"
+
+	listOpts := endpoints.ListOpts{
+		ServiceID: serviceID,
+	}
+
+	allPages, err := endpoints.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allEndpoints, err := endpoints.ExtractEndpoints(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, endpoint := range allEndpoints {
+		fmt.Printf("%+v\n", endpoint)
+	}
+
+Example to Create an Endpoint
+
+	serviceID := "e629d6e599d9489fb3ae5d9cc12eaea3"
+
+	createOpts := endpoints.CreateOpts{
+		Availability: gophercloud.AvailabilityPublic,
+		Name:         "neutron",
+		Region:       "RegionOne",
+		URL:          "https://localhost:9696",
+		ServiceID:    serviceID,
+	}
+
+	endpoint, err := endpoints.Create(identityClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+
+Example to Update an Endpoint
+
+	endpointID := "ad59deeec5154d1fa0dcff518596f499"
+
+	updateOpts := endpoints.UpdateOpts{
+		Region: "RegionTwo",
+	}
+
+	endpoint, err := endpoints.Update(identityClient, endpointID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete an Endpoint
+
+	endpointID := "ad59deeec5154d1fa0dcff518596f499"
+	err := endpoints.Delete(identityClient, endpointID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package endpoints

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints/requests.go
@@ -1,0 +1,136 @@
+package endpoints
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type CreateOptsBuilder interface {
+	ToEndpointCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains the subset of Endpoint attributes that should be used
+// to create an Endpoint.
+type CreateOpts struct {
+	// Availability is the interface type of the Endpoint (admin, internal,
+	// or public), referenced by the gophercloud.Availability type.
+	Availability gophercloud.Availability `json:"interface" required:"true"`
+
+	// Name is the name of the Endpoint.
+	Name string `json:"name" required:"true"`
+
+	// Region is the region the Endpoint is located in.
+	// This field can be omitted or left as a blank string.
+	Region string `json:"region,omitempty"`
+
+	// URL is the url of the Endpoint.
+	URL string `json:"url" required:"true"`
+
+	// ServiceID is the ID of the service the Endpoint refers to.
+	ServiceID string `json:"service_id" required:"true"`
+}
+
+// ToEndpointCreateMap builds a request body from the Endpoint Create options.
+func (opts CreateOpts) ToEndpointCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "endpoint")
+}
+
+// Create inserts a new Endpoint into the service catalog.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToEndpointCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(listURL(client), &b, &r.Body, nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add parameters to the List request.
+type ListOptsBuilder interface {
+	ToEndpointListParams() (string, error)
+}
+
+// ListOpts allows finer control over the endpoints returned by a List call.
+// All fields are optional.
+type ListOpts struct {
+	// Availability is the interface type of the Endpoint (admin, internal,
+	// or public), referenced by the gophercloud.Availability type.
+	Availability gophercloud.Availability `q:"interface"`
+
+	// ServiceID is the ID of the service the Endpoint refers to.
+	ServiceID string `q:"service_id"`
+
+	// RegionID is the ID of the region the Endpoint refers to.
+	RegionID int `q:"region_id"`
+}
+
+// ToEndpointListParams builds a list request from the List options.
+func (opts ListOpts) ToEndpointListParams() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List enumerates endpoints in a paginated collection, optionally filtered
+// by ListOpts criteria.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	u := listURL(client)
+	if opts != nil {
+		q, err := gophercloud.BuildQueryString(opts)
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		u += q.String()
+	}
+	return pagination.NewPager(client, u, func(r pagination.PageResult) pagination.Page {
+		return EndpointPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// UpdateOptsBuilder allows extensions to add parameters to the Update request.
+type UpdateOptsBuilder interface {
+	ToEndpointUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains the subset of Endpoint attributes that should be used to
+// update an Endpoint.
+type UpdateOpts struct {
+	// Availability is the interface type of the Endpoint (admin, internal,
+	// or public), referenced by the gophercloud.Availability type.
+	Availability gophercloud.Availability `json:"interface,omitempty"`
+
+	// Name is the name of the Endpoint.
+	Name string `json:"name,omitempty"`
+
+	// Region is the region the Endpoint is located in.
+	// This field can be omitted or left as a blank string.
+	Region string `json:"region,omitempty"`
+
+	// URL is the url of the Endpoint.
+	URL string `json:"url,omitempty"`
+
+	// ServiceID is the ID of the service the Endpoint refers to.
+	ServiceID string `json:"service_id,omitempty"`
+}
+
+// ToEndpointUpdateMap builds an update request body from the Update options.
+func (opts UpdateOpts) ToEndpointUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "endpoint")
+}
+
+// Update changes an existing endpoint with new data.
+func Update(client *gophercloud.ServiceClient, endpointID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToEndpointUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Patch(endpointURL(client, endpointID), &b, &r.Body, nil)
+	return
+}
+
+// Delete removes an endpoint from the service catalog.
+func Delete(client *gophercloud.ServiceClient, endpointID string) (r DeleteResult) {
+	_, r.Err = client.Delete(endpointURL(client, endpointID), nil)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints/results.go
@@ -1,0 +1,80 @@
+package endpoints
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a GetResult, CreateResult or UpdateResult as a concrete
+// Endpoint. An error is returned if the original call or the extraction failed.
+func (r commonResult) Extract() (*Endpoint, error) {
+	var s struct {
+		Endpoint *Endpoint `json:"endpoint"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Endpoint, err
+}
+
+// CreateResult is the response from a Create operation. Call its Extract
+// method to interpret it as an Endpoint.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult is the response from an Update operation. Call its Extract
+// method to interpret it as an Endpoint.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// Endpoint describes the entry point for another service's API.
+type Endpoint struct {
+	// ID is the unique ID of the endpoint.
+	ID string `json:"id"`
+
+	// Availability is the interface type of the Endpoint (admin, internal,
+	// or public), referenced by the gophercloud.Availability type.
+	Availability gophercloud.Availability `json:"interface"`
+
+	// Name is the name of the Endpoint.
+	Name string `json:"name"`
+
+	// Region is the region the Endpoint is located in.
+	Region string `json:"region"`
+
+	// ServiceID is the ID of the service the Endpoint refers to.
+	ServiceID string `json:"service_id"`
+
+	// URL is the url of the Endpoint.
+	URL string `json:"url"`
+}
+
+// EndpointPage is a single page of Endpoint results.
+type EndpointPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if no Endpoints were returned.
+func (r EndpointPage) IsEmpty() (bool, error) {
+	es, err := ExtractEndpoints(r)
+	return len(es) == 0, err
+}
+
+// ExtractEndpoints extracts an Endpoint slice from a Page.
+func ExtractEndpoints(r pagination.Page) ([]Endpoint, error) {
+	var s struct {
+		Endpoints []Endpoint `json:"endpoints"`
+	}
+	err := (r.(EndpointPage)).ExtractInto(&s)
+	return s.Endpoints, err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints/urls.go
@@ -1,0 +1,11 @@
+package endpoints
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("endpoints")
+}
+
+func endpointURL(client *gophercloud.ServiceClient, endpointID string) string {
+	return client.ServiceURL("endpoints", endpointID)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/services/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/services/doc.go
@@ -1,0 +1,66 @@
+/*
+Package services provides information and interaction with the services API
+resource for the OpenStack Identity service.
+
+Example to List Services
+
+	listOpts := services.ListOpts{
+		ServiceType: "compute",
+	}
+
+	allPages, err := services.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allServices, err := services.ExtractServices(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, service := range allServices {
+		fmt.Printf("%+v\n", service)
+	}
+
+Example to Create a Service
+
+	createOpts := services.CreateOpts{
+		Type: "compute",
+		Extra: map[string]interface{}{
+			"name": "compute-service",
+			"description": "Compute Service",
+		},
+	}
+
+	service, err := services.Create(identityClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Service
+
+	serviceID :=  "3c7bbe9a6ecb453ca1789586291380ed"
+
+	var iFalse bool = false
+	updateOpts := services.UpdateOpts{
+		Enabled: &iFalse,
+		Extra: map[string]interface{}{
+			"description": "Disabled Compute Service"
+		},
+	}
+
+	service, err := services.Update(identityClient, serviceID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Service
+
+	serviceID := "3c7bbe9a6ecb453ca1789586291380ed"
+	err := services.Delete(identityClient, serviceID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+*/
+package services

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/services/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/services/requests.go
@@ -1,0 +1,154 @@
+package services
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to
+// the Create request.
+type CreateOptsBuilder interface {
+	ToServiceCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts provides options used to create a service.
+type CreateOpts struct {
+	// Type is the type of the service.
+	Type string `json:"type"`
+
+	// Enabled is whether or not the service is enabled.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// Extra is free-form extra key/value pairs to describe the service.
+	Extra map[string]interface{} `json:"-"`
+}
+
+// ToServiceCreateMap formats a CreateOpts into a create request.
+func (opts CreateOpts) ToServiceCreateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "service")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Extra != nil {
+		if v, ok := b["service"].(map[string]interface{}); ok {
+			for key, value := range opts.Extra {
+				v[key] = value
+			}
+		}
+	}
+
+	return b, nil
+}
+
+// Create adds a new service of the requested type to the catalog.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToServiceCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	return
+}
+
+// ListOptsBuilder enables extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToServiceListMap() (string, error)
+}
+
+// ListOpts provides options for filtering the List results.
+type ListOpts struct {
+	// ServiceType filter the response by a type of service.
+	ServiceType string `q:"type"`
+
+	// Name filters the response by a service name.
+	Name string `q:"name"`
+}
+
+// ToServiceListMap builds a list query from the list options.
+func (opts ListOpts) ToServiceListMap() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List enumerates the services available to a specific user.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToServiceListMap()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ServicePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get returns additional information about a service, given its ID.
+func Get(client *gophercloud.ServiceClient, serviceID string) (r GetResult) {
+	_, r.Err = client.Get(serviceURL(client, serviceID), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateOptsBuilder interface {
+	ToServiceUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts provides options for updating a service.
+type UpdateOpts struct {
+	// Type is the type of the service.
+	Type string `json:"type"`
+
+	// Enabled is whether or not the service is enabled.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// Extra is free-form extra key/value pairs to describe the service.
+	Extra map[string]interface{} `json:"-"`
+}
+
+// ToServiceUpdateMap formats a UpdateOpts into an update request.
+func (opts UpdateOpts) ToServiceUpdateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "service")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Extra != nil {
+		if v, ok := b["service"].(map[string]interface{}); ok {
+			for key, value := range opts.Extra {
+				v[key] = value
+			}
+		}
+	}
+
+	return b, nil
+}
+
+// Update updates an existing Service.
+func Update(client *gophercloud.ServiceClient, serviceID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToServiceUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Patch(updateURL(client, serviceID), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete removes an existing service.
+// It either deletes all associated endpoints, or fails until all endpoints
+// are deleted.
+func Delete(client *gophercloud.ServiceClient, serviceID string) (r DeleteResult) {
+	_, r.Err = client.Delete(serviceURL(client, serviceID), nil)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/services/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/services/results.go
@@ -1,0 +1,131 @@
+package services
+
+import (
+	"encoding/json"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/internal"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type serviceResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a GetResult, CreateResult or UpdateResult as a concrete
+// Service. An error is returned if the original call or the extraction failed.
+func (r serviceResult) Extract() (*Service, error) {
+	var s struct {
+		Service *Service `json:"service"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Service, err
+}
+
+// CreateResult is the response from a Create request. Call its Extract method
+// to interpret it as a Service.
+type CreateResult struct {
+	serviceResult
+}
+
+// GetResult is the response from a Get request. Call its Extract method
+// to interpret it as a Service.
+type GetResult struct {
+	serviceResult
+}
+
+// UpdateResult is the response from an Update request. Call its Extract method
+// to interpret it as a Service.
+type UpdateResult struct {
+	serviceResult
+}
+
+// DeleteResult is the response from a Delete request. Call its ExtractErr
+// method to interpret it as a Service.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// Service represents an OpenStack Service.
+type Service struct {
+	// ID is the unique ID of the service.
+	ID string `json:"id"`
+
+	// Type is the type of the service.
+	Type string `json:"type"`
+
+	// Enabled is whether or not the service is enabled.
+	Enabled bool `json:"enabled"`
+
+	// Links contains referencing links to the service.
+	Links map[string]interface{} `json:"links"`
+
+	// Extra is a collection of miscellaneous key/values.
+	Extra map[string]interface{} `json:"-"`
+}
+
+func (r *Service) UnmarshalJSON(b []byte) error {
+	type tmp Service
+	var s struct {
+		tmp
+		Extra map[string]interface{} `json:"extra"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Service(s.tmp)
+
+	// Collect other fields and bundle them into Extra
+	// but only if a field titled "extra" wasn't sent.
+	if s.Extra != nil {
+		r.Extra = s.Extra
+	} else {
+		var result interface{}
+		err := json.Unmarshal(b, &result)
+		if err != nil {
+			return err
+		}
+		if resultMap, ok := result.(map[string]interface{}); ok {
+			r.Extra = internal.RemainingKeys(Service{}, resultMap)
+		}
+	}
+
+	return err
+}
+
+// ServicePage is a single page of Service results.
+type ServicePage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if the ServicePage contains no results.
+func (p ServicePage) IsEmpty() (bool, error) {
+	services, err := ExtractServices(p)
+	return len(services) == 0, err
+}
+
+// NextPageURL extracts the "next" link from the links section of the result.
+func (r ServicePage) NextPageURL() (string, error) {
+	var s struct {
+		Links struct {
+			Next     string `json:"next"`
+			Previous string `json:"previous"`
+		} `json:"links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Links.Next, err
+}
+
+// ExtractServices extracts a slice of Services from a Collection acquired
+// from List.
+func ExtractServices(r pagination.Page) ([]Service, error) {
+	var s struct {
+		Services []Service `json:"services"`
+	}
+	err := (r.(ServicePage)).ExtractInto(&s)
+	return s.Services, err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/services/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/services/urls.go
@@ -1,0 +1,19 @@
+package services
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("services")
+}
+
+func createURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("services")
+}
+
+func serviceURL(client *gophercloud.ServiceClient, serviceID string) string {
+	return client.ServiceURL("services", serviceID)
+}
+
+func updateURL(client *gophercloud.ServiceClient, serviceID string) string {
+	return client.ServiceURL("services", serviceID)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -481,6 +481,12 @@
 			"revisionTime": "2017-03-10T01:59:53Z"
 		},
 		{
+			"checksumSHA1": "Qzlv/69tlr+1r6W28WrOEEqT9EU=",
+			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints",
+			"revision": "d25795ac360dec1265fd9c09b2172f8e74444899",
+			"revisionTime": "2018-07-27T00:43:57Z"
+		},
+		{
 			"checksumSHA1": "3W2lBfZVEu3kf9Nq3KFnBwG76nw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/projects",
 			"revision": "062f2739aef0b03a8e68cd94865c34d416d753e0",
@@ -491,6 +497,12 @@
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/roles",
 			"revision": "6da026c32e2d622cc242d32984259c77237aefe1",
 			"revisionTime": "2018-02-10T02:43:43Z"
+		},
+		{
+			"checksumSHA1": "qOc+KYPka86DtcDnpvBuKdCb8jk=",
+			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/services",
+			"revision": "d25795ac360dec1265fd9c09b2172f8e74444899",
+			"revisionTime": "2018-07-27T00:43:57Z"
 		},
 		{
 			"checksumSHA1": "rOjTAohd61Ldwf1cZxbuwbZK998=",

--- a/website/docs/d/identity_endpoint_v3.html.markdown
+++ b/website/docs/d/identity_endpoint_v3.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_identity_endpoint_v3"
+sidebar_current: "docs-openstack-datasource-identity-endpoint-v3"
+description: |-
+  Get information on an OpenStack Endpoint.
+---
+
+# openstack\_identity\_endpoint_v3
+
+Use this data source to get the ID of an OpenStack endpoint.
+
+## Example Usage
+
+```hcl
+data "openstack_identity_endpoint_v3" "endpoint_1" {
+  service_name = "demo"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_id` - (Optional) The service id this endpoint belongs to.
+
+* `service_name` - (Optional) The service name of the endpoint.
+
+* `interface` - (Optional) The endpoint interface. Valid values are `public`,
+  `internal`, and `admin`. Default value is `public`
+
+* `region` - (Optional) The region the endpoint is located in.
+
+## Attributes Reference
+
+`id` is set to the ID of the found endpoint. In addition, the following attributes
+are exported:
+
+* `service_id` - See Argument Reference above.
+* `service_name` - See Argument Reference above.
+* `interface` - See Argument Reference above.
+* `url` - The endpoint URL
+* `region` - The region the endpoint is located in.

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -36,6 +36,9 @@
             <li<%= sidebar_current("docs-openstack-datasource-images-image-v2") %>>
               <a href="/docs/providers/openstack/d/images_image_v2.html">openstack_images_image_v2</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-datasource-identity-endpoint-v3") %>>
+              <a href="/docs/providers/openstack/d/identity_endpoint_v3.html">openstack_identity_endpoint_v3</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-datasource-networking-network-v2") %>>
               <a href="/docs/providers/openstack/d/networking_network_v2.html">openstack_networking_network_v2</a>
             </li>


### PR DESCRIPTION
Allow for getting endpoint's data from the catalog. This is useful to
get public URL's that needed for inter-service communication in the
cloud.

/cc @jtopjian 