### PR TITLE
Updated app deprecated resources.

### DIFF
--- a/examples/app-with-networking/README.md
+++ b/examples/app-with-networking/README.md
@@ -24,7 +24,6 @@ Afterwards run with a command like this:
 
 ```
 terraform apply \
-  -var 'external_gateway=fd21df30-693b-496a-ac69-8637b9c24cd3' \
   -var 'pool=public'
 ```
 

--- a/examples/app-with-networking/datasources.tf
+++ b/examples/app-with-networking/datasources.tf
@@ -1,0 +1,3 @@
+data "openstack_networking_network_v2" "terraform" {
+  name = "${var.pool}"
+}

--- a/examples/app-with-networking/outputs.tf
+++ b/examples/app-with-networking/outputs.tf
@@ -1,3 +1,3 @@
 output "address" {
-  value = "${openstack_compute_floatingip_v2.terraform.address}"
+  value = "${openstack_networking_floatingip_v2.terraform.address}"
 }

--- a/examples/app-with-networking/variables.tf
+++ b/examples/app-with-networking/variables.tf
@@ -7,14 +7,12 @@ variable "flavor" {
 }
 
 variable "ssh_key_file" {
-  default = "~/.ssh/id_rsa.terraform"
+  default = "~/.ssh/id_rsa"
 }
 
 variable "ssh_user_name" {
   default = "ubuntu"
 }
-
-variable "external_gateway" {}
 
 variable "pool" {
   default = "public"


### PR DESCRIPTION
- Used the `openstack_networking_network_v2` data source to get the ID of `external_gateway`.

- Updated secgroup to use `openstack_networking_secgroup_v2`

- Updated floatingip to use `openstack_networking_floatingip_v2`

- Removed `external_gateway` from  vars and README
