### PR TITLE
Compute v2: Allow power_state of error

### DIFF
--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -626,18 +626,13 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 	d.Set("region", GetRegion(d, config))
 
 	// Set the current power_state
-	var validStatus bool
 	currentStatus := strings.ToLower(server.Status)
 	switch currentStatus {
 	case "active", "shutoff", "error":
-		validStatus = true
-	}
-
-	if !validStatus {
+		d.Set("power_state", currentStatus)
+	default:
 		return fmt.Errorf("Invalid power_state for instance %s: %s", d.Id(), server.Status)
 	}
-
-	d.Set("power_state", currentStatus)
 
 	return nil
 }


### PR DESCRIPTION
This commit will allow an instance to cleanly transition into a
status of "error". This will allow users to destroy instances
which have changed into an error state either during creation
or by some event outside of Terraform.

For #404 

Additional comments in #427 