### PR TITLE
Replace deprecated external_gateway

### DIFF
--- a/website/docs/r/networking_router_interface_v2.html.markdown
+++ b/website/docs/r/networking_router_interface_v2.html.markdown
@@ -25,8 +25,8 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
 }
 
 resource "openstack_networking_router_v2" "router_1" {
-  name             = "my_router"
-  external_gateway = "f67f0d72-0ddf-11e4-9d95-e1f29f417e2f"
+  name                = "my_router"
+  external_network_id = "f67f0d72-0ddf-11e4-9d95-e1f29f417e2f"
 }
 
 resource "openstack_networking_router_interface_v2" "router_interface_1" {


### PR DESCRIPTION
According to the docs: Deprecated - use external_network_id instead

https://www.terraform.io/docs/providers/openstack/r/networking_router_v2.html#external_gateway