### PR TITLE
Create an openstack_config data source

### DIFF
--- a/openstack/config.go
+++ b/openstack/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	Username          string
 	UserID            string
 	useOctavia        bool
+	Validate          bool
 
 	OsClient *gophercloud.ProviderClient
 }
@@ -184,7 +185,7 @@ func (c *Config) LoadAndValidate() error {
 	}
 
 	// If using Swift Authentication, there's no need to validate authentication normally.
-	if !c.Swauth {
+	if !c.Swauth && c.Validate {
 		err = openstack.Authenticate(client, *ao)
 		if err != nil {
 			return err

--- a/openstack/data_source_openstack_config.go
+++ b/openstack/data_source_openstack_config.go
@@ -5,9 +5,17 @@ import (
 )
 
 func dataSourceOpenStackConfig() *schema.Resource {
+	providerSchema := getProviderSchema()
+
+	providerSchema["validate"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  "false",
+	}
+
 	return &schema.Resource{
 		Read:   dataSourceOpenStackConfigRead,
-		Schema: getProviderSchema(),
+		Schema: providerSchema,
 	}
 }
 

--- a/openstack/data_source_openstack_config.go
+++ b/openstack/data_source_openstack_config.go
@@ -1,0 +1,24 @@
+package openstack
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceOpenStackConfig() *schema.Resource {
+	return &schema.Resource{
+		Read:   dataSourceOpenStackConfigRead,
+		Schema: getProviderSchema(),
+	}
+}
+
+// dataSourceOpenStackConfigRead performs the endpoint lookup.
+func dataSourceOpenStackConfigRead(d *schema.ResourceData, meta interface{}) error {
+	config, err := configureProvider(d)
+	if err != nil {
+		return err
+	}
+
+	(config.(*Config)).LoadAndValidate()
+	d.SetId(d.Get("auth_url").(string))
+	return nil
+}

--- a/openstack/data_source_openstack_config_test.go
+++ b/openstack/data_source_openstack_config_test.go
@@ -1,0 +1,56 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccOpenStackOpenStackConfigDataSource_basic(t *testing.T) {
+	authURL := "http://10.0.0.3:5000"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOpenStackOpenStackConfigDataSource_basic(authURL),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOpenStackConfigDataSourceID("data.openstack_config.config_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_config.config_1", "auth_url", authURL),
+					resource.TestCheckResourceAttr(
+						"data.openstack_config.config_1", "swauth", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckOpenStackConfigDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find config data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Endpoint data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccOpenStackOpenStackConfigDataSource_basic(authURL string) string {
+	return fmt.Sprintf(`
+	data "openstack_config" "config_1" {
+      auth_url = "%s"
+	}
+`, authURL)
+}

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -351,7 +351,13 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		Username:          d.Get("user_name").(string),
 		UserID:            d.Get("user_id").(string),
 		useOctavia:        d.Get("use_octavia").(bool),
-		Validate:          d.Get("validate").(bool),
+		Validate:          true,
+	}
+
+	if v := d.Get("validate"); v != nil {
+		if validate, ok := v.(bool); ok {
+			config.Validate = validate
+		}
 	}
 
 	v, ok := d.GetOkExists("insecure")

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -9,182 +9,187 @@ import (
 // This is a global MutexKV for use within this plugin.
 var osMutexKV = mutexkv.NewMutexKV()
 
+func getProviderSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"auth_url": &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_AUTH_URL", ""),
+			Description: descriptions["auth_url"],
+		},
+
+		"region": &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: descriptions["region"],
+			DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+		},
+
+		"user_name": &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_USERNAME", ""),
+			Description: descriptions["user_name"],
+		},
+
+		"user_id": &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_USER_ID", ""),
+			Description: descriptions["user_name"],
+		},
+
+		"tenant_id": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+			DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+				"OS_TENANT_ID",
+				"OS_PROJECT_ID",
+			}, ""),
+			Description: descriptions["tenant_id"],
+		},
+
+		"tenant_name": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+			DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+				"OS_TENANT_NAME",
+				"OS_PROJECT_NAME",
+			}, ""),
+			Description: descriptions["tenant_name"],
+		},
+
+		"password": &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			Sensitive:   true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_PASSWORD", ""),
+			Description: descriptions["password"],
+		},
+
+		"token": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+			DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+				"OS_TOKEN",
+				"OS_AUTH_TOKEN",
+			}, ""),
+			Description: descriptions["token"],
+		},
+
+		"user_domain_name": &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_USER_DOMAIN_NAME", ""),
+			Description: descriptions["user_domain_name"],
+		},
+
+		"user_domain_id": &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_USER_DOMAIN_ID", ""),
+			Description: descriptions["user_domain_id"],
+		},
+
+		"project_domain_name": &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_PROJECT_DOMAIN_NAME", ""),
+			Description: descriptions["project_domain_name"],
+		},
+
+		"project_domain_id": &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_PROJECT_DOMAIN_ID", ""),
+			Description: descriptions["project_domain_id"],
+		},
+
+		"domain_id": &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_DOMAIN_ID", ""),
+			Description: descriptions["domain_id"],
+		},
+
+		"domain_name": &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_DOMAIN_NAME", ""),
+			Description: descriptions["domain_name"],
+		},
+
+		"default_domain": &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_DEFAULT_DOMAIN", "default"),
+			Description: descriptions["default_domain"],
+		},
+
+		"insecure": &schema.Schema{
+			Type:        schema.TypeBool,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_INSECURE", nil),
+			Description: descriptions["insecure"],
+		},
+
+		"endpoint_type": &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_ENDPOINT_TYPE", ""),
+		},
+
+		"cacert_file": &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_CACERT", ""),
+			Description: descriptions["cacert_file"],
+		},
+
+		"cert": &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_CERT", ""),
+			Description: descriptions["cert"],
+		},
+
+		"key": &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_KEY", ""),
+			Description: descriptions["key"],
+		},
+
+		"swauth": &schema.Schema{
+			Type:        schema.TypeBool,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_SWAUTH", ""),
+			Description: descriptions["swauth"],
+		},
+
+		"use_octavia": &schema.Schema{
+			Type:        schema.TypeBool,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_USE_OCTAVIA", ""),
+			Description: descriptions["use_octavia"],
+		},
+
+		"cloud": &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OS_CLOUD", ""),
+			Description: descriptions["cloud"],
+		},
+	}
+}
+
 // Provider returns a schema.Provider for OpenStack.
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
-		Schema: map[string]*schema.Schema{
-			"auth_url": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_AUTH_URL", ""),
-				Description: descriptions["auth_url"],
-			},
-
-			"region": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: descriptions["region"],
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
-			},
-
-			"user_name": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_USERNAME", ""),
-				Description: descriptions["user_name"],
-			},
-
-			"user_id": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_USER_ID", ""),
-				Description: descriptions["user_name"],
-			},
-
-			"tenant_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-					"OS_TENANT_ID",
-					"OS_PROJECT_ID",
-				}, ""),
-				Description: descriptions["tenant_id"],
-			},
-
-			"tenant_name": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-					"OS_TENANT_NAME",
-					"OS_PROJECT_NAME",
-				}, ""),
-				Description: descriptions["tenant_name"],
-			},
-
-			"password": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Sensitive:   true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_PASSWORD", ""),
-				Description: descriptions["password"],
-			},
-
-			"token": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-					"OS_TOKEN",
-					"OS_AUTH_TOKEN",
-				}, ""),
-				Description: descriptions["token"],
-			},
-
-			"user_domain_name": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_USER_DOMAIN_NAME", ""),
-				Description: descriptions["user_domain_name"],
-			},
-
-			"user_domain_id": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_USER_DOMAIN_ID", ""),
-				Description: descriptions["user_domain_id"],
-			},
-
-			"project_domain_name": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_PROJECT_DOMAIN_NAME", ""),
-				Description: descriptions["project_domain_name"],
-			},
-
-			"project_domain_id": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_PROJECT_DOMAIN_ID", ""),
-				Description: descriptions["project_domain_id"],
-			},
-
-			"domain_id": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_DOMAIN_ID", ""),
-				Description: descriptions["domain_id"],
-			},
-
-			"domain_name": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_DOMAIN_NAME", ""),
-				Description: descriptions["domain_name"],
-			},
-
-			"default_domain": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_DEFAULT_DOMAIN", "default"),
-				Description: descriptions["default_domain"],
-			},
-
-			"insecure": &schema.Schema{
-				Type:        schema.TypeBool,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_INSECURE", nil),
-				Description: descriptions["insecure"],
-			},
-
-			"endpoint_type": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_ENDPOINT_TYPE", ""),
-			},
-
-			"cacert_file": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_CACERT", ""),
-				Description: descriptions["cacert_file"],
-			},
-
-			"cert": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_CERT", ""),
-				Description: descriptions["cert"],
-			},
-
-			"key": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_KEY", ""),
-				Description: descriptions["key"],
-			},
-
-			"swauth": &schema.Schema{
-				Type:        schema.TypeBool,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_SWAUTH", ""),
-				Description: descriptions["swauth"],
-			},
-
-			"use_octavia": &schema.Schema{
-				Type:        schema.TypeBool,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_USE_OCTAVIA", ""),
-				Description: descriptions["use_octavia"],
-			},
-
-			"cloud": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_CLOUD", ""),
-				Description: descriptions["cloud"],
-			},
-		},
+		Schema: getProviderSchema(),
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"openstack_config":                   dataSourceOpenStackConfig(),
 			"openstack_compute_flavor_v2":        dataSourceComputeFlavorV2(),
 			"openstack_compute_keypair_v2":       dataSourceComputeKeypairV2(),
 			"openstack_dns_zone_v2":              dataSourceDNSZoneV2(),
