### PR TITLE
Add firewall policy data source

### DIFF
--- a/openstack/data_source_openstack_fw_policy_v1.go
+++ b/openstack/data_source_openstack_fw_policy_v1.go
@@ -1,0 +1,100 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceFWPolicyV1() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceFWPolicyV1Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"policy_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tenant_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"audited": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"shared": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"rules": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceFWPolicyV1Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+
+	listOpts := policies.ListOpts{
+		ID:       d.Get("policy_id").(string),
+		Name:     d.Get("name").(string),
+		TenantID: d.Get("tenant_id").(string),
+	}
+
+	pages, err := policies.List(networkingClient, listOpts).AllPages()
+	if err != nil {
+		return err
+	}
+
+	allFWPolicies, err := policies.ExtractPolicies(pages)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve firewall policies: %s", err)
+	}
+
+	if len(allFWPolicies) < 1 {
+		return fmt.Errorf("No firewall policies found with name: %s", d.Get("name"))
+	}
+
+	if len(allFWPolicies) > 1 {
+		return fmt.Errorf("More than one firewall policies found with name: %s", d.Get("name"))
+	}
+
+	policy := allFWPolicies[0]
+
+	log.Printf("[DEBUG] Retrieved firewall policies %s: %+v", policy.ID, policy)
+	d.SetId(policy.ID)
+
+	d.Set("name", policy.Name)
+	d.Set("tenant_id", policy.TenantID)
+	d.Set("description", policy.Description)
+	d.Set("audited", policy.Audited)
+	d.Set("shared", policy.Shared)
+	d.Set("rules", policy.Rules)
+	d.Set("region", GetRegion(d, config))
+
+	return nil
+}

--- a/openstack/data_source_openstack_fw_policy_v1.go
+++ b/openstack/data_source_openstack_fw_policy_v1.go
@@ -35,20 +35,19 @@ func dataSourceFWPolicyV1() *schema.Resource {
 			},
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
-				Optional: true,
+				Computed: true,
 			},
 			"audited": &schema.Schema{
 				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+				Computed: true,
 			},
 			"shared": &schema.Schema{
 				Type:     schema.TypeBool,
-				Optional: true,
+				Computed: true,
 			},
 			"rules": &schema.Schema{
 				Type:     schema.TypeList,
-				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},

--- a/openstack/data_source_openstack_fw_policy_v1_test.go
+++ b/openstack/data_source_openstack_fw_policy_v1_test.go
@@ -1,0 +1,86 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccOpenStackNetworkingFWPolicyV1DataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOpenStackNetworkingFWPolicyV1DataSource_group,
+			},
+			resource.TestStep{
+				Config: testAccOpenStackNetworkingFWPolicyV1DataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingFWPolicyV1DataSourceID("data.openstack_fw_policy_v1.policy_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_fw_policy_v1.policy_1", "name", "policy_1"),
+				),
+			},
+		},
+	})
+}
+func TestAccOpenStackNetworkingFWPolicyV1DataSource_FWPolicyID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOpenStackNetworkingFWPolicyV1DataSource_group,
+			},
+			resource.TestStep{
+				Config: testAccOpenStackNetworkingFWPolicyV1DataSource_policyID,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingFWPolicyV1DataSourceID("data.openstack_fw_policy_v1.policy_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_fw_policy_v1.policy_1", "name", "policy_1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckNetworkingFWPolicyV1DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find firewall policy data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("firewall policy data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccOpenStackNetworkingFWPolicyV1DataSource_group = `
+resource "openstack_fw_policy_v1" "policy_1" {
+        name        = "policy_1"
+	description = "My firewall policy"
+}
+`
+
+var testAccOpenStackNetworkingFWPolicyV1DataSource_basic = fmt.Sprintf(`
+%s
+
+data "openstack_fw_policy_v1" "policy_1" {
+	name = "${openstack_fw_policy_v1.policy_1.name}"
+}
+`, testAccOpenStackNetworkingFWPolicyV1DataSource_group)
+
+var testAccOpenStackNetworkingFWPolicyV1DataSource_policyID = fmt.Sprintf(`
+%s
+
+data "openstack_fw_policy_v1" "policy_1" {
+	policy_id = "${openstack_fw_policy_v1.policy_1.id}"
+}
+`, testAccOpenStackNetworkingFWPolicyV1DataSource_group)

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -188,6 +188,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_compute_flavor_v2":        dataSourceComputeFlavorV2(),
 			"openstack_compute_keypair_v2":       dataSourceComputeKeypairV2(),
 			"openstack_dns_zone_v2":              dataSourceDNSZoneV2(),
+			"openstack_fw_policy_v1":             dataSourceFWPolicyV1(),
 			"openstack_identity_role_v3":         dataSourceIdentityRoleV3(),
 			"openstack_identity_project_v3":      dataSourceIdentityProjectV3(),
 			"openstack_identity_user_v3":         dataSourceIdentityUserV3(),

--- a/website/docs/d/fw_policy_v1.html.markdown
+++ b/website/docs/d/fw_policy_v1.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_fw_policy_v1"
+sidebar_current: "docs-openstack-datasource-fw-policy-v1"
+description: |-
+  Get information on an OpenStack Firewall Policy.
+---
+
+# openstack\_fw\_policy_v1
+
+Use this data source to get firewall policy information^ of an available OpenStack firewall policy.
+
+## Example Usage
+
+```hcl
+data "openstack_fw_policy_v1" "policy" {
+  name = "tf_test_policy"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional) The region in which to obtain the V2 Neutron client.
+  A Neutron client is needed to retrieve firewall policy ids. If omitted, the
+  `region` argument of the provider is used.
+
+* `policy_id` - (Optional) The ID of the firewall policy.
+
+* `name` - (Optional) The name of the firewall policy.
+
+* `tenant_id` - (Optional) The owner of the firewall policy.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `policy_id` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `tenant_id` - See Argument Reference above.
+* `description` - The description of the firewall policy.
+* `audited` - The audit status of the firewall policy.
+* `shared` - The sharing status of the firewall policy.
+* `rules` - The array of one or more firewall rules that comprise the policy.

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -22,6 +22,9 @@
             <li<%= sidebar_current("docs-openstack-datasource-dns-zone-v2") %>>
               <a href="/docs/providers/openstack/d/dns_zone_v2.html">openstack_dns_zone_v2</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-datasource-fw-policy-v1") %>>
+              <a href="/docs/providers/openstack/d/fw_policy_v1.html">openstack_dns_zone_v2</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-datasource-identity-auth-scope-v3") %>>
               <a href="/docs/providers/openstack/d/identity_auth_scope_v3.html">openstack_identity_auth_scope_v3</a>
             </li>

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -23,7 +23,7 @@
               <a href="/docs/providers/openstack/d/dns_zone_v2.html">openstack_dns_zone_v2</a>
             </li>
             <li<%= sidebar_current("docs-openstack-datasource-fw-policy-v1") %>>
-              <a href="/docs/providers/openstack/d/fw_policy_v1.html">openstack_dns_zone_v2</a>
+              <a href="/docs/providers/openstack/d/fw_policy_v1.html">openstack_fw_policy_v1</a>
             </li>
             <li<%= sidebar_current("docs-openstack-datasource-identity-auth-scope-v3") %>>
               <a href="/docs/providers/openstack/d/identity_auth_scope_v3.html">openstack_identity_auth_scope_v3</a>


### PR DESCRIPTION
This commit adds a data source for `openstack_fw_policy_v1` resources.
This is useful to refer to a policy ID on creation of a `openstack_fw_firewall_v1 `.

