### PR TITLE
Handle rackspace server addresses without type

### DIFF
--- a/openstack/compute_instance_v2_networking.go
+++ b/openstack/compute_instance_v2_networking.go
@@ -324,7 +324,7 @@ func getInstanceAddresses(addresses map[string]interface{}) []InstanceAddresses 
 				instanceNIC.MAC = v
 			}
 
-			if v["OS-EXT-IPS:type"] == "fixed" {
+			if v["OS-EXT-IPS:type"] == "fixed" || v["OS-EXT-IPS:type"] == nil {
 				switch v["version"].(float64) {
 				case 6:
 					instanceNIC.FixedIPv6 = fmt.Sprintf("[%s]", v["addr"].(string))


### PR DESCRIPTION
This change fixes the server network's fixed IP addresses appearing blank in the resource output because the [rackspace servers api](https://developer.rackspace.com/docs/cloud-servers/v2/api-reference/svr-basic-operations/#show-server-details) doesn't return the `OS-EXT-IPS:type` field in the `addresses` list items, e.g.:

    {
        "server": {
            "OS-DCF:diskConfig": "AUTO",
            "OS-EXT-STS:power_state": 1,
            "OS-EXT-STS:task_state": null,
            "OS-EXT-STS:vm_state": "active",
            "accessIPv4": "198.101.241.238",
            "accessIPv6": "2001:4800:780e:0510:d87b:9cbc:ff04:513a",
            "addresses": {
                "private": [
                    {
                        "addr": "10.180.3.171",
                        "version": 4
                    }
                ],
                "public": [
                    {
                        "addr": "198.101.241.238",
                        "version": 4
                    },
                    {
                        "addr": "2001:4800:780e:0510:d87b:9cbc:ff04:513a",
                        "version": 6
                    }
                ],
                "production": [
                    {
                        "addr": "192.168.21.30",
                        "version": 4
                    }
                ]
            },
           ...

Output from `terraform refresh` before the change:

        {
            access_network = 1,
            fixed_ip_v4 = ,
            fixed_ip_v6 = ,
            floating_ip = ,
            mac = ,
            name = production,
            port = ,
            uuid = deadbeef-67bb-4ca1-9ec4-deadbeef
        }

output after the change:

        {
            access_network = 1,
            fixed_ip_v4 = 192.168.21.30,
            fixed_ip_v6 = ,
            floating_ip = ,
            mac = ,
            name = production,
            port = ,
            uuid = deadbeef-67bb-4ca1-9ec4-deadbeef
        }

Co-Authored-By: Konstantinos Koukopoulos <kouk@transifex.com>
Co-Authored-By: Nestoras Stefanou <nestoras@transifex.com>