### PR TITLE
Add resource for creating Swift tempurls

### DIFF
--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -254,6 +254,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_networking_subnetpool_v2":           resourceNetworkingSubnetPoolV2(),
 			"openstack_objectstorage_container_v1":         resourceObjectStorageContainerV1(),
 			"openstack_objectstorage_object_v1":            resourceObjectStorageObjectV1(),
+			"openstack_objectstorage_tempurl_v1":           resourceObjectstorageTempurlV1(),
 			"openstack_vpnaas_ipsec_policy_v2":             resourceIPSecPolicyV2(),
 			"openstack_vpnaas_service_v2":                  resourceServiceV2(),
 			"openstack_vpnaas_ike_policy_v2":               resourceIKEPolicyV2(),

--- a/openstack/resource_openstack_objectstorage_tempurl_v1.go
+++ b/openstack/resource_openstack_objectstorage_tempurl_v1.go
@@ -1,0 +1,142 @@
+package openstack
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceObjectstorageTempurlV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceObjectstorageTempurlV1Create,
+		Read:   resourceObjectstorageTempurlV1Read,
+		Delete: schema.RemoveFromState,
+
+		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"container": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"object": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"method": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "get",
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if value != "get" && value != "post" {
+						errors = append(errors, fmt.Errorf(
+							"Only 'get', and 'post' are supported values for 'method'"))
+					}
+					return
+				},
+			},
+
+			"ttl": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"split": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// resourceObjectstorageTempurlV1Read performs the image lookup.
+func resourceObjectstorageTempurlV1Read(d *schema.ResourceData, meta interface{}) error {
+	turl := d.Get("url").(string)
+	u, err := url.Parse(turl)
+	if err != nil {
+		return fmt.Errorf("Failed to read the temp url: %s", turl)
+	}
+
+	qp, _ := url.ParseQuery(u.RawQuery)
+	expiry, err := strconv.ParseInt(qp.Get("temp_url_expires"), 10, 64)
+	if err != nil {
+		return fmt.Errorf("Failed to parse the temp url expiration time: %s", qp.Get("temp_url_expires"))
+	}
+	now := time.Now().Unix()
+	if expiry < now {
+		log.Printf("[DEBUG] URL expired, generating a new one")
+		d.SetId("")
+	}
+
+	return nil
+}
+
+// resourceObjectstorageTempurlV1Create performs the image lookup.
+func resourceObjectstorageTempurlV1Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	objectStorageClient, err := config.objectStorageV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+
+	method := objects.GET
+	switch d.Get("method") {
+	case "post":
+		method = objects.POST
+		// gophercloud doesn't have support for PUT yet,
+		// although it's a valid method for swift
+		//case "put":
+		//	method = objects.PUT
+	}
+
+	turlOptions := objects.CreateTempURLOpts{
+		Method: method,
+		TTL:    d.Get("ttl").(int),
+		Split:  d.Get("split").(string),
+	}
+
+	containerName := d.Get("container").(string)
+	objectName := d.Get("object").(string)
+
+	log.Printf("[DEBUG] Create TempURL Options: %#v", turlOptions)
+
+	url, err := objects.CreateTempURL(objectStorageClient, containerName, objectName, turlOptions)
+	if err != nil {
+		return fmt.Errorf("Unable to generate a TempURL for the object %s in container %s: %s",
+			objectName, containerName, err)
+	}
+
+	log.Printf("[DEBUG] URL Generated: %s", url)
+
+	// Set the URL and Id fields.
+	hasher := md5.New()
+	hasher.Write([]byte(url))
+	d.SetId(hex.EncodeToString(hasher.Sum(nil)))
+	d.Set("url", url)
+	return nil
+}