@@ -317,6 +322,8 @@ func init() {
 			"service (Octavia) instead of the Networking service (Neutron).",
 
 		"cloud": "An entry in a `clouds.yaml` file to use.",
+
+		"validate": "Whether to validate the authentication configs on every provider instantiation",
 	}
 }
 
@@ -344,6 +351,7 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		Username:          d.Get("user_name").(string),
 		UserID:            d.Get("user_id").(string),
 		useOctavia:        d.Get("use_octavia").(bool),
+		Validate:          d.Get("validate").(bool),
 	}
 
 	v, ok := d.GetOkExists("insecure")


### PR DESCRIPTION
This data source loads an openstack config to memory in the format
expected by the provider. The use case for this is reading, creating
and uploading configs to nodes that need to access a specific OpenStack
cloud.

The data source takes as input the same schema used for the OpenStack
provider and generates a map with all the required configs to
authenticate to an OpenStack cloud. From this map, it's possible to
render a new config and upload it to the final destination.

In addition, this patch adds the ability to disable the
`Authentication` validation performed every time the provider is
instantiated. This way we'd be able to check the provider's configs
just once in an entire workflow execution. This also allows for testing
the new config data source without having to have an actual cloud in
the background. Lazy validation, FTW.

We could also remove validation entirely and let gophercloud error out
at the first interaction with the openstack cloud.