### PR TITLE
Support acceptance test against OpenStack Rocky release in OpenLab

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -19,6 +19,9 @@
     recheck-queens:
       jobs:
         - terraform-provider-openstack-acceptance-test-queens
+    recheck-rocky:
+      jobs:
+        - terraform-provider-openstack-acceptance-test-rocky
     recheck-trove:
       jobs:
         - terraform-provider-openstack-acceptance-test-trove


### PR DESCRIPTION
Input comment "recheck stable/rocky" in pull request comments, that
will trigger acceptance tests against OpenStack Rocky release. OpenLab
will report test result in followint comments automatically.