### PR TITLE
ContainerInfraV1: add Cluster template resource

### DIFF
--- a/openstack/config.go
+++ b/openstack/config.go
@@ -292,6 +292,13 @@ func (c *Config) databaseV1Client(region string) (*gophercloud.ServiceClient, er
 	})
 }
 
+func (c *Config) containerInfraV1Client(region string) (*gophercloud.ServiceClient, error) {
+	return openstack.NewContainerInfraV1(c.OsClient, gophercloud.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getEndpointType(),
+	})
+}
+
 func (c *Config) getEndpointType() gophercloud.Availability {
 	if c.EndpointType == "internal" || c.EndpointType == "internalURL" {
 		return gophercloud.AvailabilityInternal

--- a/openstack/import_openstack_containerinfra_clustertemplate_v1_test.go
+++ b/openstack/import_openstack_containerinfra_clustertemplate_v1_test.go
@@ -1,0 +1,32 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccContainerInfraV1ClusterTemplateImportBasic(t *testing.T) {
+	clusterTemplateName := acctest.RandomWithPrefix("tf-acc-clustertemplate")
+	imageName := acctest.RandomWithPrefix("tf-acc-image")
+	resourceName := fmt.Sprintf("openstack_containerinfra_clustertemplate_v1.%s", clusterTemplateName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerInfraV1ClusterTemplateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainerInfraV1ClusterTemplateBasic(clusterTemplateName, imageName),
+			},
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"image"},
+			},
+		},
+	})
+}