--- a/openstack/resource_openstack_objectstorage_tempurl_v1_test.go
+++ b/openstack/resource_openstack_objectstorage_tempurl_v1_test.go
@@ -1,0 +1,90 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccOpenStackObjectStorageTempurlV1_basic(t *testing.T) {
+	objectName := "object"
+	containerName := "container"
+	ttl := 60
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOpenStackObjectstorageTempurlV1Resource_basic(containerName, objectName, "get", ttl),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectstorageTempurlV1ResourceID("openstack_objectstorage_tempurl_v1.tempurl_1"),
+					resource.TestCheckResourceAttr(
+						"openstack_objectstorage_tempurl_v1.tempurl_1", "method", "get"),
+					resource.TestCheckResourceAttr(
+						"openstack_objectstorage_tempurl_v1.tempurl_1", "container", containerName),
+					resource.TestCheckResourceAttr(
+						"openstack_objectstorage_tempurl_v1.tempurl_1", "object", objectName),
+				),
+			},
+			resource.TestStep{
+				Config: testAccOpenStackObjectstorageTempurlV1Resource_basic(containerName, objectName, "post", ttl),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectstorageTempurlV1ResourceID("openstack_objectstorage_tempurl_v1.tempurl_1"),
+					resource.TestCheckResourceAttr(
+						"openstack_objectstorage_tempurl_v1.tempurl_1", "method", "post"),
+				),
+			},
+			/* TODO(flaper87): Find a good way to test the ttl expiration
+			            resource.TestStep{
+							Config: testAccOpenStackObjectstorageTempurlV1Resource_basic(containerName, objectName, "get", ),
+							Check: resource.ComposeTestCheckFunc(
+								resource.TestCheckResourceAttr(
+									"openstack_objectstorage_tempurl_v1.tempurl_1", "method", "get"),
+								testAccCheckObjectstorageTempurlV1Expired("openstack_objectstorage_tempurl_v1.tempurl_1", 1),
+							),
+						},*/
+		},
+	})
+}
+
+func testAccCheckObjectstorageTempurlV1ResourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find temp url resource: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Endpoint resource ID not set")
+		}
+
+		return nil
+	}
+}
+
+/*func testAccCheckObjectstorageTempurlV1Expired(n string, ttl int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		time.Sleep(time.Duration(ttl))
+		err := testAccCheckObjectstorageTempurlV1ResourceID(n)(s)
+		if err == nil {
+			return fmt.Errorf("The temp url didn't expire")
+		}
+		return nil
+	}
+}*/
+
+func testAccOpenStackObjectstorageTempurlV1Resource_basic(container, object string, method string, ttl int) string {
+	return fmt.Sprintf(`
+	resource "openstack_objectstorage_tempurl_v1" "tempurl_1" {
+      object = "%s"
+      container = "%s"
+      method = "%s"
+      ttl = %d
+	}
+`, object, container, method, ttl)
+}

--- a/website/docs/r/objectstorage_tempurl_v1.html.markdown
+++ b/website/docs/r/objectstorage_tempurl_v1.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_objectstorage_tempurl_v1"
+sidebar_current: "docs-openstack-resource-objectstorage-tempurl-v1"
+description: |-
+  Generate a TempURL for a Swift container and object.
+---
+
+# openstack\_objectstorage\_tempurl_v1
+
+Use this resource to generate an OpenStack Object Storage temporary URL.
+
+## Example Usage
+
+```hcl
+resource "openstack_objectstorage_tempurl_v1" "obj_tempurl" {
+  container = "test"
+  object = "container"
+  method = "post"
+  ttl = 20
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `container` - (Required) The container name the object belongs to.
+
+* `object` - (Required) The object name the tempurl is for.
+
+* `ttl` - (Required) The TTL, in seconds, for the URL. For how long it should be valid.
+
+* `method` - (Optional) What methods are allowed for this URL. Valid values are `GET`, and `POST`. Default is `GET`.
+
+* `region` - (Optional) The region the tempurl is located in.
+
+## Attributes Reference
+
+* `Id` - Computed md5 hash based on the generated url
+* `container` - See Argument Reference above.
+* `object` - See Argument Reference above.
+* `ttl` - See Argument Reference above.
+* `method` - See Argument Reference above.
+* `url` - The URL
+* `region` - The region the endpoint is located in.

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -270,6 +270,9 @@
             <li<%= sidebar_current("docs-openstack-resource-objectstorage-object-v1") %>>
               <a href="/docs/providers/openstack/r/objectstorage_object_v1.html">openstack_objectstorage_object_v1</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-datasource-objectstorage-tempurl-v1") %>>
+              <a href="/docs/providers/openstack/r/objectstorage_tempurl_v1.html">openstack_objectstorage_tempurl_v1</a>
+            </li>
           </ul>
         </li>
 


### PR DESCRIPTION
Arguably, TempUrls could be considered a resource. However, they do not
exist in the server, they cannot be updated, and they cannot be
deleted. This type of resource can only be generated and it has a
limited lifetime. Therefore, this has been implemented as a datasource.

Given a container name and an object name, it'll be possible to create
a tempurl for that object and store it as a data source.

/cc @jtopjian 