### PR TITLE
Allow to specify flavor access for tenants

### DIFF
--- a/openstack/import_openstack_compute_flavor_access_v2_test.go
+++ b/openstack/import_openstack_compute_flavor_access_v2_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccComputeV2FloatingIPAssociate_importBasic(t *testing.T) {
+func TestAccComputeV2FlavorAccess_importBasic(t *testing.T) {
 	resourceName := "openstack_compute_flavor_access_v2.access_1"
 
 	flavorName := fmt.Sprintf("ACCPTTEST-%s", acctest.RandString(5))

--- a/openstack/import_openstack_compute_flavor_access_v2_test.go
+++ b/openstack/import_openstack_compute_flavor_access_v2_test.go
@@ -1,0 +1,33 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccComputeV2FloatingIPAssociate_importBasic(t *testing.T) {
+	resourceName := "openstack_compute_flavor_access_v2.access_1"
+
+	flavorName := fmt.Sprintf("ACCPTTEST-%s", acctest.RandString(5))
+	projectName := fmt.Sprintf("ACCPTTEST-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2FlavorAccessDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeV2FlavorAccess_basic(flavorName, projectName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/openstack/import_openstack_compute_flavor_access_v2_test.go
+++ b/openstack/import_openstack_compute_flavor_access_v2_test.go
@@ -15,7 +15,10 @@ func TestAccComputeV2FlavorAccess_importBasic(t *testing.T) {
 	projectName := fmt.Sprintf("ACCPTTEST-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckComputeV2FlavorAccessDestroy,
 		Steps: []resource.TestStep{

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -212,6 +212,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_blockstorage_volume_attach_v2":      resourceBlockStorageVolumeAttachV2(),
 			"openstack_blockstorage_volume_attach_v3":      resourceBlockStorageVolumeAttachV3(),
 			"openstack_compute_flavor_v2":                  resourceComputeFlavorV2(),
+			"openstack_compute_flavor_access_v2":           resourceComputeFlavorAccessV2(),
 			"openstack_compute_instance_v2":                resourceComputeInstanceV2(),
 			"openstack_compute_keypair_v2":                 resourceComputeKeypairV2(),
 			"openstack_compute_secgroup_v2":                resourceComputeSecGroupV2(),

--- a/openstack/resource_openstack_compute_flavor_access_v2.go
+++ b/openstack/resource_openstack_compute_flavor_access_v2.go
@@ -77,7 +77,7 @@ func resourceComputeFlavorAccessV2Read(d *schema.ResourceData, meta interface{})
 
 	flavorAccess, err := getFlavorAccess(computeClient, d)
 	if err != nil {
-		return fmt.Errorf("Error getting flavor access: %s", err)
+		return CheckDeleted(d, err, "Error getting flavor access")
 	}
 
 	d.Set("region", GetRegion(d, config))

--- a/openstack/resource_openstack_compute_flavor_access_v2.go
+++ b/openstack/resource_openstack_compute_flavor_access_v2.go
@@ -33,7 +33,6 @@ func resourceComputeFlavorAccessV2() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-
 			"tenant_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,

--- a/openstack/resource_openstack_compute_flavor_access_v2.go
+++ b/openstack/resource_openstack_compute_flavor_access_v2.go
@@ -94,16 +94,16 @@ func resourceComputeFlavorAccessV2Delete(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
 
-	fa, err := getFlavorAccess(computeClient, d)
+	flavorAccess, err := getFlavorAccess(computeClient, d)
 	if err != nil {
 		return fmt.Errorf("Error getting flavor access: %s", err)
 	}
 
-	removeAccessOpts := flavors.RemoveAccessOpts{Tenant: fa.TenantID}
+	removeAccessOpts := flavors.RemoveAccessOpts{Tenant: flavorAccess.TenantID}
 	log.Printf("[DEBUG] RemoveAccess Options: %#v", removeAccessOpts)
 
-	if _, err := flavors.RemoveAccess(computeClient, fa.FlavorID, removeAccessOpts).Extract(); err != nil {
-		return fmt.Errorf("Error remove tenant %s access from flavor %s: %s", fa.TenantID, fa.FlavorID, err)
+	if _, err := flavors.RemoveAccess(computeClient, flavorAccess.FlavorID, removeAccessOpts).Extract(); err != nil {
+		return fmt.Errorf("Error remove tenant %s access from flavor %s: %s", flavorAccess.TenantID, flavorAccess.FlavorID, err)
 	}
 
 	return nil

--- a/openstack/resource_openstack_compute_flavor_access_v2.go
+++ b/openstack/resource_openstack_compute_flavor_access_v2.go
@@ -1,0 +1,149 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+func resourceComputeFlavorAccessV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceComputeFlavorAccessV2Create,
+		Read:   resourceComputeFlavorAccessV2Read,
+		Delete: resourceComputeFlavorAccessV2Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"flavor_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"tenant_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceComputeFlavorAccessV2Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+
+	flavorID := d.Get("flavor_id").(string)
+	tenantID := d.Get("tenant_id").(string)
+
+	accessOpts := flavors.AddAccessOpts{
+		Tenant: tenantID,
+	}
+	log.Printf("[DEBUG] Flavor Access Options: %#v", accessOpts)
+
+	if _, err := flavors.AddAccess(computeClient, flavorID, accessOpts).Extract(); err != nil {
+		return fmt.Errorf("Error adding access to tenant %s for flavor %s: %s", tenantID, flavorID, err)
+	}
+
+	id := fmt.Sprintf("%s/%s", flavorID, tenantID)
+	d.SetId(id)
+
+	return resourceComputeFlavorAccessV2Read(d, meta)
+}
+
+func resourceComputeFlavorAccessV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+
+	flavorAccess, err := getFlavorAccess(computeClient, d)
+	if err != nil {
+		return fmt.Errorf("Error getting flavor access: %s", err)
+	}
+
+	d.Set("region", GetRegion(d, config))
+	d.Set("flavor_id", flavorAccess.FlavorID)
+	d.Set("tenant_id", flavorAccess.TenantID)
+
+	return nil
+}
+
+func resourceComputeFlavorAccessV2Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+
+	fa, err := getFlavorAccess(computeClient, d)
+	if err != nil {
+		return fmt.Errorf("Error getting flavor access: %s", err)
+	}
+
+	removeAccessOpts := flavors.RemoveAccessOpts{Tenant: fa.TenantID}
+	log.Printf("[DEBUG] RemoveAccess Options: %#v", removeAccessOpts)
+
+	if _, err := flavors.RemoveAccess(computeClient, fa.FlavorID, removeAccessOpts).Extract(); err != nil {
+		return fmt.Errorf("Error remove tenant %s access from flavor %s: %s", fa.TenantID, fa.FlavorID, err)
+	}
+
+	return nil
+}
+
+func parseComputeFlavorAccessId(id string) (string, string, error) {
+	idParts := strings.Split(id, "/")
+	if len(idParts) < 2 {
+		return "", "", fmt.Errorf("Unable to determine flavor access ID")
+	}
+
+	flavorID := idParts[0]
+	tenantID := idParts[1]
+
+	return flavorID, tenantID, nil
+}
+
+func getFlavorAccess(computeClient *gophercloud.ServiceClient, d *schema.ResourceData) (flavors.FlavorAccess, error) {
+	var access flavors.FlavorAccess
+	flavorID, tenantID, err := parseComputeFlavorAccessId(d.Id())
+	if err != nil {
+		return access, err
+	}
+
+	pager := flavors.ListAccesses(computeClient, flavorID)
+	err = pager.EachPage(func(page pagination.Page) (bool, error) {
+		accessList, err := flavors.ExtractAccesses(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, a := range accessList {
+			if a.TenantID == tenantID && a.FlavorID == flavorID {
+				access = a
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+
+	return access, err
+}

--- a/openstack/resource_openstack_compute_flavor_access_v2.go
+++ b/openstack/resource_openstack_compute_flavor_access_v2.go
@@ -103,7 +103,7 @@ func resourceComputeFlavorAccessV2Delete(d *schema.ResourceData, meta interface{
 	log.Printf("[DEBUG] RemoveAccess Options: %#v", removeAccessOpts)
 
 	if _, err := flavors.RemoveAccess(computeClient, flavorAccess.FlavorID, removeAccessOpts).Extract(); err != nil {
-		return fmt.Errorf("Error remove tenant %s access from flavor %s: %s", flavorAccess.TenantID, flavorAccess.FlavorID, err)
+		return fmt.Errorf("Error removing tenant %s access from flavor %s: %s", flavorAccess.TenantID, flavorAccess.FlavorID, err)
 	}
 
 	return nil

--- a/openstack/resource_openstack_compute_flavor_access_v2_test.go
+++ b/openstack/resource_openstack_compute_flavor_access_v2_test.go
@@ -1,0 +1,153 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
+	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccComputeV2FlavorAccess_basic(t *testing.T) {
+	var flavor flavors.Flavor
+	var flavorName = fmt.Sprintf("ACCPTTEST-%s", acctest.RandString(5))
+
+	var project projects.Project
+	var projectName = fmt.Sprintf("ACCPTTEST-%s", acctest.RandString(5))
+
+	var flavorAccess flavors.FlavorAccess
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2FlavorAccessDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeV2FlavorAccess_basic(flavorName, projectName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityV3ProjectExists("openstack_identity_project_v3.project_1", &project),
+					testAccCheckComputeV2FlavorExists("openstack_compute_flavor_v2.flavor_1", &flavor),
+					testAccCheckComputeV2FlavorAccessExists("openstack_compute_flavor_access_v2.access_1", &flavorAccess),
+					resource.TestCheckResourceAttr(
+						"openstack_compute_flavor_access_v2.access_1", "flavor_id", flavor.ID),
+					resource.TestCheckResourceAttr(
+						"openstack_compute_flavor_access_v2.access_1", "tenant_id", project.ID),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckComputeV2FlavorAccessDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	computeClient, err := config.computeV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "openstack_compute_flavor_access_v2" {
+			continue
+		}
+
+		fid, tid, err := parseComputeFlavorAccessId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		pager := flavors.ListAccesses(computeClient, fid)
+		err = pager.EachPage(func(page pagination.Page) (bool, error) {
+			accessList, err := flavors.ExtractAccesses(page)
+			if err != nil {
+				return false, err
+			}
+
+			for _, a := range accessList {
+				if a.TenantID == tid {
+					return false, fmt.Errorf("Flavor Access still exists")
+				}
+			}
+
+			return true, nil
+		})
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckComputeV2FlavorAccessExists(n string, access *flavors.FlavorAccess) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		computeClient, err := config.computeV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+		}
+
+		fid, tid, err := parseComputeFlavorAccessId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		pager := flavors.ListAccesses(computeClient, fid)
+		err = pager.EachPage(func(page pagination.Page) (bool, error) {
+			accessList, err := flavors.ExtractAccesses(page)
+			if err != nil {
+				return false, err
+			}
+
+			for _, a := range accessList {
+				if a.TenantID == tid {
+					access = &a
+					return false, nil
+				}
+			}
+
+			return true, nil
+		})
+
+		return err
+	}
+}
+
+func testAccComputeV2FlavorAccess_basic(flavorName, tenantName string) string {
+	return fmt.Sprintf(`
+    resource "openstack_compute_flavor_v2" "flavor_1" {
+      name = "%s"
+      ram = 512
+      vcpus = 1
+      disk = 5
+
+      is_public = false
+    }
+
+    resource "openstack_identity_project_v3" "tenant_1" {
+      name = "%s"
+    }
+
+
+    resource "openstack_compute_flavor_access_v2" "access_1" {
+      flavor_id = "${openstack_compute_flavor_v2.flavor_1.id}"
+      tenant_id = "${openstack_identity_project_v3.tenant_1.id}"
+    }
+    `, flavorName, tenantName)
+}

--- a/openstack/resource_openstack_compute_flavor_access_v2_test.go
+++ b/openstack/resource_openstack_compute_flavor_access_v2_test.go
@@ -35,10 +35,10 @@ func TestAccComputeV2FlavorAccess_basic(t *testing.T) {
 					testAccCheckIdentityV3ProjectExists("openstack_identity_project_v3.project_1", &project),
 					testAccCheckComputeV2FlavorExists("openstack_compute_flavor_v2.flavor_1", &flavor),
 					testAccCheckComputeV2FlavorAccessExists("openstack_compute_flavor_access_v2.access_1", &flavorAccess),
-					resource.TestCheckResourceAttr(
-						"openstack_compute_flavor_access_v2.access_1", "flavor_id", flavor.ID),
-					resource.TestCheckResourceAttr(
-						"openstack_compute_flavor_access_v2.access_1", "tenant_id", project.ID),
+					resource.TestCheckResourceAttrPtr(
+						"openstack_compute_flavor_access_v2.access_1", "flavor_id", &flavor.ID),
+					resource.TestCheckResourceAttrPtr(
+						"openstack_compute_flavor_access_v2.access_1", "tenant_id", &project.ID),
 				),
 			},
 		},

--- a/openstack/resource_openstack_compute_flavor_access_v2_test.go
+++ b/openstack/resource_openstack_compute_flavor_access_v2_test.go
@@ -144,13 +144,13 @@ func testAccComputeV2FlavorAccess_basic(flavorName, tenantName string) string {
       is_public = false
     }
 
-    resource "openstack_identity_project_v3" "tenant_1" {
+    resource "openstack_identity_project_v3" "project_1" {
       name = "%s"
     }
 
     resource "openstack_compute_flavor_access_v2" "access_1" {
       flavor_id = "${openstack_compute_flavor_v2.flavor_1.id}"
-      tenant_id = "${openstack_identity_project_v3.tenant_1.id}"
+      tenant_id = "${openstack_identity_project_v3.project_1.id}"
     }
     `, flavorName, tenantName)
 }

--- a/openstack/resource_openstack_compute_flavor_access_v2_test.go
+++ b/openstack/resource_openstack_compute_flavor_access_v2_test.go
@@ -144,7 +144,6 @@ func testAccComputeV2FlavorAccess_basic(flavorName, tenantName string) string {
       name = "%s"
     }
 
-
     resource "openstack_compute_flavor_access_v2" "access_1" {
       flavor_id = "${openstack_compute_flavor_v2.flavor_1.id}"
       tenant_id = "${openstack_identity_project_v3.tenant_1.id}"

--- a/openstack/resource_openstack_compute_flavor_access_v2_test.go
+++ b/openstack/resource_openstack_compute_flavor_access_v2_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	"github.com/gophercloud/gophercloud/pagination"
@@ -79,6 +80,9 @@ func testAccCheckComputeV2FlavorAccessDestroy(s *terraform.State) error {
 		})
 
 		if err != nil {
+			if _, ok := err.(gophercloud.ErrDefault404); ok {
+				return nil
+			}
 			return err
 		}
 	}

--- a/website/docs/r/compute_flavor_access_v2.html.markdown
+++ b/website/docs/r/compute_flavor_access_v2.html.markdown
@@ -56,3 +56,12 @@ The following attributes are exported:
 * `region` - See Argument Reference above.
 * `flavor_id` - See Argument Reference above.
 * `tenant_id` - See Argument Reference above.
+
+## Import
+
+This resource can be imported by specifying all two arguments, separated
+by a forward slash:
+
+```
+$ terraform import openstack_compute_flavor_access_v2.access_1 <flavor_id>/<tenant_id>
+```

--- a/website/docs/r/compute_flavor_access_v2.html.markdown
+++ b/website/docs/r/compute_flavor_access_v2.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_compute_flavor_access_v2"
+sidebar_current: "docs-openstack-resource-compute-flavor-access-v2"
+description: |-
+  Manages a project access for flavor V2 resource within OpenStack.
+---
+
+# openstack\_compute\_flavor\_access_v2
+
+Manages a project access for flavor V2 resource within OpenStack.
+
+Note: You _must_ have admin privileges in your OpenStack cloud to use
+this resource.
+
+---
+
+## Example Usage
+
+```hcl
+resource "openstack_identity_project_v3" "test_project" {
+  name = "my-project"
+}
+
+resource "openstack_compute_flavor_v2" "test_flavor" {
+  name  = "my-flavor"
+  ram   = "8096"
+  vcpus = "2"
+  disk  = "20"
+  is_public = false
+}
+
+resource "openstack_compute_flavor_access_v2" "test_project_test_flavor_access" {
+  tenant_id = "${openstack_identity_project_v3.test_project.id}"
+  flavor_id = "${openstack_compute_flavor_v2.test_flavor.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional) The region in which to obtain the V2 Compute client.
+    If omitted, the `region` argument of the provider is used.
+    Changing this creates a new flavor access.
+
+* `flavor_id` - (Required) The UUID of flavor to use. Changing this creates a new flavor access.
+
+* `tenant_id` - (Required) The UUID of tenant which is allowed to use the flavor.
+    Changing this creates a new flavor access.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `flavor_id` - See Argument Reference above.
+* `tenant_id` - See Argument Reference above.

--- a/website/docs/r/compute_flavor_access_v2.html.markdown
+++ b/website/docs/r/compute_flavor_access_v2.html.markdown
@@ -18,11 +18,11 @@ this resource.
 ## Example Usage
 
 ```hcl
-resource "openstack_identity_project_v3" "test_project" {
+resource "openstack_identity_project_v3" "project_1" {
   name = "my-project"
 }
 
-resource "openstack_compute_flavor_v2" "test_flavor" {
+resource "openstack_compute_flavor_v2" "flavor_1" {
   name  = "my-flavor"
   ram   = "8096"
   vcpus = "2"
@@ -30,9 +30,9 @@ resource "openstack_compute_flavor_v2" "test_flavor" {
   is_public = false
 }
 
-resource "openstack_compute_flavor_access_v2" "test_project_test_flavor_access" {
-  tenant_id = "${openstack_identity_project_v3.test_project.id}"
-  flavor_id = "${openstack_compute_flavor_v2.test_flavor.id}"
+resource "openstack_compute_flavor_access_v2" "access_1" {
+  tenant_id = "${openstack_identity_project_v3.project_1.id}"
+  flavor_id = "${openstack_compute_flavor_v2.flavor_1.id}"
 }
 ```
 

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -97,6 +97,9 @@
             <li<%= sidebar_current("docs-openstack-resource-compute-flavor-v2") %>>
               <a href="/docs/providers/openstack/r/compute_flavor_v2.html">openstack_compute_flavor_v2</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-resource-compute-flavor-access-v2") %>>
+              <a href="/docs/providers/openstack/r/compute_flavor_access_v2.html">openstack_compute_flavor_access_v2</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-resource-compute-floatingip-v2") %>>
               <a href="/docs/providers/openstack/r/compute_floatingip_v2.html">openstack_compute_floatingip_v2</a>
             </li>


### PR DESCRIPTION
This PR adds `access` attribute to flavor resource. `access` contains list of tenant ids that are allowed to use flavor.

EDIT: create `openstack_compute_flavor_access_v2` instead of access list in flavor resource.