--- a/openstack/import_openstack_containerinfra_clustertemplate_v1_test.go
+++ b/openstack/import_openstack_containerinfra_clustertemplate_v1_test.go
@@ -14,7 +14,7 @@ func TestAccContainerInfraV1ClusterTemplateImportBasic(t *testing.T) {
 	resourceName := fmt.Sprintf("openstack_containerinfra_clustertemplate_v1.%s", clusterTemplateName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckContainerInfra(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckContainerInfraV1ClusterTemplateDestroy,
 		Steps: []resource.TestStep{

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -218,6 +218,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_compute_floatingip_v2":              resourceComputeFloatingIPV2(),
 			"openstack_compute_floatingip_associate_v2":    resourceComputeFloatingIPAssociateV2(),
 			"openstack_compute_volume_attach_v2":           resourceComputeVolumeAttachV2(),
+			"openstack_containerinfra_clustertemplate_v1":  resourceContainerInfraClusterTemplateV1(),
 			"openstack_db_instance_v1":                     resourceDatabaseInstanceV1(),
 			"openstack_db_user_v1":                         resourceDatabaseUserV1(),
 			"openstack_db_configuration_v1":                resourceDatabaseConfigurationV1(),

--- a/openstack/provider_test.go
+++ b/openstack/provider_test.go
@@ -13,24 +13,25 @@ import (
 )
 
 var (
-	OS_DB_ENVIRONMENT         = os.Getenv("OS_DB_ENVIRONMENT")
-	OS_DB_DATASTORE_VERSION   = os.Getenv("OS_DB_DATASTORE_VERSION")
-	OS_DB_DATASTORE_TYPE      = os.Getenv("OS_DB_DATASTORE_TYPE")
-	OS_DEPRECATED_ENVIRONMENT = os.Getenv("OS_DEPRECATED_ENVIRONMENT")
-	OS_DNS_ENVIRONMENT        = os.Getenv("OS_DNS_ENVIRONMENT")
-	OS_EXTGW_ID               = os.Getenv("OS_EXTGW_ID")
-	OS_FLAVOR_ID              = os.Getenv("OS_FLAVOR_ID")
-	OS_FLAVOR_NAME            = os.Getenv("OS_FLAVOR_NAME")
-	OS_IMAGE_ID               = os.Getenv("OS_IMAGE_ID")
-	OS_IMAGE_NAME             = os.Getenv("OS_IMAGE_NAME")
-	OS_NETWORK_ID             = os.Getenv("OS_NETWORK_ID")
-	OS_POOL_NAME              = os.Getenv("OS_POOL_NAME")
-	OS_REGION_NAME            = os.Getenv("OS_REGION_NAME")
-	OS_SWIFT_ENVIRONMENT      = os.Getenv("OS_SWIFT_ENVIRONMENT")
-	OS_LB_ENVIRONMENT         = os.Getenv("OS_LB_ENVIRONMENT")
-	OS_FW_ENVIRONMENT         = os.Getenv("OS_FW_ENVIRONMENT")
-	OS_VPN_ENVIRONMENT        = os.Getenv("OS_VPN_ENVIRONMENT")
-	OS_USE_OCTAVIA            = os.Getenv("OS_USE_OCTAVIA")
+	OS_DB_ENVIRONMENT              = os.Getenv("OS_DB_ENVIRONMENT")
+	OS_DB_DATASTORE_VERSION        = os.Getenv("OS_DB_DATASTORE_VERSION")
+	OS_DB_DATASTORE_TYPE           = os.Getenv("OS_DB_DATASTORE_TYPE")
+	OS_DEPRECATED_ENVIRONMENT      = os.Getenv("OS_DEPRECATED_ENVIRONMENT")
+	OS_DNS_ENVIRONMENT             = os.Getenv("OS_DNS_ENVIRONMENT")
+	OS_EXTGW_ID                    = os.Getenv("OS_EXTGW_ID")
+	OS_FLAVOR_ID                   = os.Getenv("OS_FLAVOR_ID")
+	OS_FLAVOR_NAME                 = os.Getenv("OS_FLAVOR_NAME")
+	OS_IMAGE_ID                    = os.Getenv("OS_IMAGE_ID")
+	OS_IMAGE_NAME                  = os.Getenv("OS_IMAGE_NAME")
+	OS_NETWORK_ID                  = os.Getenv("OS_NETWORK_ID")
+	OS_POOL_NAME                   = os.Getenv("OS_POOL_NAME")
+	OS_REGION_NAME                 = os.Getenv("OS_REGION_NAME")
+	OS_SWIFT_ENVIRONMENT           = os.Getenv("OS_SWIFT_ENVIRONMENT")
+	OS_LB_ENVIRONMENT              = os.Getenv("OS_LB_ENVIRONMENT")
+	OS_FW_ENVIRONMENT              = os.Getenv("OS_FW_ENVIRONMENT")
+	OS_VPN_ENVIRONMENT             = os.Getenv("OS_VPN_ENVIRONMENT")
+	OS_USE_OCTAVIA                 = os.Getenv("OS_USE_OCTAVIA")
+	OS_CONTAINER_INFRA_ENVIRONMENT = os.Getenv("OS_CONTAINER_INFRA_ENVIRONMENT")
 )
 
 var testAccProviders map[string]terraform.ResourceProvider
@@ -132,6 +133,14 @@ func testAccPreCheckVPN(t *testing.T) {
 
 	if OS_VPN_ENVIRONMENT == "" {
 		t.Skip("This environment does not support VPN tests")
+	}
+}
+
+func testAccPreCheckContainerInfra(t *testing.T) {
+	testAccPreCheckRequiredEnvVars(t)
+
+	if OS_CONTAINER_INFRA_ENVIRONMENT == "" {
+		t.Skip("This environment does not support Container Infra tests")
 	}
 }
 

--- a/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
+++ b/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
@@ -313,8 +313,13 @@ func resourceContainerInfraClusterTemplateV1Read(d *schema.ResourceData, meta in
 	d.Set("name", s.Name)
 	d.Set("project_id", s.ProjectID)
 	d.Set("user_id", s.UserID)
-	d.Set("created_at", s.CreatedAt)
-	d.Set("updated_at", s.UpdatedAt)
+
+	if err := d.Set("created_at", s.CreatedAt); err != nil {
+		log.Printf("[DEBUG] created_at: %s", err)
+	}
+	if err := d.Set("updated_at", s.CreatedAt); err != nil {
+		log.Printf("[DEBUG] updated_at: %s", err)
+	}
 
 	return nil
 }

--- a/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
+++ b/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
@@ -312,6 +312,7 @@ func resourceContainerInfraClusterTemplateV1Read(d *schema.ResourceData, meta in
 
 	log.Printf("[DEBUG] Retrieved Clustertemplate %s: %#v", d.Id(), s)
 
+	d.Set("apiserver_port", s.APIServerPort)
 	d.Set("coe", s.COE)
 	d.Set("cluster_distro", s.ClusterDistro)
 	d.Set("dns_nameserver", s.DNSNameServer)
@@ -344,15 +345,6 @@ func resourceContainerInfraClusterTemplateV1Read(d *schema.ResourceData, meta in
 	d.Set("user_id", s.UserID)
 	d.Set("created_at", s.CreatedAt)
 	d.Set("updated_at", s.UpdatedAt)
-
-	// Set apiserver_port.
-	if s.APIServerPort != "" {
-		apiServerPort, err := strconv.Atoi(s.APIServerPort)
-		if err != nil {
-			return fmt.Errorf("Error setting Cluster template API server port: %v", s.APIServerPort)
-		}
-		d.Set("apiserver_port", apiServerPort)
-	}
 
 	return nil
 }
@@ -474,8 +466,8 @@ func resourceContainerInfraClusterTemplateV1Delete(d *schema.ResourceData, meta 
 
 func validateClusterTemplateAPIServerPortV1(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(int)
-	if value < 1024 {
-		err := fmt.Errorf("%s should be greater or equal to 1024", k)
+	if value < 1024 || value > 65535 {
+		err := fmt.Errorf("%s should be between 1024 and 65535", k)
 		errors = append(errors, err)
 	}
 	return

--- a/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
+++ b/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
@@ -152,25 +152,6 @@ func resourceContainerInfraClusterTemplateV1() *schema.Resource {
 				Optional: true,
 				ForceNew: false,
 			},
-			"links": &schema.Schema{
-				Type: schema.TypeList,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"href": &schema.Schema{
-							Type:     schema.TypeString,
-							ForceNew: false,
-							Computed: true,
-						},
-						"rel": &schema.Schema{
-							Type:     schema.TypeString,
-							ForceNew: false,
-							Computed: true,
-						},
-					},
-				},
-				ForceNew: false,
-				Computed: true,
-			},
 			"master_lb_enabled": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -311,7 +292,6 @@ func resourceContainerInfraClusterTemplateV1Read(d *schema.ResourceData, meta in
 	d.Set("insecure_registry", s.InsecureRegistry)
 	d.Set("keypair_id", s.KeyPairID)
 	d.Set("labels", s.Labels)
-	d.Set("links", resourceLinks(s.Links))
 	d.Set("master_lb_enabled", s.MasterLBEnabled)
 	d.Set("network_driver", s.NetworkDriver)
 	d.Set("no_proxy", s.NoProxy)

--- a/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
+++ b/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
@@ -1,0 +1,505 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/images"
+	"github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceContainerInfraClusterTemplateV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceContainerInfraClusterTemplateV1Create,
+		Read:   resourceContainerInfraClusterTemplateV1Read,
+		// Update: resourceContainerInfraClusterTemplateV1Update,
+		Delete: resourceContainerInfraClusterTemplateV1Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"project_id": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Computed: true,
+			},
+			"user_id": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Computed: true,
+			},
+			"created_at": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: false,
+				Computed: true,
+			},
+			"updated_at": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: false,
+				Computed: true,
+			},
+			"apiserver_port": &schema.Schema{
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     false,
+				Computed:     true,
+				ValidateFunc: validateClusterTemplateAPIServerPortV1,
+			},
+			"coe": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"cluster_distro": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: false,
+				Computed: true,
+			},
+			"dns_nameserver": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"docker_storage_driver": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"docker_volume_size": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"external_network_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"fixed_network": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"fixed_subnet": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"flavor_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    false,
+				Computed:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_FLAVOR_ID", nil),
+			},
+			"flavor_name": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    false,
+				Computed:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_FLAVOR_NAME", nil),
+			},
+			"master_flavor_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    false,
+				Computed:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_FLAVOR_ID", nil),
+			},
+			"master_flavor_name": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    false,
+				Computed:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_FLAVOR_NAME", nil),
+			},
+			"floating_ip_enabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"http_proxy": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"https_proxy": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"image_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    false,
+				Computed:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_CONTAINERINFRA_IMAGE_ID", nil),
+			},
+			"image_name": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    false,
+				Computed:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_CONTAINERINFRA_IMAGE_NAME", nil),
+			},
+			"insecure_registry": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"keypair_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"labels": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"links": &schema.Schema{
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"href": &schema.Schema{
+							Type:     schema.TypeString,
+							ForceNew: false,
+							Computed: true,
+						},
+						"rel": &schema.Schema{
+							Type:     schema.TypeString,
+							ForceNew: false,
+							Computed: true,
+						},
+					},
+				},
+				ForceNew: false,
+				Computed: true,
+			},
+			"master_lb_enabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"network_driver": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"no_proxy": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"public": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"registry_enabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"server_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"tls_disabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"volume_driver": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceContainerInfraClusterTemplateV1Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+	containerInfraClient, err := config.containerInfraV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack container infra client: %s", err)
+	}
+
+	// Get imageID using following rules:
+	//  - if an image_id was specified, use it
+	//  - if an image_name was specified, look up the ID, report if error
+	imageID, err := getContainerInfraImageID(computeClient, d)
+	if err != nil {
+		return err
+	}
+
+	// Get boolean parameters that will be passed by reference.
+	floatingIPEnabled := d.Get("floating_ip_enabled").(bool)
+	masterLBEnabled := d.Get("master_lb_enabled").(bool)
+	public := d.Get("public").(bool)
+	registryEnabled := d.Get("registry_enabled").(bool)
+	tlsDisabled := d.Get("tls_disabled").(bool)
+
+	createOpts := clustertemplates.CreateOpts{
+		COE:                 d.Get("coe").(string),
+		DNSNameServer:       d.Get("dns_nameserver").(string),
+		DockerStorageDriver: d.Get("docker_storage_driver").(string),
+		ExternalNetworkID:   d.Get("external_network_id").(string),
+		FixedNetwork:        d.Get("fixed_network").(string),
+		FixedSubnet:         d.Get("fixed_subnet").(string),
+		FloatingIPEnabled:   &floatingIPEnabled,
+		HTTPProxy:           d.Get("http_proxy").(string),
+		HTTPSProxy:          d.Get("https_proxy").(string),
+		ImageID:             imageID,
+		InsecureRegistry:    d.Get("insecure_registry").(string),
+		KeyPairID:           d.Get("keypair_id").(string),
+		Labels:              resourceClusterTemplateLabelsV1(d),
+		MasterLBEnabled:     &masterLBEnabled,
+		Name:                d.Get("name").(string),
+		NetworkDriver:       d.Get("network_driver").(string),
+		NoProxy:             d.Get("no_proxy").(string),
+		Public:              &public,
+		RegistryEnabled:     &registryEnabled,
+		ServerType:          d.Get("server_type").(string),
+		TLSDisabled:         &tlsDisabled,
+		VolumeDriver:        d.Get("volume_driver").(string),
+	}
+
+	// Get nodes and masters flavors using following rules:
+	//  - if a flavor_id was specified, use it for regular nodes
+	//  - if a flavor_name was specified, look up the ID, report if error
+	//  - if a master_flavor_id was specified, use it for regular nodes
+	//  - if a master_flavor_name was specified, look up the ID, report if error
+	flavorID, err := getContainerInfraFlavorID(computeClient, d, "")
+	if err != nil {
+		return err
+	}
+	if flavorID != "" {
+		createOpts.FlavorID = flavorID
+	}
+	masterFlavorID, err := getContainerInfraFlavorID(computeClient, d, "master")
+	if err != nil {
+		return err
+	}
+	if masterFlavorID != "" {
+		createOpts.MasterFlavorID = masterFlavorID
+	}
+
+	// Set int parameters that will be passed by reference.
+	apiServerPort := d.Get("apiserver_port").(int)
+	if apiServerPort > 0 {
+		createOpts.APIServerPort = &apiServerPort
+	}
+	dockerVolumeSize := d.Get("docker_volume_size").(int)
+	if dockerVolumeSize > 0 {
+		createOpts.DockerVolumeSize = &dockerVolumeSize
+	}
+
+	s, err := clustertemplates.Create(containerInfraClient, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack container infra Cluster template: %s", err)
+	}
+
+	d.SetId(s.UUID)
+
+	log.Printf("[DEBUG] Created Cluster template %s: %#v", s.UUID, s)
+	return resourceContainerInfraClusterTemplateV1Read(d, meta)
+}
+
+func resourceContainerInfraClusterTemplateV1Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+	containerInfraClient, err := config.containerInfraV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack container infra client: %s", err)
+	}
+
+	s, err := clustertemplates.Get(containerInfraClient, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "clustertemplate")
+	}
+
+	log.Printf("[DEBUG] Retrieved Clustertemplate %s: %#v", d.Id(), s)
+
+	d.Set("coe", s.COE)
+	d.Set("cluster_distro", s.ClusterDistro)
+	d.Set("dns_nameserver", s.DNSNameServer)
+	d.Set("docker_storage_driver", s.DockerStorageDriver)
+	d.Set("docker_volume_size", s.DockerVolumeSize)
+	d.Set("external_network_id", s.ExternalNetworkID)
+	d.Set("fixed_network", s.FixedNetwork)
+	d.Set("fixed_subnet", s.FixedSubnet)
+	d.Set("flavor_id", s.FlavorID)
+	d.Set("master_flavor_id", s.MasterFlavorID)
+	d.Set("floating_ip_enabled", s.FloatingIPEnabled)
+	d.Set("http_proxy", s.HTTPProxy)
+	d.Set("https_proxy", s.HTTPSProxy)
+	d.Set("image_id", s.ImageID)
+	d.Set("insecure_registry", s.InsecureRegistry)
+	d.Set("keypair_id", s.KeyPairID)
+	d.Set("labels", s.Labels)
+	d.Set("links", resourceLinks(s.Links))
+	d.Set("master_lb_enabled", s.MasterLBEnabled)
+	d.Set("network_driver", s.NetworkDriver)
+	d.Set("no_proxy", s.NoProxy)
+	d.Set("public", s.Public)
+	d.Set("registry_enabled", s.RegistryEnabled)
+	d.Set("server_type", s.ServerType)
+	d.Set("tls_disabled", s.TLSDisabled)
+	d.Set("volume_driver", s.VolumeDriver)
+	d.Set("region", GetRegion(d, config))
+	d.Set("name", s.Name)
+	d.Set("project_id", s.ProjectID)
+	d.Set("user_id", s.UserID)
+	d.Set("created_at", s.CreatedAt)
+	d.Set("updated_at", s.UpdatedAt)
+
+	// Set flavors names.
+	if s.FlavorID != "" {
+		flavor, err := flavors.Get(computeClient, s.FlavorID).Extract()
+		if err != nil {
+			return err
+		}
+		d.Set("flavor_name", flavor.Name)
+	}
+	if s.MasterFlavorID != "" {
+		masterFlavor, err := flavors.Get(computeClient, s.MasterFlavorID).Extract()
+		if err != nil {
+			return err
+		}
+		d.Set("master_flavor_name", masterFlavor.Name)
+	}
+
+	// Set apiserver_port.
+	if s.APIServerPort != "" {
+		apiServerPort, err := strconv.Atoi(s.APIServerPort)
+		if err != nil {
+			return fmt.Errorf("Error setting Cluster template API server port: %v", s.APIServerPort)
+		}
+		d.Set("apiserver_port", apiServerPort)
+	}
+
+	return nil
+}
+
+// func resourceContainerInfraClusterTemplateV1Update(d *schema.ResourceData, meta interface{}) error {
+//
+// }
+
+func resourceContainerInfraClusterTemplateV1Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	containerInfraClient, err := config.containerInfraV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack container infra client: %s", err)
+	}
+
+	if err := clustertemplates.Delete(containerInfraClient, d.Id()).ExtractErr(); err != nil {
+		return fmt.Errorf("Error deleting Cluster template: %v", err)
+	}
+
+	return nil
+}
+
+func validateClusterTemplateAPIServerPortV1(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(int)
+	if value < 1024 {
+		err := fmt.Errorf("%s should be greater or equal to 1024", k)
+		errors = append(errors, err)
+	}
+	return
+}
+
+func getContainerInfraImageID(computeClient *gophercloud.ServiceClient, d *schema.ResourceData) (string, error) {
+	if imageID := d.Get("image_id").(string); imageID != "" {
+		return imageID, nil
+	}
+
+	if imageName := d.Get("image_name").(string); imageName != "" {
+		imageID, err := images.IDFromName(computeClient, imageName)
+		if err != nil {
+			return "", err
+		}
+		return imageID, nil
+	}
+
+	return "", fmt.Errorf("Neither an image_id or image_name were able to be determined.")
+}
+
+func getContainerInfraFlavorID(client *gophercloud.ServiceClient, d *schema.ResourceData, prefix string) (string, error) {
+	attrID := "flavor_id"
+	attrName := "flavor_name"
+	if prefix != "" {
+		attrID = strings.Join([]string{prefix, attrID}, "_")
+		attrName = strings.Join([]string{prefix, attrName}, "_")
+	}
+
+	flavorID := d.Get("flavor_id").(string)
+	if flavorID != "" {
+		return flavorID, nil
+	}
+
+	flavorName := d.Get("flavor_name").(string)
+	if flavorName == "" {
+		return "", nil
+	}
+
+	return flavors.IDFromName(client, flavorName)
+}
+
+func resourceClusterTemplateLabelsV1(d *schema.ResourceData) map[string]string {
+	m := make(map[string]string)
+	for key, val := range d.Get("labels").(map[string]interface{}) {
+		m[key] = val.(string)
+	}
+	return m
+}

--- a/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
+++ b/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
@@ -329,58 +329,79 @@ func resourceContainerInfraClusterTemplateV1Update(d *schema.ResourceData, meta 
 	updateOpts := []clustertemplates.UpdateOptsBuilder{}
 
 	if d.HasChange("name") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "name", d.Get("name").(string))
+		v := d.Get("name").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "name", v)
 	}
 	if d.HasChange("apiserver_port") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "apiserver_port", strconv.Itoa(d.Get("apiserver_port").(int)))
+		v := d.Get("apiserver_port").(int)
+		apiServerPort := strconv.Itoa(v)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "apiserver_port", apiServerPort)
 	}
 	if d.HasChange("coe") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "coe", d.Get("coe").(string))
+		v := d.Get("coe").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "coe", v)
 	}
 	if d.HasChange("cluster_distro") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "cluster_distro", d.Get("cluster_distro").(string))
+		v := d.Get("cluster_distro").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "cluster_distro", v)
 	}
 	if d.HasChange("dns_nameserver") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "dns_nameserver", d.Get("dns_nameserver").(string))
+		v := d.Get("dns_nameserver").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "dns_nameserver", v)
 	}
 	if d.HasChange("docker_storage_driver") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "docker_storage_driver", d.Get("docker_storage_driver").(string))
