### PR TITLE
Updated syntax to use "[]" instead of "element()"

### DIFF
--- a/website/docs/r/compute_volume_attach_v2.html.markdown
+++ b/website/docs/r/compute_volume_attach_v2.html.markdown
@@ -49,7 +49,7 @@ resource "openstack_compute_instance_v2" "instance_1" {
 resource "openstack_compute_volume_attach_v2" "attachments" {
   count       = 2
   instance_id = "${openstack_compute_instance_v2.instance_1.id}"
-  volume_id   = "${element(openstack_blockstorage_volume_v2.volumes.*.id, count.index)}"
+  volume_id   = "${openstack_blockstorage_volume_v2.volumes.*.id[count.index]}"
 }
 
 output "volume devices" {


### PR DESCRIPTION
Fixes #406
Using "element()" makes all attachments get
destroyed and re-created when the count
is increased. This is fixed by using the "[]"
syntax instead as explained here:
https://github.com/hashicorp/terraform/issues/3449