### PR TITLE
Networking v2: Add no_fixed_ip to openstack_networking_port_v2

### DIFF
--- a/website/docs/r/networking_port_v2.html.markdown
+++ b/website/docs/r/networking_port_v2.html.markdown
@@ -67,8 +67,12 @@ The following arguments are supported:
 * `device_id` - (Optional) The ID of the device attached to the port. Changing this
     creates a new port.
 
-* `fixed_ip` - (Optional) An array of desired IPs for this port. The structure is
-    described below.
+* `fixed_ip` - (Optional - Conflicts with `no_fixed_ip`) An array of desired IPs for
+    this port. The structure is described below.
+
+* `no_fixed_ip` - (Optional - Conflicts with `fixed_ip`) Create a port with no fixed
+    IP address. This will also remove any fixed IPs previously set on a port. `true`
+    is the only valid value for this argument.
 
 * `allowed_address_pairs` - (Optional) An IP/MAC Address pair of additional IP
     addresses that can be active on this port. The structure is described
@@ -84,8 +88,8 @@ this port.
 * `ip_address` - (Optional) IP address desired in the subnet for this port. If
 you don't specify `ip_address`, an available IP address from the specified
 subnet will be allocated to this port. This field will not be populated if it
-is left blank. To retrieve the assigned IP address, use the `all_fixed_ips`
-attribute.
+is left blank or omitted. To retrieve the assigned IP address, use the
+`all_fixed_ips` attribute.
 
 The `allowed_address_pairs` block supports:
 


### PR DESCRIPTION
This commit adds the `no_fixed_ip` argument to the
openstack_networking_port_v2 resource which will enable a port to
be created without a Fixed IP address set.

For #429 