+		v := d.Get("docker_storage_driver").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "docker_storage_driver", v)
 	}
 	if d.HasChange("docker_volume_size") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "docker_volume_size", strconv.Itoa(d.Get("docker_volume_size").(int)))
+		v := d.Get("docker_volume_size").(int)
+		dockerVolumeSize := strconv.Itoa(v)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "docker_volume_size", dockerVolumeSize)
 	}
 	if d.HasChange("external_network_id") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "external_network_id", d.Get("external_network_id").(string))
+		v := d.Get("external_network_id").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "external_network_id", v)
 	}
 	if d.HasChange("fixed_network") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "fixed_network", d.Get("fixed_network").(string))
+		v := d.Get("fixed_network").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "fixed_network", v)
 	}
 	if d.HasChange("fixed_subnet") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "fixed_subnet", d.Get("fixed_subnet").(string))
+		v := d.Get("fixed_subnet").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "fixed_subnet", v)
 	}
 	if d.HasChange("flavor") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "flavor_id", d.Get("flavor").(string))
+		v := d.Get("flavor").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "flavor_id", v)
 	}
 	if d.HasChange("master_flavor") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "master_flavor_id", d.Get("master_flavor").(string))
+		v := d.Get("master_flavor").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "master_flavor_id", v)
 	}
 	if d.HasChange("floating_ip_enabled") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "floating_ip_enabled", strconv.FormatBool(d.Get("floating_ip_enabled").(bool)))
+		v := d.Get("floating_ip_enabled").(bool)
+		floatingIPEnabled := strconv.FormatBool(v)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "floating_ip_enabled", floatingIPEnabled)
 	}
 	if d.HasChange("http_proxy") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "http_proxy", d.Get("http_proxy").(string))
+		v := d.Get("http_proxy").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "http_proxy", v)
 	}
 	if d.HasChange("https_proxy") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "https_proxy", d.Get("https_proxy").(string))
+		v := d.Get("https_proxy").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "https_proxy", v)
 	}
 	if d.HasChange("image") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "image_id", d.Get("image").(string))
+		v := d.Get("image").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "image_id", v)
 	}
 	if d.HasChange("insecure_registry") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "insecure_registry", d.Get("insecure_registry").(string))
+		v := d.Get("insecure_registry").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "insecure_registry", v)
 	}
 	if d.HasChange("keypair_id") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "keypair_id", d.Get("keypair_id").(string))
+		v := d.Get("keypair_id").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "keypair_id", v)
 	}
 	if d.HasChange("labels") {
 		v, err := resourceClusterTemplateLabelsStringV1(d)
@@ -390,28 +411,40 @@ func resourceContainerInfraClusterTemplateV1Update(d *schema.ResourceData, meta 
 		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "labels", v)
 	}
 	if d.HasChange("master_lb_enabled") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "master_lb_enabled", strconv.FormatBool(d.Get("master_lb_enabled").(bool)))
+		v := d.Get("master_lb_enabled").(bool)
+		masterLBEnabled := strconv.FormatBool(v)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "master_lb_enabled", masterLBEnabled)
 	}
 	if d.HasChange("network_driver") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "network_driver", d.Get("network_driver").(string))
+		v := d.Get("network_driver").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "network_driver", v)
 	}
 	if d.HasChange("no_proxy") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "no_proxy", d.Get("no_proxy").(string))
+		v := d.Get("no_proxy").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "no_proxy", v)
 	}
 	if d.HasChange("public") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "public", strconv.FormatBool(d.Get("public").(bool)))
+		v := d.Get("public").(bool)
+		public := strconv.FormatBool(v)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "public", public)
 	}
 	if d.HasChange("registry_enabled") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "registry_enabled", strconv.FormatBool(d.Get("registry_enabled").(bool)))
+		v := d.Get("registry_enabled").(bool)
+		registryEnabled := strconv.FormatBool(v)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "registry_enabled", registryEnabled)
 	}
 	if d.HasChange("server_type") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "server_type", d.Get("server_type").(string))
+		v := d.Get("server_type").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "server_type", v)
 	}
 	if d.HasChange("tls_disabled") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "tls_disabled", strconv.FormatBool(d.Get("tls_disabled").(bool)))
+		v := d.Get("tls_disabled").(bool)
+		tlsDisabled := strconv.FormatBool(v)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "tls_disabled", tlsDisabled)
 	}
 	if d.HasChange("volume_driver") {
-		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "volume_driver", d.Get("volume_driver").(string))
+		v := d.Get("volume_driver").(string)
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "volume_driver", v)
 	}
 
 	log.Printf("[DEBUG] Updating Cluster template %s with options: %+v", d.Id(), updateOpts)

--- a/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
+++ b/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
@@ -60,7 +60,6 @@ func resourceContainerInfraClusterTemplateV1() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ForceNew:     false,
-				Computed:     true,
 				ValidateFunc: validateClusterTemplateAPIServerPortV1,
 			},
 			"coe": &schema.Schema{
@@ -70,6 +69,7 @@ func resourceContainerInfraClusterTemplateV1() *schema.Resource {
 			},
 			"cluster_distro": &schema.Schema{
 				Type:     schema.TypeString,
+				Optional: true,
 				ForceNew: false,
 				Computed: true,
 			},
@@ -77,69 +77,58 @@ func resourceContainerInfraClusterTemplateV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 			},
 			"docker_storage_driver": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 			},
 			"docker_volume_size": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 			},
 			"external_network_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 			},
 			"fixed_network": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 			},
 			"fixed_subnet": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 			},
 			"flavor": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    false,
-				Computed:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OS_MAGNUM_FLAVOR", nil),
 			},
 			"master_flavor": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    false,
-				Computed:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OS_MAGNUM_MASTER_FLAVOR", nil),
 			},
 			"floating_ip_enabled": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 			},
 			"http_proxy": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 			},
 			"https_proxy": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 			},
 			"image": &schema.Schema{
 				Type:        schema.TypeString,
@@ -151,19 +140,16 @@ func resourceContainerInfraClusterTemplateV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 			},
 			"keypair_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 			},
 			"labels": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 			},
 			"links": &schema.Schema{
 				Type: schema.TypeList,
@@ -188,7 +174,6 @@ func resourceContainerInfraClusterTemplateV1() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 			},
 			"network_driver": &schema.Schema{
 				Type:     schema.TypeString,
@@ -200,19 +185,16 @@ func resourceContainerInfraClusterTemplateV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 			},
 			"public": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 			},
 			"registry_enabled": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 			},
 			"server_type": &schema.Schema{
 				Type:     schema.TypeString,
@@ -224,13 +206,11 @@ func resourceContainerInfraClusterTemplateV1() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 			},
 			"volume_driver": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 			},
 		},
 	}
@@ -495,10 +475,17 @@ func resourceClusterTemplateLabelsStringV1(labels map[string]interface{}) string
 }
 
 func resourceClusterTemplateAppendUpdateOptsV1(updateOpts []clustertemplates.UpdateOptsBuilder, attribute string, value string) []clustertemplates.UpdateOptsBuilder {
-	updateOpts = append(updateOpts, clustertemplates.UpdateOpts{
-		Op:    clustertemplates.ReplaceOp,
-		Path:  strings.Join([]string{"/", attribute}, ""),
-		Value: value,
-	})
+	if value == "" {
+		updateOpts = append(updateOpts, clustertemplates.UpdateOpts{
+			Op:   clustertemplates.RemoveOp,
+			Path: strings.Join([]string{"/", attribute}, ""),
+		})
+	} else {
+		updateOpts = append(updateOpts, clustertemplates.UpdateOpts{
+			Op:    clustertemplates.ReplaceOp,
+			Path:  strings.Join([]string{"/", attribute}, ""),
+			Value: value,
+		})
+	}
 	return updateOpts
 }

--- a/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
+++ b/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
@@ -314,10 +314,10 @@ func resourceContainerInfraClusterTemplateV1Read(d *schema.ResourceData, meta in
 	d.Set("project_id", s.ProjectID)
 	d.Set("user_id", s.UserID)
 
-	if err := d.Set("created_at", s.CreatedAt); err != nil {
+	if err := d.Set("created_at", s.CreatedAt.Format(time.RFC3339)); err != nil {
 		log.Printf("[DEBUG] created_at: %s", err)
 	}
-	if err := d.Set("updated_at", s.CreatedAt); err != nil {
+	if err := d.Set("updated_at", s.UpdatedAt.Format(time.RFC3339)); err != nil {
 		log.Printf("[DEBUG] updated_at: %s", err)
 	}
 

--- a/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
+++ b/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates"
@@ -14,7 +15,7 @@ func resourceContainerInfraClusterTemplateV1() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceContainerInfraClusterTemplateV1Create,
 		Read:   resourceContainerInfraClusterTemplateV1Read,
-		// Update: resourceContainerInfraClusterTemplateV1Update,
+		Update: resourceContainerInfraClusterTemplateV1Update,
 		Delete: resourceContainerInfraClusterTemplateV1Delete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -264,7 +265,7 @@ func resourceContainerInfraClusterTemplateV1Create(d *schema.ResourceData, meta 
 		ImageID:             d.Get("image").(string),
 		InsecureRegistry:    d.Get("insecure_registry").(string),
 		KeyPairID:           d.Get("keypair_id").(string),
-		Labels:              resourceClusterTemplateLabelsV1(d),
+		Labels:              resourceClusterTemplateLabelsMapV1(d),
 		MasterLBEnabled:     &masterLBEnabled,
 		Name:                d.Get("name").(string),
 		NetworkDriver:       d.Get("network_driver").(string),
@@ -356,9 +357,106 @@ func resourceContainerInfraClusterTemplateV1Read(d *schema.ResourceData, meta in
 	return nil
 }
 
-// func resourceContainerInfraClusterTemplateV1Update(d *schema.ResourceData, meta interface{}) error {
-//
-// }
+func resourceContainerInfraClusterTemplateV1Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	containerInfraClient, err := config.containerInfraV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack container infra client: %s", err)
+	}
+
+	updateOpts := []clustertemplates.UpdateOptsBuilder{}
+
+	if d.HasChange("name") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "name", d.Get("name").(string))
+	}
+	if d.HasChange("apiserver_port") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "apiserver_port", strconv.Itoa(d.Get("apiserver_port").(int)))
+	}
+	if d.HasChange("coe") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "coe", d.Get("coe").(string))
+	}
+	if d.HasChange("cluster_distro") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "cluster_distro", d.Get("cluster_distro").(string))
+	}
+	if d.HasChange("dns_nameserver") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "dns_nameserver", d.Get("dns_nameserver").(string))
+	}
+	if d.HasChange("docker_storage_driver") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "docker_storage_driver", d.Get("docker_storage_driver").(string))
+	}
+	if d.HasChange("docker_volume_size") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "docker_volume_size", strconv.Itoa(d.Get("docker_volume_size").(int)))
+	}
+	if d.HasChange("external_network_id") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "external_network_id", d.Get("external_network_id").(string))
+	}
+	if d.HasChange("fixed_network") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "fixed_network", d.Get("fixed_network").(string))
+	}
+	if d.HasChange("fixed_subnet") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "fixed_subnet", d.Get("fixed_subnet").(string))
+	}
+	if d.HasChange("flavor") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "flavor_id", d.Get("flavor").(string))
+	}
+	if d.HasChange("master_flavor") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "master_flavor_id", d.Get("master_flavor").(string))
+	}
+	if d.HasChange("floating_ip_enabled") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "floating_ip_enabled", strconv.FormatBool(d.Get("floating_ip_enabled").(bool)))
+	}
+	if d.HasChange("http_proxy") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "http_proxy", d.Get("http_proxy").(string))
+	}
+	if d.HasChange("https_proxy") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "https_proxy", d.Get("https_proxy").(string))
+	}
+	if d.HasChange("image") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "image_id", d.Get("image").(string))
+	}
+	if d.HasChange("insecure_registry") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "insecure_registry", d.Get("insecure_registry").(string))
+	}
+	if d.HasChange("keypair_id") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "keypair_id", d.Get("keypair_id").(string))
+	}
+	if d.HasChange("labels") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "labels", resourceClusterTemplateLabelsStringV1(d.Get("labels").(map[string]interface{})))
+	}
+	if d.HasChange("master_lb_enabled") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "master_lb_enabled", strconv.FormatBool(d.Get("master_lb_enabled").(bool)))
+	}
+	if d.HasChange("network_driver") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "network_driver", d.Get("network_driver").(string))
+	}
+	if d.HasChange("no_proxy") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "no_proxy", d.Get("no_proxy").(string))
+	}
+	if d.HasChange("public") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "public", strconv.FormatBool(d.Get("public").(bool)))
+	}
+	if d.HasChange("registry_enabled") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "registry_enabled", strconv.FormatBool(d.Get("registry_enabled").(bool)))
+	}
+	if d.HasChange("server_type") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "server_type", d.Get("server_type").(string))
+	}
+	if d.HasChange("tls_disabled") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "tls_disabled", strconv.FormatBool(d.Get("tls_disabled").(bool)))
+	}
+	if d.HasChange("volume_driver") {
+		updateOpts = resourceClusterTemplateAppendUpdateOptsV1(updateOpts, "volume_driver", d.Get("volume_driver").(string))
+	}
+
+	log.Printf("[DEBUG] Updating Cluster template %s with options: %+v", d.Id(), updateOpts)
+
+	_, err = clustertemplates.Update(containerInfraClient, d.Id(), updateOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error updating OpenStack container infra Cluster template: %s", err)
+	}
+
+	return resourceContainerInfraClusterTemplateV1Read(d, meta)
+}
 
 func resourceContainerInfraClusterTemplateV1Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
