### PR TITLE
Image Service v2: Make Properties non-computed

### DIFF
--- a/openstack/import_openstack_images_image_v2_test.go
+++ b/openstack/import_openstack_images_image_v2_test.go
@@ -15,7 +15,7 @@ func TestAccImagesImageV2_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckImagesImageV2Destroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccImagesImageV2_basic,
+				Config: testAccImagesImageV2_basicImport,
 			},
 
 			resource.TestStep{
@@ -28,6 +28,7 @@ func TestAccImagesImageV2_importBasic(t *testing.T) {
 					"image_cache_path",
 					"image_source_url",
 					"verify_checksum",
+					"properties",
 				},
 			},
 		},

--- a/openstack/resource_openstack_images_image_v2.go
+++ b/openstack/resource_openstack_images_image_v2.go
@@ -174,6 +174,10 @@ func resourceImagesImageV2() *schema.Resource {
 			"properties": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
+			},
+
+			"all_properties": &schema.Schema{
+				Type:     schema.TypeMap,
 				Computed: true,
 			},
 		},
@@ -307,18 +311,9 @@ func resourceImagesImageV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("visibility", img.Visibility)
 	d.Set("region", GetRegion(d, config))
 
-	// New versions of OpenStack are setting a property of os_hidden with a
-	// boolean value. This clashes with TypeMap which expects all values to
-	// be a string. For now, we'll filter out all non-string types.
-	properties := make(map[string]string)
-	for key, value := range img.Properties {
-		if v, ok := value.(string); ok {
-			properties[key] = v
-		}
-	}
-
-	if err := d.Set("properties", properties); err != nil {
-		log.Printf("[WARN] unable to set properties for image %s: %s", img.ID, err)
+	allProperties := resourceImagesImageV2ExpandProperties(img.Properties)
+	if err := d.Set("all_properties", allProperties); err != nil {
+		log.Printf("[WARN] unable to set all_properties for image %s: %s", img.ID, err)
 	}
 
 	return nil

--- a/openstack/resource_openstack_images_image_v2_test.go
+++ b/openstack/resource_openstack_images_image_v2_test.go
@@ -33,7 +33,11 @@ func TestAccImagesImageV2_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"openstack_images_image_v2.image_1", "properties.foo", "bar"),
 					resource.TestCheckResourceAttr(
+						"openstack_images_image_v2.image_1", "all_properties.foo", "bar"),
+					resource.TestCheckResourceAttr(
 						"openstack_images_image_v2.image_1", "properties.baz", "foo"),
+					resource.TestCheckResourceAttr(
+						"openstack_images_image_v2.image_1", "all_properties.baz", "foo"),
 				),
 			},
 		},
@@ -282,7 +286,7 @@ func testAccCheckImagesImageV2TagCount(n string, expected int) resource.TestChec
 
 var testAccImagesImageV2_basic = `
   resource "openstack_images_image_v2" "image_1" {
-      name   = "Rancher TerraformAccTest"
+      name = "Rancher TerraformAccTest"
       image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
       container_format = "bare"
       disk_format = "qcow2"
@@ -292,9 +296,17 @@ var testAccImagesImageV2_basic = `
       }
   }`
 
+var testAccImagesImageV2_basicImport = `
+  resource "openstack_images_image_v2" "image_1" {
+      name = "Rancher TerraformAccTest"
+      image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
+      container_format = "bare"
+      disk_format = "qcow2"
+  }`
+
 var testAccImagesImageV2_name_1 = `
   resource "openstack_images_image_v2" "image_1" {
-      name   = "Rancher TerraformAccTest"
+      name = "Rancher TerraformAccTest"
       image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
       container_format = "bare"
       disk_format = "qcow2"
@@ -302,7 +314,7 @@ var testAccImagesImageV2_name_1 = `
 
 var testAccImagesImageV2_name_2 = `
   resource "openstack_images_image_v2" "image_1" {
-      name   = "TerraformAccTest Rancher"
+      name = "TerraformAccTest Rancher"
       image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
       container_format = "bare"
       disk_format = "qcow2"
@@ -310,7 +322,7 @@ var testAccImagesImageV2_name_2 = `
 
 var testAccImagesImageV2_tags_1 = `
   resource "openstack_images_image_v2" "image_1" {
-      name   = "Rancher TerraformAccTest"
+      name = "Rancher TerraformAccTest"
       image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
       container_format = "bare"
       disk_format = "qcow2"
@@ -319,7 +331,7 @@ var testAccImagesImageV2_tags_1 = `
 
 var testAccImagesImageV2_tags_2 = `
   resource "openstack_images_image_v2" "image_1" {
-      name   = "Rancher TerraformAccTest"
+      name = "Rancher TerraformAccTest"
       image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
       container_format = "bare"
       disk_format = "qcow2"
@@ -328,7 +340,7 @@ var testAccImagesImageV2_tags_2 = `
 
 var testAccImagesImageV2_tags_3 = `
   resource "openstack_images_image_v2" "image_1" {
-      name   = "Rancher TerraformAccTest"
+      name = "Rancher TerraformAccTest"
       image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
       container_format = "bare"
       disk_format = "qcow2"
@@ -337,7 +349,7 @@ var testAccImagesImageV2_tags_3 = `
 
 var testAccImagesImageV2_visibility_1 = `
   resource "openstack_images_image_v2" "image_1" {
-      name   = "Rancher TerraformAccTest"
+      name = "Rancher TerraformAccTest"
       image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
       container_format = "bare"
       disk_format = "qcow2"
@@ -346,7 +358,7 @@ var testAccImagesImageV2_visibility_1 = `
 
 var testAccImagesImageV2_visibility_2 = `
   resource "openstack_images_image_v2" "image_1" {
-      name   = "Rancher TerraformAccTest"
+      name = "Rancher TerraformAccTest"
       image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
       container_format = "bare"
       disk_format = "qcow2"
@@ -355,7 +367,7 @@ var testAccImagesImageV2_visibility_2 = `
 
 var testAccImagesImageV2_timeout = `
   resource "openstack_images_image_v2" "image_1" {
-      name   = "Rancher TerraformAccTest"
+      name = "Rancher TerraformAccTest"
       image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
       container_format = "bare"
       disk_format = "qcow2"

--- a/website/docs/r/images_image_v2.html.markdown
+++ b/website/docs/r/images_image_v2.html.markdown
@@ -57,7 +57,9 @@ The following arguments are supported:
 * `name` - (Required) The name of the image.
 
 * `properties` - (Optional) A map of key/value pairs to set freeform
-    information about an image.
+    information about an image. This will not include properties that have
+    been automatically set by the Image service. To see those properties,
+    use the `all_properties` attribute detailed below.
 
 * `protected` - (Optional) If true, image will not be deletable.
    Defaults to false.
@@ -97,6 +99,8 @@ The following attributes are exported:
 * `name` - See Argument Reference above.
 * `owner` - The id of the openstack user who owns the image.
 * `properties` - See Argument Reference above.
+* `all_properties` - All properties of the image, both user-defined
+  and service-defined.
 * `protected` - See Argument Reference above.
 * `region` - See Argument Reference above.
 * `schema` - The path to the JSON-schema that represent


### PR DESCRIPTION
This commit changes the "properties" attribute to no longer be computed.
This is because OpenStack is adding an increasing amount of properties
to the image from the server-side which is causing conflicts with
user-generated properties.

A new attribute called "all_properties" has been added which will contain
all properties, both from the user and from the server.