### PR TITLE
Networks v2: Network Data Source Fixes

### DIFF
--- a/openstack/data_source_openstack_networking_network_v2.go
+++ b/openstack/data_source_openstack_networking_network_v2.go
@@ -70,22 +70,29 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 
-	listOpts := networks.ListOpts{
+	var listOpts networks.ListOptsBuilder
+
+	var status string
+	if v, ok := d.GetOk("status"); ok {
+		status = v.(string)
+	}
+
+	listOpts = networks.ListOpts{
 		ID:       d.Get("network_id").(string),
 		Name:     d.Get("name").(string),
 		TenantID: d.Get("tenant_id").(string),
-	}
-	if v, ok := d.GetOk("status"); ok {
-		listOpts.Status = v.(string)
+		Status:   status,
 	}
 
-	isExternal := d.Get("external").(bool)
-	listExternalOpts := external.ListOptsExt{
-		ListOptsBuilder: listOpts,
-		External:        &isExternal,
+	if v, ok := d.GetOkExists("external"); ok {
+		isExternal := v.(bool)
+		listOpts = external.ListOptsExt{
+			ListOptsBuilder: listOpts,
+			External:        &isExternal,
+		}
 	}
 
-	pages, err := networks.List(networkingClient, listExternalOpts).AllPages()
+	pages, err := networks.List(networkingClient, listOpts).AllPages()
 	if err != nil {
 		return err
 	}
@@ -141,7 +148,7 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 	d.Set("name", network.Name)
 	d.Set("admin_state_up", strconv.FormatBool(network.AdminStateUp))
 	d.Set("shared", strconv.FormatBool(network.Shared))
-	d.Set("external", strconv.FormatBool(network.External))
+	d.Set("external", network.External)
 	d.Set("tenant_id", network.TenantID)
 	d.Set("region", GetRegion(d, config))
 

--- a/openstack/data_source_openstack_networking_network_v2.go
+++ b/openstack/data_source_openstack_networking_network_v2.go
@@ -96,6 +96,19 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 	if err != nil {
 		return err
 	}
+
+	// First extract into a normal networks.Network in order to see if
+	// there were any results at all.
+	tmpAllNetworks, err := networks.ExtractNetworks(pages)
+	if err != nil {
+		return err
+	}
+
+	if len(tmpAllNetworks) < 1 {
+		return fmt.Errorf("Your query reqturned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
 	type networkWithExternalExt struct {
 		networks.Network
 		external.NetworkExternalExt

--- a/openstack/data_source_openstack_networking_network_v2_test.go
+++ b/openstack/data_source_openstack_networking_network_v2_test.go
@@ -74,23 +74,42 @@ func TestAccOpenStackNetworkingNetworkV2DataSource_networkID(t *testing.T) {
 	})
 }
 
-func TestAccOpenStackNetworkingNetworkV2DataSource_external(t *testing.T) {
+func TestAccOpenStackNetworkingNetworkV2DataSource_externalExplicit(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckAdminOnly(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccOpenStackNetworkingNetworkV2DataSource_networkExternal,
-			},
-			resource.TestStep{
-				Config: testAccOpenStackNetworkingNetworkV2DataSource_external,
+				Config: testAccOpenStackNetworkingNetworkV2DataSource_externalExplicit,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingNetworkV2DataSourceID("data.openstack_networking_network_v2.net"),
 					resource.TestCheckResourceAttr(
-						"data.openstack_networking_network_v2.net", "name", "tf_test_network"),
+						"data.openstack_networking_network_v2.net", "name", OS_POOL_NAME),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_network_v2.net", "admin_state_up", "true"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_network_v2.net", "external", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOpenStackNetworkingNetworkV2DataSource_externalImplicit(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOpenStackNetworkingNetworkV2DataSource_externalImplicit,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingNetworkV2DataSourceID("data.openstack_networking_network_v2.net"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_network_v2.net", "name", OS_POOL_NAME),
 					resource.TestCheckResourceAttr(
 						"data.openstack_networking_network_v2.net", "admin_state_up", "true"),
 					resource.TestCheckResourceAttr(
@@ -130,14 +149,6 @@ resource "openstack_networking_subnet_v2" "subnet" {
 }
 `
 
-const testAccOpenStackNetworkingNetworkV2DataSource_networkExternal = `
-resource "openstack_networking_network_v2" "net" {
-  name = "tf_test_network"
-  admin_state_up = "true"
-  external = "true"
-}
-`
-
 var testAccOpenStackNetworkingNetworkV2DataSource_basic = fmt.Sprintf(`
 %s
 
@@ -162,11 +173,15 @@ data "openstack_networking_network_v2" "net" {
 }
 `, testAccOpenStackNetworkingNetworkV2DataSource_network)
 
-var testAccOpenStackNetworkingNetworkV2DataSource_external = fmt.Sprintf(`
-%s
-
+var testAccOpenStackNetworkingNetworkV2DataSource_externalExplicit = fmt.Sprintf(`
 data "openstack_networking_network_v2" "net" {
-	name = "${openstack_networking_network_v2.net.name}"
+	name = "%s"
 	external = "true"
 }
-`, testAccOpenStackNetworkingNetworkV2DataSource_networkExternal)
+`, OS_POOL_NAME)
+
+var testAccOpenStackNetworkingNetworkV2DataSource_externalImplicit = fmt.Sprintf(`
+data "openstack_networking_network_v2" "net" {
+	name = "%s"
+}
+`, OS_POOL_NAME)


### PR DESCRIPTION
For #382 

#358 added support for querying networks by using the "external"
argument. However, this caused results to either contain only external
networks or only non-external networks.

This fixes the behavior to only query with the "external" argument if
it is explicitly defined in the Terraform configuration.

The introduction of the "external" Gophercloud package extracted the
network results in a new way. This new method did not safely handle
results which did not contain any networks.