@@ -383,10 +481,32 @@ func validateClusterTemplateAPIServerPortV1(v interface{}, k string) (ws []strin
 	return
 }
 
-func resourceClusterTemplateLabelsV1(d *schema.ResourceData) map[string]string {
+func resourceClusterTemplateLabelsMapV1(d *schema.ResourceData) map[string]string {
 	m := make(map[string]string)
 	for key, val := range d.Get("labels").(map[string]interface{}) {
 		m[key] = val.(string)
 	}
 	return m
+}
+
+func resourceClusterTemplateLabelsStringV1(labels map[string]interface{}) string {
+	var formattedLabels string
+	for labelKey, labelValue := range labels {
+		formattedLabels = strings.Join([]string{
+			formattedLabels,
+			fmt.Sprintf("%s=%s", labelKey, labelValue.(string)),
+		}, ",")
+	}
+	formattedLabels = strings.Trim(formattedLabels, ",")
+
+	return formattedLabels
+}
+
+func resourceClusterTemplateAppendUpdateOptsV1(updateOpts []clustertemplates.UpdateOptsBuilder, attribute string, value string) []clustertemplates.UpdateOptsBuilder {
+	updateOpts = append(updateOpts, clustertemplates.UpdateOpts{
+		Op:    clustertemplates.ReplaceOp,
+		Path:  strings.Join([]string{"/", attribute}, ""),
+		Value: value,
+	})
+	return updateOpts
 }

--- a/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
+++ b/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceContainerInfraClusterTemplateV1() *schema.Resource {
@@ -60,7 +61,7 @@ func resourceContainerInfraClusterTemplateV1() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ForceNew:     false,
-				ValidateFunc: validateClusterTemplateAPIServerPortV1,
+				ValidateFunc: validation.IntBetween(1024, 65535),
 			},
 			"coe": &schema.Schema{
 				Type:     schema.TypeString,
@@ -442,15 +443,6 @@ func resourceContainerInfraClusterTemplateV1Delete(d *schema.ResourceData, meta 
 	}
 
 	return nil
-}
-
-func validateClusterTemplateAPIServerPortV1(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(int)
-	if value < 1024 || value > 65535 {
-		err := fmt.Errorf("%s should be between 1024 and 65535", k)
-		errors = append(errors, err)
-	}
-	return
 }
 
 func resourceClusterTemplateLabelsMapV1(d *schema.ResourceData) map[string]string {

--- a/openstack/resource_openstack_containerinfra_clustertemplate_v1_test.go
+++ b/openstack/resource_openstack_containerinfra_clustertemplate_v1_test.go
@@ -14,10 +14,10 @@ import (
 func TestAccContainerInfraV1ClusterTemplate_basic(t *testing.T) {
 	var clusterTemplate clustertemplates.ClusterTemplate
 
+	resourceName := "openstack_containerinfra_clustertemplate_v1.clustertemplate_1"
 	clusterTemplateName := acctest.RandomWithPrefix("tf-acc-clustertemplate")
 	imageName := acctest.RandomWithPrefix("tf-acc-image")
 	dockerVolumeSize := 5
-	resourceName := fmt.Sprintf("openstack_containerinfra_clustertemplate_v1.%s", clusterTemplateName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -49,9 +49,9 @@ func TestAccContainerInfraV1ClusterTemplate_basic(t *testing.T) {
 
 func TestAccContainerInfraV1ClusterTemplate_labels(t *testing.T) {
 
+	resourceName := "openstack_containerinfra_clustertemplate_v1.clustertemplate_1"
 	clusterTemplateName := acctest.RandomWithPrefix("tf-acc-clustertemplate")
 	imageName := acctest.RandomWithPrefix("tf-acc-image")
-	resourceName := fmt.Sprintf("openstack_containerinfra_clustertemplate_v1.%s", clusterTemplateName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -126,32 +126,32 @@ func testAccCheckContainerInfraV1ClusterTemplateDestroy(s *terraform.State) erro
 
 func testAccContainerInfraV1ClusterTemplateBasic(clusterTemplateName, imageName string) string {
 	return fmt.Sprintf(`
-resource "openstack_images_image_v2" "%s" {
+resource "openstack_images_image_v2" "image_1" {
   name             = "%s"
   image_source_url = "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
   container_format = "bare"
   disk_format      = "raw"
   properties {
     os_distro = "fedora-atomic"
-	}
+  }
 
   timeouts {
     create = "10m"
   }
 }
 
-resource "openstack_containerinfra_clustertemplate_v1" "%s" {
+resource "openstack_containerinfra_clustertemplate_v1" "clustertemplate_1" {
   name       = "%s"
-  image      = "${openstack_images_image_v2.%s.id}"
+  image      = "${openstack_images_image_v2.image_1.id}"
   coe        = "kubernetes"
   http_proxy = "127.0.0.1:8801"
 }
-`, imageName, imageName, clusterTemplateName, clusterTemplateName, imageName)
+`, imageName, clusterTemplateName)
 }
 
 func testAccContainerInfraV1ClusterTemplateUpdate(clusterTemplateName, imageName string, dockerVolumeSize int) string {
 	return fmt.Sprintf(`
-resource "openstack_images_image_v2" "%s" {
+resource "openstack_images_image_v2" "image_1" {
   name   = "%s"
   image_source_url = "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
   container_format = "bare"
@@ -165,19 +165,19 @@ resource "openstack_images_image_v2" "%s" {
   }
 }
 
-resource "openstack_containerinfra_clustertemplate_v1" "%s" {
+resource "openstack_containerinfra_clustertemplate_v1" "clustertemplate_1" {
   name = "%s"
-  image = "${openstack_images_image_v2.%s.id}"
+  image = "${openstack_images_image_v2.image_1.id}"
   coe = "kubernetes"
   docker_storage_driver = "devicemapper"
   docker_volume_size = %d
 }
-`, imageName, imageName, clusterTemplateName, clusterTemplateName, imageName, dockerVolumeSize)
+`, imageName, clusterTemplateName, dockerVolumeSize)
 }
 
 func testAccContainerInfraV1ClusterTemplateLabels(clusterTemplateName, imageName string) string {
 	return fmt.Sprintf(`
-resource "openstack_images_image_v2" "%s" {
+resource "openstack_images_image_v2" "image_1" {
   name             = "%s"
   image_source_url = "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
   container_format = "bare"
@@ -191,9 +191,9 @@ resource "openstack_images_image_v2" "%s" {
   }
 }
 
-resource "openstack_containerinfra_clustertemplate_v1" "%s" {
+resource "openstack_containerinfra_clustertemplate_v1" "clustertemplate_1" {
   name   = "%s"
-  image  = "${openstack_images_image_v2.%s.id}"
+  image  = "${openstack_images_image_v2.image_1.id}"
   coe    = "kubernetes"
   labels {
     kube_tag                         = "1.11.1"
@@ -202,5 +202,5 @@ resource "openstack_containerinfra_clustertemplate_v1" "%s" {
     kube_dashboard_enabled           = "true"
   }
 }
-`, imageName, imageName, clusterTemplateName, clusterTemplateName, imageName)
+`, imageName, clusterTemplateName)
 }

--- a/openstack/resource_openstack_containerinfra_clustertemplate_v1_test.go
+++ b/openstack/resource_openstack_containerinfra_clustertemplate_v1_test.go
@@ -20,7 +20,7 @@ func TestAccContainerInfraV1ClusterTemplate_basic(t *testing.T) {
 	dockerVolumeSize := 5
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckContainerInfra(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckContainerInfraV1ClusterTemplateDestroy,
 		Steps: []resource.TestStep{
@@ -54,7 +54,7 @@ func TestAccContainerInfraV1ClusterTemplate_labels(t *testing.T) {
 	imageName := acctest.RandomWithPrefix("tf-acc-image")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckContainerInfra(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckContainerInfraV1ClusterTemplateDestroy,
 		Steps: []resource.TestStep{

--- a/openstack/resource_openstack_containerinfra_clustertemplate_v1_test.go
+++ b/openstack/resource_openstack_containerinfra_clustertemplate_v1_test.go
@@ -17,6 +17,7 @@ func TestAccContainerInfraV1ClusterTemplateBasic(t *testing.T) {
 	clusterTemplateName := acctest.RandomWithPrefix("tf-acc-clustertemplate")
 	imageName := acctest.RandomWithPrefix("tf-acc-image")
 	dockerVolumeSize := 5
+	resourceName := fmt.Sprintf("openstack_containerinfra_clustertemplate_v1.%s", clusterTemplateName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -26,22 +27,16 @@ func TestAccContainerInfraV1ClusterTemplateBasic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccContainerInfraV1ClusterTemplateBasic(clusterTemplateName, imageName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckContainerInfraV1ClusterTemplateExists("openstack_containerinfra_clustertemplate_v1.clustertemplate_1", &clusterTemplate),
-					resource.TestCheckResourceAttr(
-						"openstack_containerinfra_clustertemplate_v1.clustertemplate_1", "name", clusterTemplateName),
+					testAccCheckContainerInfraV1ClusterTemplateExists(resourceName, &clusterTemplate),
+					resource.TestCheckResourceAttr(resourceName, "name", clusterTemplateName),
 				),
 			},
 			resource.TestStep{
 				Config: testAccContainerInfraV1ClusterTemplateUpdate(clusterTemplateName, imageName, dockerVolumeSize),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"openstack_containerinfra_clustertemplate_v1.clustertemplate_1", "name", clusterTemplateName),
-					resource.TestCheckResourceAttr(
-						"openstack_containerinfra_clustertemplate_v1.clustertemplate_1", "coe", "kubernetes"),
-					resource.TestCheckResourceAttr(
-						"openstack_containerinfra_clustertemplate_v1.clustertemplate_1", "docker_storage_driver", "devicemapper"),
-					resource.TestCheckResourceAttr(
-						"openstack_containerinfra_clustertemplate_v1.clustertemplate_1", "docker_volume_size", strconv.Itoa(dockerVolumeSize)),
+					resource.TestCheckResourceAttr(resourceName, "coe", "kubernetes"),
+					resource.TestCheckResourceAttr(resourceName, "docker_storage_driver", "devicemapper"),
+					resource.TestCheckResourceAttr(resourceName, "docker_volume_size", strconv.Itoa(dockerVolumeSize)),
 				),
 			},
 		},
@@ -117,12 +112,12 @@ resource "openstack_images_image_v2" "%s" {
 	}
 }
 
-resource "openstack_containerinfra_clustertemplate_v1" "clustertemplate_1" {
+resource "openstack_containerinfra_clustertemplate_v1" "%s" {
   name = "%s"
   image = "${openstack_images_image_v2.%s.id}"
 	coe = "kubernetes"
 }
-`, imageName, imageName, clusterTemplateName, imageName)
+`, imageName, imageName, clusterTemplateName, clusterTemplateName, imageName)
 }
 
 func testAccContainerInfraV1ClusterTemplateUpdate(clusterTemplateName, imageName string, dockerVolumeSize int) string {
@@ -141,12 +136,12 @@ resource "openstack_images_image_v2" "%s" {
   }
 }
 
-resource "openstack_containerinfra_clustertemplate_v1" "clustertemplate_1" {
+resource "openstack_containerinfra_clustertemplate_v1" "%s" {
   name = "%s"
   image = "${openstack_images_image_v2.%s.id}"
   coe = "kubernetes"
   docker_storage_driver = "devicemapper"
   docker_volume_size = %d
 }
-`, imageName, imageName, clusterTemplateName, imageName, dockerVolumeSize)
+`, imageName, imageName, clusterTemplateName, clusterTemplateName, imageName, dockerVolumeSize)
 }

--- a/openstack/resource_openstack_containerinfra_clustertemplate_v1_test.go
+++ b/openstack/resource_openstack_containerinfra_clustertemplate_v1_test.go
@@ -29,12 +29,16 @@ func TestAccContainerInfraV1ClusterTemplateBasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerInfraV1ClusterTemplateExists(resourceName, &clusterTemplate),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterTemplateName),
+					resource.TestCheckResourceAttr(resourceName, "coe", "kubernetes"),
+					resource.TestCheckResourceAttr(resourceName, "http_proxy", "127.0.0.1:8801"),
 				),
 			},
 			resource.TestStep{
 				Config: testAccContainerInfraV1ClusterTemplateUpdate(clusterTemplateName, imageName, dockerVolumeSize),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", clusterTemplateName),
 					resource.TestCheckResourceAttr(resourceName, "coe", "kubernetes"),
+					resource.TestCheckResourceAttr(resourceName, "http_proxy", ""),
 					resource.TestCheckResourceAttr(resourceName, "docker_storage_driver", "devicemapper"),
 					resource.TestCheckResourceAttr(resourceName, "docker_volume_size", strconv.Itoa(dockerVolumeSize)),
 				),
@@ -116,6 +120,7 @@ resource "openstack_containerinfra_clustertemplate_v1" "%s" {
   name = "%s"
   image = "${openstack_images_image_v2.%s.id}"
 	coe = "kubernetes"
+	http_proxy = "127.0.0.1:8801"
 }
 `, imageName, imageName, clusterTemplateName, clusterTemplateName, imageName)
 }

--- a/openstack/resource_openstack_containerinfra_clustertemplate_v1_test.go
+++ b/openstack/resource_openstack_containerinfra_clustertemplate_v1_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccContainerInfraV1ClusterTemplateBasic(t *testing.T) {
+func TestAccContainerInfraV1ClusterTemplate_basic(t *testing.T) {
 	var clusterTemplate clustertemplates.ClusterTemplate
 
 	clusterTemplateName := acctest.RandomWithPrefix("tf-acc-clustertemplate")
@@ -47,7 +47,7 @@ func TestAccContainerInfraV1ClusterTemplateBasic(t *testing.T) {
 	})
 }
 
-func TestAccContainerInfraV1ClusterTemplateLabels(t *testing.T) {
+func TestAccContainerInfraV1ClusterTemplate_labels(t *testing.T) {
 
 	clusterTemplateName := acctest.RandomWithPrefix("tf-acc-clustertemplate")
 	imageName := acctest.RandomWithPrefix("tf-acc-image")

--- a/openstack/resource_openstack_containerinfra_clustertemplate_v1_test.go
+++ b/openstack/resource_openstack_containerinfra_clustertemplate_v1_test.go
@@ -1,0 +1,152 @@
+package openstack
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccContainerInfraV1ClusterTemplateBasic(t *testing.T) {
+	var clusterTemplate clustertemplates.ClusterTemplate
+
+	clusterTemplateName := acctest.RandomWithPrefix("tf-acc-clustertemplate")
+	imageName := acctest.RandomWithPrefix("tf-acc-image")
+	dockerVolumeSize := 5
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerInfraV1ClusterTemplateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainerInfraV1ClusterTemplateBasic(clusterTemplateName, imageName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerInfraV1ClusterTemplateExists("openstack_containerinfra_clustertemplate_v1.clustertemplate_1", &clusterTemplate),
+					resource.TestCheckResourceAttr(
+						"openstack_containerinfra_clustertemplate_v1.clustertemplate_1", "name", clusterTemplateName),
+				),
+			},
+			resource.TestStep{
+				Config: testAccContainerInfraV1ClusterTemplateUpdate(clusterTemplateName, imageName, dockerVolumeSize),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"openstack_containerinfra_clustertemplate_v1.clustertemplate_1", "name", clusterTemplateName),
+					resource.TestCheckResourceAttr(
+						"openstack_containerinfra_clustertemplate_v1.clustertemplate_1", "coe", "kubernetes"),
+					resource.TestCheckResourceAttr(
+						"openstack_containerinfra_clustertemplate_v1.clustertemplate_1", "docker_storage_driver", "devicemapper"),
+					resource.TestCheckResourceAttr(
+						"openstack_containerinfra_clustertemplate_v1.clustertemplate_1", "docker_volume_size", strconv.Itoa(dockerVolumeSize)),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckContainerInfraV1ClusterTemplateExists(n string, clustertemplate *clustertemplates.ClusterTemplate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		containerInfraClient, err := config.containerInfraV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating OpenStack container infra client: %s", err)
+		}
+
+		found, err := clustertemplates.Get(containerInfraClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.UUID != rs.Primary.ID {
+			return fmt.Errorf("Cluster template not found")
+		}
+
+		*clustertemplate = *found
+
+		return nil
+	}
+}
+
+func testAccCheckContainerInfraV1ClusterTemplateDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	containerInfraClient, err := config.containerInfraV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack container infra client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "openstack_containerinfra_clustertemplate_v1" {
+			continue
+		}
+
+		_, err := clustertemplates.Get(containerInfraClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Cluster template still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccContainerInfraV1ClusterTemplateBasic(clusterTemplateName, imageName string) string {
+	return fmt.Sprintf(`
+resource "openstack_images_image_v2" "%s" {
+	name   = "%s"
+	image_source_url = "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
+	container_format = "bare"
+	disk_format = "raw"
+  properties {
+    os_distro = "fedora-atomic"
+  }
+
+	timeouts {
+		create = "10m"
+	}
+}
+
+resource "openstack_containerinfra_clustertemplate_v1" "clustertemplate_1" {
+  name = "%s"
+  image = "${openstack_images_image_v2.%s.id}"
+	coe = "kubernetes"
+}
+`, imageName, imageName, clusterTemplateName, imageName)
+}
+
+func testAccContainerInfraV1ClusterTemplateUpdate(clusterTemplateName, imageName string, dockerVolumeSize int) string {
+	return fmt.Sprintf(`
+resource "openstack_images_image_v2" "%s" {
+  name   = "%s"
+  image_source_url = "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
+  container_format = "bare"
+	disk_format = "raw"
+  properties {
+    os_distro = "fedora-atomic"
+  }
+
+  timeouts {
+    create = "10m"
+  }
+}
+
+resource "openstack_containerinfra_clustertemplate_v1" "clustertemplate_1" {
+  name = "%s"
+  image = "${openstack_images_image_v2.%s.id}"
+  coe = "kubernetes"
+  docker_storage_driver = "devicemapper"
+  docker_volume_size = %d
+}
+`, imageName, imageName, clusterTemplateName, imageName, dockerVolumeSize)
+}

--- a/openstack/resource_openstack_containerinfra_clustertemplate_v1_test.go
+++ b/openstack/resource_openstack_containerinfra_clustertemplate_v1_test.go
@@ -127,24 +127,24 @@ func testAccCheckContainerInfraV1ClusterTemplateDestroy(s *terraform.State) erro
 func testAccContainerInfraV1ClusterTemplateBasic(clusterTemplateName, imageName string) string {
 	return fmt.Sprintf(`
 resource "openstack_images_image_v2" "%s" {
-	name   = "%s"
-	image_source_url = "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
-	container_format = "bare"
-	disk_format = "raw"
+  name             = "%s"
+  image_source_url = "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
+  container_format = "bare"
+  disk_format      = "raw"
   properties {
     os_distro = "fedora-atomic"
-  }
-
-	timeouts {
-		create = "10m"
 	}
+
+  timeouts {
+    create = "10m"
+  }
 }
 
 resource "openstack_containerinfra_clustertemplate_v1" "%s" {
-  name = "%s"
-  image = "${openstack_images_image_v2.%s.id}"
-	coe = "kubernetes"
-	http_proxy = "127.0.0.1:8801"
+  name       = "%s"
+  image      = "${openstack_images_image_v2.%s.id}"
+  coe        = "kubernetes"
+  http_proxy = "127.0.0.1:8801"
 }
 `, imageName, imageName, clusterTemplateName, clusterTemplateName, imageName)
 }
@@ -155,7 +155,7 @@ resource "openstack_images_image_v2" "%s" {
   name   = "%s"
   image_source_url = "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
   container_format = "bare"
-	disk_format = "raw"
+  disk_format = "raw"
   properties {
     os_distro = "fedora-atomic"
   }
@@ -178,10 +178,10 @@ resource "openstack_containerinfra_clustertemplate_v1" "%s" {
 func testAccContainerInfraV1ClusterTemplateLabels(clusterTemplateName, imageName string) string {
 	return fmt.Sprintf(`
 resource "openstack_images_image_v2" "%s" {
-  name   = "%s"
+  name             = "%s"
   image_source_url = "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
   container_format = "bare"
-  disk_format = "raw"
+  disk_format      = "raw"
   properties {
     os_distro = "fedora-atomic"
   }
@@ -192,15 +192,15 @@ resource "openstack_images_image_v2" "%s" {
 }
 
 resource "openstack_containerinfra_clustertemplate_v1" "%s" {
-  name = "%s"
-  image = "${openstack_images_image_v2.%s.id}"
-  coe = "kubernetes"
-  labels = {
-		kube_tag = "1.11.1"
-		prometheus_monitoring = "true"
-		influx_grafana_dashboard_enabled = "true"
-		kube_dashboard_enabled = "true"
-	}
+  name   = "%s"
+  image  = "${openstack_images_image_v2.%s.id}"
+  coe    = "kubernetes"
+  labels {
+    kube_tag                         = "1.11.1"
+    prometheus_monitoring            = "true"
+    influx_grafana_dashboard_enabled = "true"
+    kube_dashboard_enabled           = "true"
+  }
 }
 `, imageName, imageName, clusterTemplateName, clusterTemplateName, imageName)
 }

--- a/openstack/util.go
+++ b/openstack/util.go
@@ -145,3 +145,14 @@ func resourceNetworkingAvailabilityZoneHintsV2(d *schema.ResourceData) []string 
 	}
 	return azh
 }
+
+func resourceLinks(rawLinks []gophercloud.Link) []map[string]string {
+	links := make([]map[string]string, len(rawLinks))
+	for _, rawLink := range rawLinks {
+		links = append(links, map[string]string{
+			"rel":  rawLink.Rel,
+			"href": rawLink.Href,
+		})
+	}
+	return links
+}

--- a/openstack/util.go
+++ b/openstack/util.go
@@ -145,14 +145,3 @@ func resourceNetworkingAvailabilityZoneHintsV2(d *schema.ResourceData) []string 
 	}
 	return azh
 }
-
-func resourceLinks(rawLinks []gophercloud.Link) []map[string]string {
-	links := make([]map[string]string, len(rawLinks))
-	for _, rawLink := range rawLinks {
-		links = append(links, map[string]string{
-			"rel":  rawLink.Rel,
-			"href": rawLink.Href,
-		})
-	}
-	return links
-}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates/doc.go
@@ -1,0 +1,70 @@
+// Package clustertemplates contains functionality for working with Magnum Cluster Templates
+// resources.
+/*
+Package clustertemplates provides information and interaction with the cluster-templates through
+the OpenStack Container Infra service.
+
+Example to Create Cluster Template
+
+	boolFalse := false
+	boolTrue := true
+	createOpts := clustertemplates.CreateOpts{
+		Name:                "test-cluster-template",
+		Labels:              map[string]string{},
+		FixedSubnet:         "",
+		MasterFlavorID:      "",
+		NoProxy:             "10.0.0.0/8,172.0.0.0/8,192.0.0.0/8,localhost",
+		HTTPSProxy:          "http://10.164.177.169:8080",
+		TLSDisabled:         &boolFalse,
+		KeyPairID:           "kp",
+		Public:              &boolFalse,
+		HTTPProxy:           "http://10.164.177.169:8080",
+		ServerType:          "vm",
+		ExternalNetworkID:   "public",
+		ImageID:             "fedora-atomic-latest",
+		VolumeDriver:        "cinder",
+		RegistryEnabled:     &boolFalse,
+		DockerStorageDriver: "devicemapper",
+		NetworkDriver:       "flannel",
+		FixedNetwork:        "",
+		COE:                 "kubernetes",
+		FlavorID:            "m1.small",
+		MasterLBEnabled:     &boolTrue,
+		DNSNameServer:       "8.8.8.8",
+	}
+
+	clustertemplate, err := clustertemplates.Create(serviceClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete Cluster Template
+
+	clusterTemplateID := "dc6d336e3fc4c0a951b5698cd1236ee"
+	err := clustertemplates.Delete(serviceClient, clusterTemplateID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to List Clusters Templates
+
+	listOpts := clustertemplates.ListOpts{
+		Limit: 20,
+	}
+
+	allPages, err := clustertemplates.List(serviceClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allClusterTemplates, err := clusters.ExtractClusterTemplates(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, clusterTemplate := range allClusterTemplates {
+		fmt.Printf("%+v\n", clusterTemplate)
+	}
+
+*/
+package clustertemplates

--- a/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates/doc.go
@@ -66,5 +66,25 @@ Example to List Clusters Templates
 		fmt.Printf("%+v\n", clusterTemplate)
 	}
 
+Example to Update Cluster Template
+
+	updateOpts := []clustertemplates.UpdateOptsBuilder{
+		clustertemplates.UpdateOpts{
+			Op:    clustertemplates.ReplaceOp,
+			Path:  "/master_lb_enabled",
+			Value: "True",
+		},
+		clustertemplates.UpdateOpts{
+			Op:    clustertemplates.ReplaceOp,
+			Path:  "/registry_enabled",
+			Value: "True",
+		},
+	}
+
+	clustertemplate, err := clustertemplates.Update(serviceClient, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 */
 package clustertemplates

--- a/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates/requests.go
@@ -1,0 +1,125 @@
+package clustertemplates
+
+import (
+	"net/http"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder Builder.
+type CreateOptsBuilder interface {
+	ToClusterCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts params
+type CreateOpts struct {
+	APIServerPort       *int              `json:"apiserver_port,omitempty"`
+	COE                 string            `json:"coe" required:"true"`
+	DNSNameServer       string            `json:"dns_nameserver,omitempty"`
+	DockerStorageDriver string            `json:"docker_storage_driver,omitempty"`
+	DockerVolumeSize    *int              `json:"docker_volume_size,omitempty"`
+	ExternalNetworkID   string            `json:"external_network_id,omitempty"`
+	FixedNetwork        string            `json:"fixed_network,omitempty"`
+	FixedSubnet         string            `json:"fixed_subnet,omitempty"`
+	FlavorID            string            `json:"flavor_id,omitempty"`
+	FloatingIPEnabled   *bool             `json:"floating_ip_enabled,omitempty"`
+	HTTPProxy           string            `json:"http_proxy,omitempty"`
+	HTTPSProxy          string            `json:"https_proxy,omitempty"`
+	ImageID             string            `json:"image_id" required:"true"`
+	InsecureRegistry    string            `json:"insecure_registry,omitempty"`
+	KeyPairID           string            `json:"keypair_id,omitempty"`
+	Labels              map[string]string `json:"labels,omitempty"`
+	MasterFlavorID      string            `json:"master_flavor_id,omitempty"`
+	MasterLBEnabled     *bool             `json:"master_lb_enabled,omitempty"`
+	Name                string            `json:"name,omitempty"`
+	NetworkDriver       string            `json:"network_driver,omitempty"`
+	NoProxy             string            `json:"no_proxy,omitempty"`
+	Public              *bool             `json:"public,omitempty"`
+	RegistryEnabled     *bool             `json:"registry_enabled,omitempty"`
+	ServerType          string            `json:"server_type,omitempty"`
+	TLSDisabled         *bool             `json:"tls_disabled,omitempty"`
+	VolumeDriver        string            `json:"volume_driver,omitempty"`
+}
+
+// ToClusterCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToClusterCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Create requests the creation of a new cluster.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToClusterCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	var result *http.Response
+	result, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+
+	return
+}
+
+// Delete deletes the specified cluster ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	var result *http.Response
+	result, r.Err = client.Delete(deleteURL(client, id), nil)
+	r.Header = result.Header
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToClusterTemplateListQuery() (string, error)
+}
+
+// ListOpts allows the sorting of paginated collections through
+// the API. SortKey allows you to sort by a particular cluster templates attribute.
+// SortDir sets the direction, and is either `asc' or `desc'.
+// Marker and Limit are used for pagination.
+type ListOpts struct {
+	Marker  string `q:"marker"`
+	Limit   int    `q:"limit"`
+	SortKey string `q:"sort_key"`
+	SortDir string `q:"sort_dir"`
+}
+
+// ToClusterTemplateListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToClusterTemplateListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// cluster-templates. It accepts a ListOptsBuilder, which allows you to sort
+// the returned collection for greater efficiency.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToClusterTemplateListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ClusterTemplatePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves a specific cluster-template based on its unique ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	var result *http.Response
+	result, r.Err = client.Get(getURL(client, id), &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates/results.go
@@ -27,6 +27,11 @@ type GetResult struct {
 	commonResult
 }
 
+// UpdateResult is the response of a Update operations.
+type UpdateResult struct {
+	commonResult
+}
+
 // Extract is a function that accepts a result and extracts a cluster-template resource.
 func (r commonResult) Extract() (*ClusterTemplate, error) {
 	var s *ClusterTemplate

--- a/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates/results.go
@@ -41,7 +41,7 @@ func (r commonResult) Extract() (*ClusterTemplate, error) {
 
 // Represents a template for a Cluster Template
 type ClusterTemplate struct {
-	APIServerPort       string             `json:"apiserver_port"`
+	APIServerPort       int                `json:"apiserver_port"`
 	COE                 string             `json:"coe"`
 	ClusterDistro       string             `json:"cluster_distro"`
 	CreatedAt           time.Time          `json:"created_at"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates/results.go
@@ -1,0 +1,109 @@
+package clustertemplates
+
+import (
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// CreateResult is the response of a Create operations.
+type CreateResult struct {
+	commonResult
+}
+
+// DeleteResult is the result from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// GetResult is the response of a Get operations.
+type GetResult struct {
+	commonResult
+}
+
+// Extract is a function that accepts a result and extracts a cluster-template resource.
+func (r commonResult) Extract() (*ClusterTemplate, error) {
+	var s *ClusterTemplate
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// Represents a template for a Cluster Template
+type ClusterTemplate struct {
+	APIServerPort       string             `json:"apiserver_port"`
+	COE                 string             `json:"coe"`
+	ClusterDistro       string             `json:"cluster_distro"`
+	CreatedAt           time.Time          `json:"created_at"`
+	DNSNameServer       string             `json:"dns_nameserver"`
+	DockerStorageDriver string             `json:"docker_storage_driver"`
+	DockerVolumeSize    int                `json:"docker_volume_size"`
+	ExternalNetworkID   string             `json:"external_network_id"`
+	FixedNetwork        string             `json:"fixed_network"`
+	FixedSubnet         string             `json:"fixed_subnet"`
+	FlavorID            string             `json:"flavor_id"`
+	FloatingIPEnabled   bool               `json:"floating_ip_enabled"`
+	HTTPProxy           string             `json:"http_proxy"`
+	HTTPSProxy          string             `json:"https_proxy"`
+	ImageID             string             `json:"image_id"`
+	InsecureRegistry    string             `json:"insecure_registry"`
+	KeyPairID           string             `json:"keypair_id"`
+	Labels              map[string]string  `json:"labels"`
+	Links               []gophercloud.Link `json:"links"`
+	MasterFlavorID      string             `json:"master_flavor_id"`
+	MasterLBEnabled     bool               `json:"master_lb_enabled"`
+	Name                string             `json:"name"`
+	NetworkDriver       string             `json:"network_driver"`
+	NoProxy             string             `json:"no_proxy"`
+	ProjectID           string             `json:"project_id"`
+	Public              bool               `json:"public"`
+	RegistryEnabled     bool               `json:"registry_enabled"`
+	ServerType          string             `json:"server_type"`
+	TLSDisabled         bool               `json:"tls_disabled"`
+	UUID                string             `json:"uuid"`
+	UpdatedAt           time.Time          `json:"updated_at"`
+	UserID              string             `json:"user_id"`
+	VolumeDriver        string             `json:"volume_driver"`
+}
+
+// ClusterTemplatePage is the page returned by a pager when traversing over a
+// collection of cluster-templates.
+type ClusterTemplatePage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of cluster template has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r ClusterTemplatePage) NextPageURL() (string, error) {
+	var s struct {
+		Next string `json:"next"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Next, nil
+}
+
+// IsEmpty checks whether a ClusterTemplatePage struct is empty.
+func (r ClusterTemplatePage) IsEmpty() (bool, error) {
+	is, err := ExtractClusterTemplates(r)
+	return len(is) == 0, err
+}
+
+// ExtractClusterTemplates accepts a Page struct, specifically a ClusterTemplatePage struct,
+// and extracts the elements into a slice of cluster templates structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractClusterTemplates(r pagination.Page) ([]ClusterTemplate, error) {
+	var s struct {
+		ClusterTemplates []ClusterTemplate `json:"clustertemplates"`
+	}
+	err := (r.(ClusterTemplatePage)).ExtractInto(&s)
+	return s.ClusterTemplates, err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates/urls.go
@@ -29,3 +29,7 @@ func listURL(client *gophercloud.ServiceClient) string {
 func getURL(client *gophercloud.ServiceClient, id string) string {
 	return idURL(client, id)
 }
+
+func updateURL(client *gophercloud.ServiceClient, id string) string {
+	return idURL(client, id)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates/urls.go
@@ -1,0 +1,31 @@
+package clustertemplates
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+var apiName = "clustertemplates"
+
+func commonURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL(apiName)
+}
+
+func idURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(apiName, id)
+}
+
+func createURL(client *gophercloud.ServiceClient) string {
+	return commonURL(client)
+}
+
+func deleteURL(client *gophercloud.ServiceClient, id string) string {
+	return idURL(client, id)
+}
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return commonURL(client)
+}
+
+func getURL(client *gophercloud.ServiceClient, id string) string {
+	return idURL(client, id)
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/expand_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/expand_json.go
@@ -1,0 +1,11 @@
+package structure
+
+import "encoding/json"
+
+func ExpandJsonFromString(jsonString string) (map[string]interface{}, error) {
+	var result map[string]interface{}
+
+	err := json.Unmarshal([]byte(jsonString), &result)
+
+	return result, err
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/flatten_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/flatten_json.go
@@ -1,0 +1,16 @@
+package structure
+
+import "encoding/json"
+
+func FlattenJsonToString(input map[string]interface{}) (string, error) {
+	if len(input) == 0 {
+		return "", nil
+	}
+
+	result, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+
+	return string(result), nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/normalize_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/normalize_json.go
@@ -1,0 +1,24 @@
+package structure
+
+import "encoding/json"
+
+// Takes a value containing JSON string and passes it through
+// the JSON parser to normalize it, returns either a parsing
+// error or normalized JSON string.
+func NormalizeJsonString(jsonString interface{}) (string, error) {
+	var j interface{}
+
+	if jsonString == nil || jsonString.(string) == "" {
+		return "", nil
+	}
+
+	s := jsonString.(string)
+
+	err := json.Unmarshal([]byte(s), &j)
+	if err != nil {
+		return s, err
+	}
+
+	bytes, _ := json.Marshal(j)
+	return string(bytes[:]), nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/suppress_json_diff.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/suppress_json_diff.go
@@ -1,0 +1,21 @@
+package structure
+
+import (
+	"reflect"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func SuppressJsonDiff(k, old, new string, d *schema.ResourceData) bool {
+	oldMap, err := ExpandJsonFromString(old)
+	if err != nil {
+		return false
+	}
+
+	newMap, err := ExpandJsonFromString(new)
+	if err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(oldMap, newMap)
+}

--- a/vendor/github.com/hashicorp/terraform/helper/validation/validation.go
+++ b/vendor/github.com/hashicorp/terraform/helper/validation/validation.go
@@ -1,0 +1,268 @@
+package validation
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/structure"
+)
+
+// IntBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is between min and max (inclusive)
+func IntBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v < min || v > max {
+			es = append(es, fmt.Errorf("expected %s to be in the range (%d - %d), got %d", k, min, max, v))
+			return
+		}
+
+		return
+	}
+}
+
+// IntAtLeast returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is at least min (inclusive)
+func IntAtLeast(min int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v < min {
+			es = append(es, fmt.Errorf("expected %s to be at least (%d), got %d", k, min, v))
+			return
+		}
+
+		return
+	}
+}
+
+// IntAtMost returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is at most max (inclusive)
+func IntAtMost(max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v > max {
+			es = append(es, fmt.Errorf("expected %s to be at most (%d), got %d", k, max, v))
+			return
+		}
+
+		return
+	}
+}
+
+// StringInSlice returns a SchemaValidateFunc which tests if the provided value
+// is of type string and matches the value of an element in the valid slice
+// will test with in lower case if ignoreCase is true
+func StringInSlice(valid []string, ignoreCase bool) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		for _, str := range valid {
+			if v == str || (ignoreCase && strings.ToLower(v) == strings.ToLower(str)) {
+				return
+			}
+		}
+
+		es = append(es, fmt.Errorf("expected %s to be one of %v, got %s", k, valid, v))
+		return
+	}
+}
+
+// StringLenBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type string and has length between min and max (inclusive)
+func StringLenBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+		if len(v) < min || len(v) > max {
+			es = append(es, fmt.Errorf("expected length of %s to be in the range (%d - %d), got %s", k, min, max, v))
+		}
+		return
+	}
+}
+
+// StringMatch returns a SchemaValidateFunc which tests if the provided value
+// matches a given regexp. Optionally an error message can be provided to
+// return something friendlier than "must match some globby regexp".
+func StringMatch(r *regexp.Regexp, message string) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) ([]string, []error) {
+		v, ok := i.(string)
+		if !ok {
+			return nil, []error{fmt.Errorf("expected type of %s to be string", k)}
+		}
+
+		if ok := r.MatchString(v); !ok {
+			if message != "" {
+				return nil, []error{fmt.Errorf("invalid value for %s (%s)", k, message)}
+
+			}
+			return nil, []error{fmt.Errorf("expected value of %s to match regular expression %q", k, r)}
+		}
+		return nil, nil
+	}
+}
+
+// NoZeroValues is a SchemaValidateFunc which tests if the provided value is
+// not a zero value. It's useful in situations where you want to catch
+// explicit zero values on things like required fields during validation.
+func NoZeroValues(i interface{}, k string) (s []string, es []error) {
+	if reflect.ValueOf(i).Interface() == reflect.Zero(reflect.TypeOf(i)).Interface() {
+		switch reflect.TypeOf(i).Kind() {
+		case reflect.String:
+			es = append(es, fmt.Errorf("%s must not be empty", k))
+		case reflect.Int, reflect.Float64:
+			es = append(es, fmt.Errorf("%s must not be zero", k))
+		default:
+			// this validator should only ever be applied to TypeString, TypeInt and TypeFloat
+			panic(fmt.Errorf("can't use NoZeroValues with %T attribute %s", i, k))
+		}
+	}
+	return
+}
+
+// CIDRNetwork returns a SchemaValidateFunc which tests if the provided value
+// is of type string, is in valid CIDR network notation, and has significant bits between min and max (inclusive)
+func CIDRNetwork(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		_, ipnet, err := net.ParseCIDR(v)
+		if err != nil {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid CIDR, got: %s with err: %s", k, v, err))
+			return
+		}
+
+		if ipnet == nil || v != ipnet.String() {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid network CIDR, expected %s, got %s",
+				k, ipnet, v))
+		}
+
+		sigbits, _ := ipnet.Mask.Size()
+		if sigbits < min || sigbits > max {
+			es = append(es, fmt.Errorf(
+				"expected %q to contain a network CIDR with between %d and %d significant bits, got: %d",
+				k, min, max, sigbits))
+		}
+
+		return
+	}
+}
+
+// SingleIP returns a SchemaValidateFunc which tests if the provided value
+// is of type string, and in valid single IP notation
+func SingleIP() schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		ip := net.ParseIP(v)
+		if ip == nil {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid IP, got: %s", k, v))
+		}
+		return
+	}
+}
+
+// IPRange returns a SchemaValidateFunc which tests if the provided value
+// is of type string, and in valid IP range notation
+func IPRange() schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		ips := strings.Split(v, "-")
+		if len(ips) != 2 {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid IP range, got: %s", k, v))
+			return
+		}
+		ip1 := net.ParseIP(ips[0])
+		ip2 := net.ParseIP(ips[1])
+		if ip1 == nil || ip2 == nil || bytes.Compare(ip1, ip2) > 0 {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid IP range, got: %s", k, v))
+		}
+		return
+	}
+}
+
+// ValidateJsonString is a SchemaValidateFunc which tests to make sure the
+// supplied string is valid JSON.
+func ValidateJsonString(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := structure.NormalizeJsonString(v); err != nil {
+		errors = append(errors, fmt.Errorf("%q contains an invalid JSON: %s", k, err))
+	}
+	return
+}
+
+// ValidateListUniqueStrings is a ValidateFunc that ensures a list has no
+// duplicate items in it. It's useful for when a list is needed over a set
+// because order matters, yet the items still need to be unique.
+func ValidateListUniqueStrings(v interface{}, k string) (ws []string, errors []error) {
+	for n1, v1 := range v.([]interface{}) {
+		for n2, v2 := range v.([]interface{}) {
+			if v1.(string) == v2.(string) && n1 != n2 {
+				errors = append(errors, fmt.Errorf("%q: duplicate entry - %s", k, v1.(string)))
+			}
+		}
+	}
+	return
+}
+
+// ValidateRegexp returns a SchemaValidateFunc which tests to make sure the
+// supplied string is a valid regular expression.
+func ValidateRegexp(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := regexp.Compile(v.(string)); err != nil {
+		errors = append(errors, fmt.Errorf("%q: %s", k, err))
+	}
+	return
+}
+
+// ValidateRFC3339TimeString is a ValidateFunc that ensures a string parses
+// as time.RFC3339 format
+func ValidateRFC3339TimeString(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := time.Parse(time.RFC3339, v.(string)); err != nil {
+		errors = append(errors, fmt.Errorf("%q: invalid RFC3339 timestamp", k))
+	}
+	return
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1064,6 +1064,20 @@
 			"versionExact": "v0.11.7"
 		},
 		{
+			"checksumSHA1": "Fzbv+N7hFXOtrR6E7ZcHT3jEE9s=",
+			"path": "github.com/hashicorp/terraform/helper/structure",
+			"revision": "313108201dd0b2f639776890ada0ac08e0a88b84",
+			"revisionTime": "2018-08-20T14:44:34Z"
+		},
+		{
+			"checksumSHA1": "nEC56vB6M60BJtGPe+N9rziHqLg=",
+			"path": "github.com/hashicorp/terraform/helper/validation",
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
+		},
+		{
 			"checksumSHA1": "kD1ayilNruf2cES1LDfNZjYRscQ=",
 			"path": "github.com/hashicorp/terraform/httpclient",
 			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -433,6 +433,12 @@
 			"revisionTime": "2018-08-17T04:16:43Z"
 		},
 		{
+			"checksumSHA1": "MGvjsfqOSarUqCcot2lkJ3A4El0=",
+			"path": "github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates",
+			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
+			"revisionTime": "2018-08-07T01:54:16Z"
+		},
+		{
 			"checksumSHA1": "paRHLRizEZWL2sm/vG38zr+DQRM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/configurations",
 			"revision": "185230dfbd12fc178f22e1e2a5c4cf0e3ef5ae45",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -433,10 +433,10 @@
 			"revisionTime": "2018-08-17T04:16:43Z"
 		},
 		{
-			"checksumSHA1": "wNF5RUo1+Z9bhwURZNkmz3jpmAc=",
+			"checksumSHA1": "VxqXejG0O0WC7oYiC1V4Hx2OKTU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates",
-			"revision": "69b1773a4cfb2743ab6661acb860b1873eb9b041",
-			"revisionTime": "2018-08-14T03:36:50Z"
+			"revision": "185230dfbd12fc178f22e1e2a5c4cf0e3ef5ae45",
+			"revisionTime": "2018-08-17T04:16:43Z"
 		},
 		{
 			"checksumSHA1": "paRHLRizEZWL2sm/vG38zr+DQRM=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -433,10 +433,10 @@
 			"revisionTime": "2018-08-17T04:16:43Z"
 		},
 		{
-			"checksumSHA1": "MGvjsfqOSarUqCcot2lkJ3A4El0=",
+			"checksumSHA1": "wNF5RUo1+Z9bhwURZNkmz3jpmAc=",
 			"path": "github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates",
-			"revision": "4ea085781bae939cfc932f7bf0d11534423dc84b",
-			"revisionTime": "2018-08-07T01:54:16Z"
+			"revision": "69b1773a4cfb2743ab6661acb860b1873eb9b041",
+			"revisionTime": "2018-08-14T03:36:50Z"
 		},
 		{
 			"checksumSHA1": "paRHLRizEZWL2sm/vG38zr+DQRM=",

--- a/website/docs/r/containerinfra_clustertemplate_v1.html.markdown
+++ b/website/docs/r/containerinfra_clustertemplate_v1.html.markdown
@@ -88,11 +88,13 @@ The following arguments are supported:
     cluster. Changing this updates the fixed subnet of the existing cluster
     template.
 
-* `flavor` - (Optional) The flavor for the nodes of the cluster. Changing this
-    updates the flavor of the existing cluster template.
+* `flavor` - (Optional) The flavor for the nodes of the cluster. Can be set via
+    the `OS_MAGNUM_FLAVOR` environment variable. Changing this updates the
+    flavor of the existing cluster template.
 
-* `master_flavor` - (Optional) The flavor for the master nodes. Changing this
-    updates the master flavor of the existing cluster template.
+* `master_flavor` - (Optional) The flavor for the master nodes. Can be set via
+    the `OS_MAGNUM_MASTER_FLAVOR` environment variable. Changing this updates
+    the master flavor of the existing cluster template.
 
 * `floating_ip_enabled` - (Optional) Indicates whether created cluster should
     create floating IP for every node or not. Changing this updates the
@@ -107,8 +109,8 @@ The following arguments are supported:
     the existing cluster template.
 
 * `image` - (Required) The reference to an image that is used for nodes of the
-    cluster. Changing this updates the image attribute of the existing cluster
-    template.
+    cluster. Can be set via the `OS_MAGNUM_IMAGE` environment variable.
+    Changing this updates the image attribute of the existing cluster template.
 
 * `insecure_registry` - (Optional) The insecure registry URL for the cluster
     template. Changing this updates the insecure registry attribute of the

--- a/website/docs/r/containerinfra_clustertemplate_v1.html.markdown
+++ b/website/docs/r/containerinfra_clustertemplate_v1.html.markdown
@@ -1,0 +1,197 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_containerinfra_clustertemplate_v1"
+sidebar_current: "docs-openstack-resource-containerinfra-clustertemplate-v1"
+description: |-
+  Manages a V1 Magnum cluster template resource within OpenStack.
+---
+
+# openstack\_containerinfra\_clustertemplate_v1
+
+Manages a V1 Magnum cluster template resource within OpenStack.
+
+## Example Usage
+
+### Create a Cluster template
+
+```hcl
+resource "openstack_containerinfra_clustertemplate_v1" "clustertemplate_1" {
+  name                  = "clustertemplate_1"
+  image                 = "Fedora-Atomic-27"
+  coe                   = "kubernetes"
+  flavor                = "m1.small"
+  master_flavor         = "m1.medium"
+  dns_nameserver        = "1.1.1.1"
+  docker_storage_driver = "devicemapper"
+  docker_volume_size    = 10
+  volume_driver         = "cinder"
+  network_driver        = "flannel"
+  server_type           = "vm"
+  master_lb_enabled     = true
+  floating_ip_enabled   = false
+  labels                = "kube_tag=1.11.1,kube_dashboard_enabled=true,prometheus_monitoring=true,influx_grafana_dashboard_enabled=true"
+}
+```
+
+## Argument reference
+
+The following arguments are supported:
+
+* `region` - (Optional) The region in which to obtain the V1 Container Infra
+    client. A Container Infra client is needed to create a cluster template. If
+    omitted,the `region` argument of the provider is used. Changing this
+    creates a new cluster template.
+
+* `name` - (Required) The name of the cluster template. Changing this updates
+    the name of the existing cluster template.
+
+* `project_id` - (Optional) The project of the cluster template. Required if
+    admin wants to create a cluster template in another project. Changing this
+    creates a new cluster template.
+
+* `user_id` - (Optional) The user of the cluster template. Required if admin
+    wants to create a cluster template for another user. Changing this creates
+    a new cluster template.
+
+* `apiserver_port` - (Optional) The API server port for the Container
+    Orchestration Engine for this cluster template. Changing this updates the
+    API server port of the existing cluster template.
+
+* `coe` - (Required) The Container Orchestration Engine for this cluster
+    template. Changing this updates the engine of the existing cluster
+    template.
+
+* `cluster_distro` - (Optional) The distro for the cluster (fedora-atomic,
+    coreos, etc.). Changing this updates the cluster distro of the existing
+    cluster template.
+
+* `dns_nameserver` - (Optional) Address of the DNS nameserver that is used in
+    nodes of the cluster. Changing this updates the DNS nameserver of the
+    existing cluster template.
+
+* `docker_storage_driver` - (Optional) Docker storage driver. Changing this
+    updates the Docker storage driver of the existing cluster template.
+
+* `docker_volume_size` - (Optional) The size (in GB) of the Docker volume.
+    Changing this updates the Docker volume size of the existing cluster
+    template.
+
+* `external_network_id` - (Optional) The ID of the external network that will
+    be used for the cluster. Changing this updates the external network ID of
+    the existing cluster template.
+
+* `fixed_network` - (Optional) The fixed network that will be attached to the
+    cluster. Changing this updates the fixed network of the existing cluster
+    template.
+
+* `fixed_subnet` - (Optional) The fixed subnet that will be attached to the
+    cluster. Changing this updates the fixed subnet of the existing cluster
+    template.
+
+* `flavor` - (Optional) The flavor for the nodes of the cluster. Changing this
+    updates the flavor of the existing cluster template.
+
+* `master_flavor` - (Optional) The flavor for the master nodes. Changing this
+    updates the master flavor of the existing cluster template.
+
+* `floating_ip_enabled` - (Optional) Indicates whether created cluster should
+    create floating IP for every node or not. Changing this updates the
+    floating IP enabled attribute of the existing cluster template.
+
+* `http_proxy` - (Optional) The address of a proxy for receiving all HTTP
+    requests and relay them. Changing this updates the HTTP proxy address of
+    the existing cluster template.
+
+* `https_proxy` - (Optional) The address of a proxy for receiving all HTTPS
+    requests and relay them. Changing this updates the HTTPS proxy address of
+    the existing cluster template.
+
+* `image` - (Required) The reference to an image that is used for nodes of the
+    cluster. Changing this updates the image attribute of the existing cluster
+    template.
+
+* `insecure_registry` - (Optional) The insecure registry URL for the cluster
+    template. Changing this updates the insecure registry attribute of the
+    existing cluster template.
+
+* `keypair_id` - (Optional) The name of the Compute service SSH keypair.
+    Changing this updates the keypair of the existing cluster template.
+
+* `labels` - (Optional) The list of key value pairs representing additional
+    properties of the cluster template. Changing this updates the labels of the
+    existing cluster template.
+
+* `master_lb_enabled` - (Optional) Indicates whether created cluster should
+    has a loadbalancer for master nodes or not. Changing this updates the
+    attribute of the existing cluster template.
+
+* `network_driver` - (Optional) The name of the driver for the container
+    network. Changing this updates the network driver of the existing cluster
+    template.
+
+* `no_proxy` - (Optional) A comma-separated list of IP addresses that shouldn't
+    be used in the cluster. Changing this updates the no proxy list of the
+    existing cluster template.
+
+* `public` - (Optional) Indicates whether cluster template should be public.
+    Changing this updates the public attribute of the existing cluster
+    template.
+
+* `registry_enabled` - (Optional) Indicates whether Docker registry is enabled
+    in the cluster. Changing this updates the registry enabled attribute of the
+    existing cluster template.
+
+* `server_type` - (Optional) The server type for the cluster template. Changing
+    this updates the server type of the existing cluster template.
+
+* `tls_disabled` - (Optional) Indicates whether the TLS should be disabled in
+    the cluster. Changing this updates the attribute of the existing cluster.
+
+* `volume_driver` - (Optional) The name of the driver that is used for the
+    volumes of the cluster nodes. Changing this updates the volume driver of
+    the existing cluster template.
+
+## Attributes reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `project_id` - See Argument Reference above.
+* `created_at` - The time at which cluster template was created.
+* `updated_at` - The time at which cluster template was created.
+* `apiserver_port` - See Argument Reference above.
+* `coe` - See Argument Reference above.
+* `cluster_distro` - See Argument Reference above.
+* `dns_nameserver` - See Argument Reference above.
+* `docker_storage_driver` - See Argument Reference above.
+* `docker_volume_size` - See Argument Reference above.
+* `external_network_id` - See Argument Reference above.
+* `fixed_network` - See Argument Reference above.
+* `fixed_subnet` - See Argument Reference above.
+* `flavor` - See Argument Reference above.
+* `master_flavor` - See Argument Reference above.
+* `floating_ip_enabled` - See Argument Reference above.
+* `http_proxy` - See Argument Reference above.
+* `https_proxy` - See Argument Reference above.
+* `image` - See Argument Reference above.
+* `insecure_registry` - See Argument Reference above.
+* `keypair_id` - See Argument Reference above.
+* `labels` - See Argument Reference above.
+* `links` - A list containing associated cluster template links.
+* `master_lb_enabled` - See Argument Reference above.
+* `network_driver` - See Argument Reference above.
+* `no_proxy` - See Argument Reference above.
+* `public` - See Argument Reference above.
+* `registry_enabled` - See Argument Reference above.
+* `server_type` - See Argument Reference above.
+* `tls_disabled` - See Argument Reference above.
+* `volume_driver` - See Argument Reference above.
+
+## Import
+
+Cluster templates can be imported using the `id`, e.g.
+
+```
+$ terraform import openstack_containerinfra_clustertemplate_v1.clustertemplate_1 b9a45c5c-cd03-4958-82aa-b80bf93cb922
+```

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -118,6 +118,15 @@
           </ul>
         </li>
 
+        <li<%= sidebar_current("docs-openstack-resource-containerinfra") %>>
+          <a href="#">Container Infra Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-openstack-resource-containerinfra-clustertemplate-v1") %>>
+              <a href="/docs/providers/openstack/r/containerinfra_clustertemplate_v1.html">openstack_containerinfra_clustertemplate_v1</a>
+            </li>
+          </ul>
+        </li>
+
         <li<%= sidebar_current("docs-openstack-resource-db") %>>
           <a href="#">Database Resources</a>
           <ul class="nav nav-visible">


### PR DESCRIPTION
Add resource to manage OpenStack Magnum cluster templates.
Add common resourceLinks() function to unmarhal slice of gophercloud.Links to a slice of maps.

For #402

Some links:
[Constraints for the `apiserver_port`](https://github.com/openstack/magnum/blob/stable/queens/magnum/api/controllers/v1/cluster_template.py#L82)
[Requirement of the `coe`](https://github.com/openstack/magnum/blob/stable/queens/magnum/api/controllers/v1/cluster_template.py#L50)
[Requirement of the `image`](https://github.com/openstack/magnum/blob/stable/queens/magnum/api/controllers/v1/cluster_template.py#L53)
