### PR TITLE
ComputeV2: add instance vendor_options

### DIFF
--- a/openstack/resource_openstack_networking_router_v2.go
+++ b/openstack/resource_openstack_networking_router_v2.go
@@ -446,16 +446,3 @@ func resourceRouterExternalFixedIPsV2(d *schema.ResourceData) []routers.External
 
 	return externalFixedIPs
 }
-
-func expandVendorOptions(vendOptsRaw []interface{}) map[string]interface{} {
-	vendorOptions := make(map[string]interface{})
-
-	for _, option := range vendOptsRaw {
-		for optKey, optValue := range option.(map[string]interface{}) {
-			vendorOptions[optKey] = optValue
-		}
-
-	}
-
-	return vendorOptions
-}

--- a/openstack/util.go
+++ b/openstack/util.go
@@ -145,3 +145,16 @@ func resourceNetworkingAvailabilityZoneHintsV2(d *schema.ResourceData) []string 
 	}
 	return azh
 }
+
+func expandVendorOptions(vendOptsRaw []interface{}) map[string]interface{} {
+	vendorOptions := make(map[string]interface{})
+
+	for _, option := range vendOptsRaw {
+		for optKey, optValue := range option.(map[string]interface{}) {
+			vendorOptions[optKey] = optValue
+		}
+
+	}
+
+	return vendorOptions
+}

--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -359,6 +359,8 @@ The following arguments are supported:
     the VM will be stopped immediately after build and the provisioners like
     remote-exec or files are not supported.
 
+* `vendor_options` - (Optional) Map of additional vendor-specific options.
+    Supported options are described below.
 
 The `network` block supports:
 
@@ -431,6 +433,13 @@ The `personality` block supports:
 * `file` - (Required) The absolute path of the destination file.
 
 * `contents` - (Required) The contents of the file. Limited to 255 bytes.
+
+The `vendor_options` block supports:
+
+* `ignore_resize_confirmation` - (Optional) Boolean to control whether
+    to ignore manual confirmation of the instance resizing. This can be helpful
+    to work with some OpenStack clouds which automatically confirm resizing of
+    instances after some timeout.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add "vendor_options" map attribute for instance with the
"ignore_resize_confirmation" option.

New option can be used to ignore manual confirmation of the Compute
instance resizing. Some OpenStack cloud providers automatically confirm
resizing of instances after configured timeout.

For #420 