### PR TITLE
 Object Storage v1: Add regenerate to temp url resource 

### DIFF
--- a/openstack/resource_openstack_objectstorage_tempurl_v1.go
+++ b/openstack/resource_openstack_objectstorage_tempurl_v1.go
@@ -67,6 +67,12 @@ func resourceObjectstorageTempurlV1() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"regenerate": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"url": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -134,8 +140,10 @@ func resourceObjectstorageTempurlV1Read(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Failed to parse the temp url expiration time: %s", qp.Get("temp_url_expires"))
 	}
 
+	// Regenerate the URL if it has expired and if the user requested it to be.
+	regen := d.Get("regenerate").(bool)
 	now := time.Now().Unix()
-	if expiry < now {
+	if expiry < now && regen {
 		log.Printf("[DEBUG] URL expired, generating a new one")
 		d.SetId("")
 	}

--- a/openstack/resource_openstack_objectstorage_tempurl_v1.go
+++ b/openstack/resource_openstack_objectstorage_tempurl_v1.go
@@ -108,11 +108,11 @@ func resourceObjectstorageTempurlV1Create(d *schema.ResourceData, meta interface
 	containerName := d.Get("container").(string)
 	objectName := d.Get("object").(string)
 
-	log.Printf("[DEBUG] Create TempURL Options: %#v", turlOptions)
+	log.Printf("[DEBUG] Create temporary url Options: %#v", turlOptions)
 
 	url, err := objects.CreateTempURL(objectStorageClient, containerName, objectName, turlOptions)
 	if err != nil {
-		return fmt.Errorf("Unable to generate a TempURL for the object %s in container %s: %s",
+		return fmt.Errorf("Unable to generate a temporary url for the object %s in container %s: %s",
 			objectName, containerName, err)
 	}
 
@@ -131,20 +131,27 @@ func resourceObjectstorageTempurlV1Read(d *schema.ResourceData, meta interface{}
 	turl := d.Get("url").(string)
 	u, err := url.Parse(turl)
 	if err != nil {
-		return fmt.Errorf("Failed to read the temp url: %s", turl)
+		return fmt.Errorf("Failed to read the temporary url %s: %s", turl, err)
 	}
 
-	qp, _ := url.ParseQuery(u.RawQuery)
-	expiry, err := strconv.ParseInt(qp.Get("temp_url_expires"), 10, 64)
+	qp, err := url.ParseQuery(u.RawQuery)
 	if err != nil {
-		return fmt.Errorf("Failed to parse the temp url expiration time: %s", qp.Get("temp_url_expires"))
+		return fmt.Errorf("Failed to parse the temporary url %s query string: %s", turl, err)
+	}
+
+	tempURLExpires := qp.Get("temp_url_expires")
+	expiry, err := strconv.ParseInt(tempURLExpires, 10, 64)
+	if err != nil {
+		return fmt.Errorf(
+			"Failed to parse the temporary url %s expiration time %s: %s",
+			turl, tempURLExpires, err)
 	}
 
 	// Regenerate the URL if it has expired and if the user requested it to be.
 	regen := d.Get("regenerate").(bool)
 	now := time.Now().Unix()
 	if expiry < now && regen {
-		log.Printf("[DEBUG] URL expired, generating a new one")
+		log.Printf("[DEBUG] temporary url %s expired, generating a new one", turl)
 		d.SetId("")
 	}
 

--- a/openstack/resource_openstack_objectstorage_tempurl_v1.go
+++ b/openstack/resource_openstack_objectstorage_tempurl_v1.go
@@ -66,34 +66,13 @@ func resourceObjectstorageTempurlV1() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+
 			"url": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},
 	}
-}
-
-// resourceObjectstorageTempurlV1Read performs the image lookup.
-func resourceObjectstorageTempurlV1Read(d *schema.ResourceData, meta interface{}) error {
-	turl := d.Get("url").(string)
-	u, err := url.Parse(turl)
-	if err != nil {
-		return fmt.Errorf("Failed to read the temp url: %s", turl)
-	}
-
-	qp, _ := url.ParseQuery(u.RawQuery)
-	expiry, err := strconv.ParseInt(qp.Get("temp_url_expires"), 10, 64)
-	if err != nil {
-		return fmt.Errorf("Failed to parse the temp url expiration time: %s", qp.Get("temp_url_expires"))
-	}
-	now := time.Now().Unix()
-	if expiry < now {
-		log.Printf("[DEBUG] URL expired, generating a new one")
-		d.SetId("")
-	}
-
-	return nil
 }
 
 // resourceObjectstorageTempurlV1Create performs the image lookup.
@@ -138,5 +117,28 @@ func resourceObjectstorageTempurlV1Create(d *schema.ResourceData, meta interface
 	hasher.Write([]byte(url))
 	d.SetId(hex.EncodeToString(hasher.Sum(nil)))
 	d.Set("url", url)
+	return nil
+}
+
+// resourceObjectstorageTempurlV1Read performs the image lookup.
+func resourceObjectstorageTempurlV1Read(d *schema.ResourceData, meta interface{}) error {
+	turl := d.Get("url").(string)
+	u, err := url.Parse(turl)
+	if err != nil {
+		return fmt.Errorf("Failed to read the temp url: %s", turl)
+	}
+
+	qp, _ := url.ParseQuery(u.RawQuery)
+	expiry, err := strconv.ParseInt(qp.Get("temp_url_expires"), 10, 64)
+	if err != nil {
+		return fmt.Errorf("Failed to parse the temp url expiration time: %s", qp.Get("temp_url_expires"))
+	}
+
+	now := time.Now().Unix()
+	if expiry < now {
+		log.Printf("[DEBUG] URL expired, generating a new one")
+		d.SetId("")
+	}
+
 	return nil
 }

--- a/website/docs/r/objectstorage_tempurl_v1.html.markdown
+++ b/website/docs/r/objectstorage_tempurl_v1.html.markdown
@@ -16,7 +16,6 @@ will remain in place. If you wish to automatically regenerate a URL, set
 the `regenerate` argument to `true`. This will create a new resource with
 a new ID and URL.
 
-
 ## Example Usage
 
 ```hcl
@@ -41,7 +40,7 @@ The following arguments are supported:
 * `ttl` - (Required) The TTL, in seconds, for the URL. For how long it should
   be valid.
 
-* `method` - (Optional) What methods are allowed for this URL.
+* `method` - (Optional) The method allowed when accessing this URL.
   Valid values are `GET`, and `POST`. Default is `GET`.
 
 * `regenerate` - (Optional) Whether to automatically regenerate the URL when

--- a/website/docs/r/objectstorage_tempurl_v1.html.markdown
+++ b/website/docs/r/objectstorage_tempurl_v1.html.markdown
@@ -10,6 +10,13 @@ description: |-
 
 Use this resource to generate an OpenStack Object Storage temporary URL.
 
+The temporary URL will be valid for as long as TTL is set to (in seconds).
+Once the URL has expired, it will no longer be valid, but the resource
+will remain in place. If you wish to automatically regenerate a URL, set
+the `regenerate` argument to `true`. This will create a new resource with
+a new ID and URL.
+
+
 ## Example Usage
 
 ```hcl
@@ -36,6 +43,10 @@ The following arguments are supported:
 
 * `method` - (Optional) What methods are allowed for this URL.
   Valid values are `GET`, and `POST`. Default is `GET`.
+
+* `regenerate` - (Optional) Whether to automatically regenerate the URL when
+  it has expired. If set to true, this will create a new resource with a new
+  ID and new URL. Defaults to false.
 
 ## Attributes Reference
 

--- a/website/docs/r/objectstorage_tempurl_v1.html.markdown
+++ b/website/docs/r/objectstorage_tempurl_v1.html.markdown
@@ -25,19 +25,21 @@ resource "openstack_objectstorage_tempurl_v1" "obj_tempurl" {
 
 The following arguments are supported:
 
+* `region` - (Optional) The region the tempurl is located in.
+
 * `container` - (Required) The container name the object belongs to.
 
 * `object` - (Required) The object name the tempurl is for.
 
-* `ttl` - (Required) The TTL, in seconds, for the URL. For how long it should be valid.
+* `ttl` - (Required) The TTL, in seconds, for the URL. For how long it should
+  be valid.
 
-* `method` - (Optional) What methods are allowed for this URL. Valid values are `GET`, and `POST`. Default is `GET`.
-
-* `region` - (Optional) The region the tempurl is located in.
+* `method` - (Optional) What methods are allowed for this URL.
+  Valid values are `GET`, and `POST`. Default is `GET`.
 
 ## Attributes Reference
 
-* `Id` - Computed md5 hash based on the generated url
+* `id` - Computed md5 hash based on the generated url
 * `container` - See Argument Reference above.
 * `object` - See Argument Reference above.
 * `ttl` - See Argument Reference above.


### PR DESCRIPTION
This commit adds the `regenerate` argument to the
`openstack_objectstorage_tempurl_v1` resource. This allows users to
opt-in to having the resource automatically regenerate when the
temporary URL has expired.