### PR TITLE
Networking v2: Security Group Rule Fix

### DIFF
--- a/openstack/resource_openstack_networking_secgroup_rule_v2_test.go
+++ b/openstack/resource_openstack_networking_secgroup_rule_v2_test.go
@@ -33,6 +33,10 @@ func TestAccNetworkingV2SecGroupRule_basic(t *testing.T) {
 						"openstack_networking_secgroup_rule_v2.secgroup_rule_1", &secgroup_rule_1),
 					testAccCheckNetworkingV2SecGroupRuleExists(
 						"openstack_networking_secgroup_rule_v2.secgroup_rule_2", &secgroup_rule_2),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_secgroup_rule_v2.secgroup_rule_1", "description", "secgroup_rule_1"),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_secgroup_rule_v2.secgroup_rule_2", "description", ""),
 				),
 			},
 		},
@@ -290,6 +294,7 @@ resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_1" {
   protocol = "tcp"
   remote_ip_prefix = "0.0.0.0/0"
   security_group_id = "${openstack_networking_secgroup_v2.secgroup_1.id}"
+	description = "secgroup_rule_1"
 }
 
 resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_2" {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/requests.go
@@ -89,7 +89,7 @@ type CreateOpts struct {
 	Direction RuleDirection `json:"direction" required:"true"`
 
 	// String description of each rule, optional
-	Description string `json:"description" required:"false"`
+	Description string `json:"description,omitempty"`
 
 	// Must be "IPv4" or "IPv6", and addresses represented in CIDR must match the
 	// ingress or egress rules.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -315,440 +315,440 @@
 		{
 			"checksumSHA1": "90HfuOdlP9yK6xUnJCAnCrL73DQ=",
 			"path": "github.com/gophercloud/gophercloud",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "b7g9TcU1OmW7e2UySYeOAmcfHpY=",
 			"path": "github.com/gophercloud/gophercloud/internal",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "zDja+rJdiRPG4YeVdt21YX1J8bk=",
 			"path": "github.com/gophercloud/gophercloud/openstack",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "8YtBD+Um7I8ee1Xf1ZAWu74eP7w=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "ULM+8z6I3O1uJlPKgy1K2Rt7si0=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v1/volumes",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "AXL8Rf/vvEUlxCyy6vEgkA9E7VI=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "ZagRxF+wog7lc3QHkvZUtbx1EFw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "nQlviweyWynvpsXf1Ms0AecMzO8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "La8c0H0Eds4MmAKJ9lPdDgJDjSk=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "vFS5BwnCdQIfKm1nNWrR+ijsAZA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "lAQuKIqTuQ9JuMgN0pPkNtRH2RM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "+hlElX7o8ULWTc0r7oGyDlOnwWM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "/8WPKCjuQ2gE8mMDuWc1fCSC9vI=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "PWbrce9A6LMWIGr0fK04AEEuQec=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "qfVZltu1fYTYXS97WbjeLuLPgUc=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/startstop",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "+Gif+WFd0WVjefjvmlR7jyTrdzQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/tenantnetworks",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "TMkBTIrYeL78yJ6wZNJQqG0tHR4=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "tRY1hWvCAjOtcouMKA9V6Aq9Afo=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/flavors",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "CSnfH01hSas0bdc/3m/f5Rt6SFY=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/images",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "gxNCsaZKNT2SUIUtirxfEcLn9jw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/servers",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "j2li+asUKunCgz691sa92VOjAvg=",
 			"path": "github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "VxqXejG0O0WC7oYiC1V4Hx2OKTU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "dRzL6zMlpGRW0b8wjASTYtR/u2Q=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/configurations",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "jdKwC7fxB11ACuo8CUH2VoleJao=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/databases",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "sQjGBGkPPevEYcyWz/7BN7inFbo=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/datastores",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "OufByUxj+IvLN5K7XcVVziy28Pw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/instances",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "62KZtZ4VoCLsOrXxcFTpp0qJEgw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/users",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "hBVpoXsfRy6beVIhE6tcmtvgx+s=",
 			"path": "github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "VxvzmFE0VrKXbmVvSN5dZ+w2zPE=",
 			"path": "github.com/gophercloud/gophercloud/openstack/dns/v2/zones",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "oOJkelRgWx0NzUmxuI3kTS27gM0=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v2/tenants",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "z5NsqMZX3TLMzpmwzOOXE4M5D9w=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "Qzlv/69tlr+1r6W28WrOEEqT9EU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "obpfSV89ht0YMt3WYLFmQj1rWLE=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/groups",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "jfmxyd2jfyxLIBHiNwHURX/9RSQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/projects",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "ZG+k94WuW6QA8ttJMRvNT5kqI9g=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/roles",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "qOc+KYPka86DtcDnpvBuKdCb8jk=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/services",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "HNLKHXv7aYtKnRMo3msTbdGE5H8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "9m7iJ7qQ7SUjZUWPV8DbHCvf9Gc=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/users",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "4Ci0F5SJgiJCXyDuxTQZYvwA00s=",
 			"path": "github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "ysiv+OUUPt6HfAKlWbR9w0QP4YU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/imageservice/v2/images",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "x6lD4wQOZc1rtm6kMaUBMwLxAlA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "a++vnjXX0eXWLylR29L3z8dcxwU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "bqEG939LJ5te1hZuZXRxy1CLMyw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "FDgt1WaVGbp8w6vyCJbtkbsbWBc=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/routerinsertion",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "uZ5/gCROQHaiHpXfoLrfisRzbAU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "K4VAatvB/jywsU+g/mU7bnSaVaI=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "tvOf0FGjKmpz9vZD0ZBHtcMFpwI=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "HiGzZXGIxrItijPCH+L7EbbCb9w=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/members",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "KZJLk70d5SX8TQO1q0MLAxGEBCU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/monitors",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "KXKo/TByIHelRDES1IB01nlQMoM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/pools",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "3QfwJnsJHohoYV16/BOtDXpNEYI=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/vips",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "ObFcwdTfyGmVsVE3OspHtaUbsSQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "CgrfM+dEvV3q3iFcw5CZnljw3xg=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "iCgTFonxOlW7f2b3KUJjKGFNaJk=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/monitors",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "UMHh7JpSwn5PX4kxK8YDgqpasL4=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "eUvwdXvz/Zkckr/isvP+2nXY2J8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/provider",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "nRwN9RkBXzcnWHngcfGmKK/Y31E=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
-			"checksumSHA1": "EeEKPgTDFSvWk1WGB3p9hKmZ3F8=",
+			"checksumSHA1": "B8h1ilzQ5GrGABcvRiy9zSf/u5U=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "nbFJZRXhTvv4g0LK+FCzG0W11G4=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "grviOYvybawC80v7Fmw0XOBwr0A=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/endpointgroups",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "HhRP7Hw7cS7RM4cxGmQYk/vI8uM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/ikepolicies",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "NRvuezUVg0gU4CIZkWHnMhIYXx8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/ipsecpolicies",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "RnSw4UFgNNxmOuobe7c0GxGWwKM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/services",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "4H6GsYh9zKxk8Z/Gs8NdMtMCVvQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/siteconnections",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "MjflHgd/Zq1cs8MRCPG+of5FGVs=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/networks",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "sD5ZxU4ikiAs/rXwtedSu5jm1yw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/ports",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "3Y+x/QZYUvpoDeARw3UYVcYeYHM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "v0EdYYIyrzR6j8tAiVkl2AQzmao=",
 			"path": "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "X231/CMtP5XQTvQmkcsaGuKrGms=",
 			"path": "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "RswTYBtPwd1KE8EpLpHhsvO1Jtw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "aODoF15ZwA4XJOWciguaAJRq/6o=",
 			"path": "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/swauth",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "nkRXTSQyEk7yy+4u4/yC1kdvpaE=",
 			"path": "github.com/gophercloud/gophercloud/openstack/utils",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "/Wkc4WKxF/P87dOmUh5XUXcfmz8=",
 			"path": "github.com/gophercloud/gophercloud/pagination",
-			"revision": "bfc006765209a570e9a783bd7e4372e24fb72781",
-			"revisionTime": "2018-09-28T22:43:55Z"
+			"revision": "546f1f72e004a4406b2b1e8e3af9fdf0a1874b71",
+			"revisionTime": "2018-10-06T17:00:26Z"
 		},
 		{
 			"checksumSHA1": "eNZBK2/EosbOp40tcw2iu1lkdXM=",


### PR DESCRIPTION
This fixes a bug where older OpenStack releases (pre-Mitaka) do not support the `description` field in security group rules.

I've added the `description` field to the acceptance tests, though it doesn't help detect regression since Mitaka is the oldest release we test with. However, by looking at the debug output, you can see that the Gophercloud patch fixes the problem.

Before:

```
2018/10/06 17:13:45 [DEBUG] OpenStack Request Body: {          
  "security_group_rule": {                                     
    "description": "",                                         
    "direction": "ingress",                                    
    "ethertype": "IPv4",                                       
    "port_range_max": 80,                                      
    "port_range_min": 80,                                      
    "protocol": "tcp",                                         
    "remote_group_id": "7248f470-9aab-489c-a69e-72a292b8d986", 
    "security_group_id": "d984597f-735f-4ac8-be77-61cfa4f65314"
  }                                                            
}                                                              
```


After:

```
2018/10/06 17:09:20 [DEBUG] OpenStack Request Body: {          
  "security_group_rule": {                                     
    "direction": "ingress",                                    
    "ethertype": "IPv4",                                       
    "port_range_max": 80,                                      
    "port_range_min": 80,                                      
    "protocol": "tcp",                                         
    "remote_group_id": "bd2efb6e-fd45-44f1-a4c5-de08eac204c0", 
    "security_group_id": "a971c943-6436-46b1-88e9-74bb56725486"
  }                                                            
}                                                              
```

For #437 