### PR TITLE
Compute v2: Enable Multiattach Volumes

### DIFF
--- a/openstack/resource_openstack_compute_volume_attach_v2.go
+++ b/openstack/resource_openstack_compute_volume_attach_v2.go
@@ -52,6 +52,12 @@ func resourceComputeVolumeAttachV2() *schema.Resource {
 				Computed: true,
 				Optional: true,
 			},
+
+			"multiattach": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -77,6 +83,10 @@ func resourceComputeVolumeAttachV2Create(d *schema.ResourceData, meta interface{
 	}
 
 	log.Printf("[DEBUG] Creating volume attachment: %#v", attachOpts)
+
+	if v := d.Get("multiattach").(bool); v {
+		computeClient.Microversion = "2.60"
+	}
 
 	attachment, err := volumeattach.Create(computeClient, instanceId, attachOpts).Extract()
 	if err != nil {

--- a/website/docs/r/compute_volume_attach_v2.html.markdown
+++ b/website/docs/r/compute_volume_attach_v2.html.markdown
@@ -93,6 +93,45 @@ output "volume devices" {
 }
 ```
 
+### Using Multiattach-enabled volumes
+
+Multiattach Volumes are dependent upon your OpenStack cloud and not all
+clouds support multiattach.
+
+```hcl
+resource "openstack_blockstorage_volume_v3" "volume_1" {
+  name        = "volume_1"
+  size        = 1
+  multiattach = true
+}
+
+resource "openstack_compute_instance_v2" "instance_1" {
+  name            = "instance_1"
+  security_groups = ["default"]
+}
+
+resource "openstack_compute_instance_v2" "instance_2" {
+  name            = "instance_2"
+  security_groups = ["default"]
+}
+
+resource "openstack_compute_volume_attach_v2" "va_1" {
+  instance_id = "${openstack_compute_instance_v2.instance_1.id}"
+  volume_id   = "${openstack_blockstorage_volume_v2.volume_1.id}"
+  multiattach = true
+}
+
+resource "openstack_compute_volume_attach_v2" "va_2" {
+  instance_id = "${openstack_compute_instance_v2.instance_2.id}"
+  volume_id   = "${openstack_blockstorage_volume_v2.volume_1.id}"
+  multiattach = true
+
+  depends_on  = ["openstack_compute_volume_attach_v2.va_1"]
+}
+```
+
+It is recommended to use `depends_on` for the attach resources
+to enforce the volume attachments to happen one at a time.
 
 ## Argument Reference
 
@@ -114,6 +153,8 @@ The following arguments are supported:
   to update the device upon subsequent applying which will cause the volume
   to be detached and reattached indefinitely. Please use with caution.
 
+* `multiattach` - (Optional) Enable attachment of multiattach-capable volumes.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -124,6 +165,7 @@ The following attributes are exported:
 * `device` - See Argument Reference above. _NOTE_: The correctness of this
   information is dependent upon the hypervisor in use. In some cases, this
   should not be used as an authoritative piece of information.
+* `multiattach` - See Argument Reference above.
 
 ## Import
 


### PR DESCRIPTION
This commit allows instances to attach multiattach volumes
by adding a new argument called "multiattach". When set, the
compute client will use Microversion 2.60, which enables multiattach
support in the Compute/Nova API.

For #432 

@jamesmmccarthy I'm unable to test multiattach volumes at the moment, so I'm not sure if this works. Would you be able to give it a try? I've updated the documentation to include an example implementation, though I'm not sure if it's correct.