### PR TITLE
Block Storage Snapshot Data Sources

### DIFF
--- a/openstack/data_source_openstack_blockstorage_snapshot_v2.go
+++ b/openstack/data_source_openstack_blockstorage_snapshot_v2.go
@@ -1,0 +1,132 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+	"sort"
+
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceBlockStorageSnapshotV2() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceBlockStorageSnapshotV2Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"status": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"volume_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"most_recent": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			// Computed values
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"size": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"metadata": &schema.Schema{
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceBlockStorageSnapshotV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	client, err := config.blockStorageV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
+	}
+
+	listOpts := snapshots.ListOpts{
+		Name:     d.Get("name").(string),
+		Status:   d.Get("status").(string),
+		VolumeID: d.Get("volume_id").(string),
+	}
+
+	allPages, err := snapshots.List(client, listOpts).AllPages()
+	if err != nil {
+		return fmt.Errorf("Unable to query snapshots: %s", err)
+	}
+
+	allSnapshots, err := snapshots.ExtractSnapshots(allPages)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve snapshots: %s", err)
+	}
+
+	if len(allSnapshots) < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	var snapshot snapshots.Snapshot
+	if len(allSnapshots) > 1 {
+		recent := d.Get("most_recent").(bool)
+		log.Printf("[DEBUG] Multiple results found and `most_recent` is set to: %t", recent)
+
+		if recent {
+			snapshot = dataSourceBlockStorageV2MostRecentSnapshot(allSnapshots)
+		} else {
+			log.Printf("[DEBUG] Multiple results found: %#v", allSnapshots)
+			return fmt.Errorf("Your query returned more than one result. Please try a more " +
+				"specific search criteria, or set `most_recent` attribute to true.")
+		}
+	} else {
+		snapshot = allSnapshots[0]
+	}
+
+	return dataSourceBlockStorageSnapshotV2Attributes(d, snapshot)
+}
+
+func dataSourceBlockStorageSnapshotV2Attributes(d *schema.ResourceData, snapshot snapshots.Snapshot) error {
+
+	d.SetId(snapshot.ID)
+	d.Set("name", snapshot.Name)
+	d.Set("description", snapshot.Description)
+	d.Set("size", snapshot.Size)
+	d.Set("status", snapshot.Status)
+	d.Set("volume_id", snapshot.VolumeID)
+
+	if err := d.Set("metadata", snapshot.Metadata); err != nil {
+		log.Printf("[DEBUG] Unable to set metadata for snapshot %s: %s", snapshot.ID, err)
+	}
+
+	return nil
+}
+
+func dataSourceBlockStorageV2MostRecentSnapshot(snapshots []snapshots.Snapshot) snapshots.Snapshot {
+	sortedSnapshots := snapshots
+	sort.Sort(blockStorageV2SnapshotSort(sortedSnapshots))
+	return sortedSnapshots[len(sortedSnapshots)-1]
+}

--- a/openstack/data_source_openstack_blockstorage_snapshot_v2_test.go
+++ b/openstack/data_source_openstack_blockstorage_snapshot_v2_test.go
@@ -1,0 +1,149 @@
+package openstack
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
+)
+
+func TestAccBlockStorageV2SnapshotDataSource_basic(t *testing.T) {
+	resourceName := "data.openstack_blockstorage_snapshot_v2.snapshot_1"
+	volumeName := acctest.RandomWithPrefix("tf-acc-volume")
+	snapshotName := acctest.RandomWithPrefix("tf-acc-snapshot")
+
+	var volumeID, snapshotID string
+	if os.Getenv("TF_ACC") != "" {
+		var err error
+		volumeID, snapshotID, err = testAccBlockStorageV2CreateVolumeAndSnapshot(volumeName, snapshotName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer testAccBlockStorageV2DeleteVolumeAndSnapshot(t, volumeID, snapshotID)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccBlockStorageV2SnapshotDataSource_basic(snapshotName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBlockStorageV2SnapshotDataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", snapshotName),
+					resource.TestCheckResourceAttr(resourceName, "volume_id", volumeID),
+				),
+			},
+		},
+	})
+}
+
+func testAccBlockStorageV2CreateVolumeAndSnapshot(volumeName, snapshotName string) (string, string, error) {
+	config, err := testAccAuthFromEnv()
+	if err != nil {
+		return "", "", err
+	}
+
+	bsClient, err := config.blockStorageV2Client(OS_REGION_NAME)
+	if err != nil {
+		return "", "", err
+	}
+
+	volCreateOpts := volumes.CreateOpts{
+		Size: 1,
+		Name: volumeName,
+	}
+
+	volume, err := volumes.Create(bsClient, volCreateOpts).Extract()
+	if err != nil {
+		return "", "", err
+	}
+
+	err = volumes.WaitForStatus(bsClient, volume.ID, "available", 60)
+	if err != nil {
+		return "", "", err
+	}
+
+	snapCreateOpts := snapshots.CreateOpts{
+		VolumeID: volume.ID,
+		Name:     snapshotName,
+	}
+
+	snapshot, err := snapshots.Create(bsClient, snapCreateOpts).Extract()
+	if err != nil {
+		return volume.ID, "", err
+	}
+
+	err = snapshots.WaitForStatus(bsClient, snapshot.ID, "available", 60)
+	if err != nil {
+		return volume.ID, "", err
+	}
+
+	return volume.ID, snapshot.ID, nil
+}
+
+func testAccBlockStorageV2DeleteVolumeAndSnapshot(t *testing.T, volumeID, snapshotID string) {
+	config, err := testAccAuthFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bsClient, err := config.blockStorageV2Client(OS_REGION_NAME)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = snapshots.Delete(bsClient, snapshotID).ExtractErr()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = snapshots.WaitForStatus(bsClient, snapshotID, "DELETED", 60)
+	if err != nil {
+		if _, ok := err.(gophercloud.ErrDefault404); !ok {
+			t.Fatal(err)
+		}
+	}
+
+	err = volumes.Delete(bsClient, volumeID).ExtractErr()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = volumes.WaitForStatus(bsClient, volumeID, "DELETED", 60)
+	if err != nil {
+		if _, ok := err.(gophercloud.ErrDefault404); !ok {
+			t.Fatal(err)
+		}
+	}
+}
+
+func testAccCheckBlockStorageV2SnapshotDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find snapshot data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Snapshot data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccBlockStorageV2SnapshotDataSource_basic(snapshotName string) string {
+	return fmt.Sprintf(`
+    data "openstack_blockstorage_snapshot_v2" "snapshot_1" {
+      name = "%s"
+    }
+  `, snapshotName)
+}

--- a/openstack/data_source_openstack_blockstorage_snapshot_v2_test.go
+++ b/openstack/data_source_openstack_blockstorage_snapshot_v2_test.go
@@ -112,7 +112,7 @@ func testAccBlockStorageV2DeleteVolumeAndSnapshot(t *testing.T, volumeID, snapsh
 		}
 	}
 
-	err = volumes.Delete(bsClient, volumeID).ExtractErr()
+	err = volumes.Delete(bsClient, volumeID, nil).ExtractErr()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/openstack/data_source_openstack_blockstorage_snapshot_v3.go
+++ b/openstack/data_source_openstack_blockstorage_snapshot_v3.go
@@ -1,0 +1,132 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+	"sort"
+
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceBlockStorageSnapshotV3() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceBlockStorageSnapshotV3Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"status": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"volume_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"most_recent": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			// Computed values
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"size": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"metadata": &schema.Schema{
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceBlockStorageSnapshotV3Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	client, err := config.blockStorageV3Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
+	}
+
+	listOpts := snapshots.ListOpts{
+		Name:     d.Get("name").(string),
+		Status:   d.Get("status").(string),
+		VolumeID: d.Get("volume_id").(string),
+	}
+
+	allPages, err := snapshots.List(client, listOpts).AllPages()
+	if err != nil {
+		return fmt.Errorf("Unable to query snapshots: %s", err)
+	}
+
+	allSnapshots, err := snapshots.ExtractSnapshots(allPages)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve snapshots: %s", err)
+	}
+
+	if len(allSnapshots) < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	var snapshot snapshots.Snapshot
+	if len(allSnapshots) > 1 {
+		recent := d.Get("most_recent").(bool)
+		log.Printf("[DEBUG] Multiple results found and `most_recent` is set to: %t", recent)
+
+		if recent {
+			snapshot = dataSourceBlockStorageV3MostRecentSnapshot(allSnapshots)
+		} else {
+			log.Printf("[DEBUG] Multiple results found: %#v", allSnapshots)
+			return fmt.Errorf("Your query returned more than one result. Please try a more " +
+				"specific search criteria, or set `most_recent` attribute to true.")
+		}
+	} else {
+		snapshot = allSnapshots[0]
+	}
+
+	return dataSourceBlockStorageSnapshotV3Attributes(d, snapshot)
+}
+
+func dataSourceBlockStorageSnapshotV3Attributes(d *schema.ResourceData, snapshot snapshots.Snapshot) error {
+
+	d.SetId(snapshot.ID)
+	d.Set("name", snapshot.Name)
+	d.Set("description", snapshot.Description)
+	d.Set("size", snapshot.Size)
+	d.Set("status", snapshot.Status)
+	d.Set("volume_id", snapshot.VolumeID)
+
+	if err := d.Set("metadata", snapshot.Metadata); err != nil {
+		log.Printf("[DEBUG] Unable to set metadata for snapshot %s: %s", snapshot.ID, err)
+	}
+
+	return nil
+}
+
+func dataSourceBlockStorageV3MostRecentSnapshot(snapshots []snapshots.Snapshot) snapshots.Snapshot {
+	sortedSnapshots := snapshots
+	sort.Sort(blockStorageV3SnapshotSort(sortedSnapshots))
+	return sortedSnapshots[len(sortedSnapshots)-1]
+}

--- a/openstack/data_source_openstack_blockstorage_snapshot_v3_test.go
+++ b/openstack/data_source_openstack_blockstorage_snapshot_v3_test.go
@@ -1,0 +1,149 @@
+package openstack
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
+)
+
+func TestAccBlockStorageV3SnapshotDataSource_basic(t *testing.T) {
+	resourceName := "data.openstack_blockstorage_snapshot_v3.snapshot_1"
+	volumeName := acctest.RandomWithPrefix("tf-acc-volume")
+	snapshotName := acctest.RandomWithPrefix("tf-acc-snapshot")
+
+	var volumeID, snapshotID string
+	if os.Getenv("TF_ACC") != "" {
+		var err error
+		volumeID, snapshotID, err = testAccBlockStorageV3CreateVolumeAndSnapshot(volumeName, snapshotName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer testAccBlockStorageV3DeleteVolumeAndSnapshot(t, volumeID, snapshotID)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccBlockStorageV3SnapshotDataSource_basic(snapshotName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBlockStorageV3SnapshotDataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", snapshotName),
+					resource.TestCheckResourceAttr(resourceName, "volume_id", volumeID),
+				),
+			},
+		},
+	})
+}
+
+func testAccBlockStorageV3CreateVolumeAndSnapshot(volumeName, snapshotName string) (string, string, error) {
+	config, err := testAccAuthFromEnv()
+	if err != nil {
+		return "", "", err
+	}
+
+	bsClient, err := config.blockStorageV3Client(OS_REGION_NAME)
+	if err != nil {
+		return "", "", err
+	}
+
+	volCreateOpts := volumes.CreateOpts{
+		Size: 1,
+		Name: volumeName,
+	}
+
+	volume, err := volumes.Create(bsClient, volCreateOpts).Extract()
+	if err != nil {
+		return "", "", err
+	}
+
+	err = volumes.WaitForStatus(bsClient, volume.ID, "available", 60)
+	if err != nil {
+		return "", "", err
+	}
+
+	snapCreateOpts := snapshots.CreateOpts{
+		VolumeID: volume.ID,
+		Name:     snapshotName,
+	}
+
+	snapshot, err := snapshots.Create(bsClient, snapCreateOpts).Extract()
+	if err != nil {
+		return volume.ID, "", err
+	}
+
+	err = snapshots.WaitForStatus(bsClient, snapshot.ID, "available", 60)
+	if err != nil {
+		return volume.ID, "", err
+	}
+
+	return volume.ID, snapshot.ID, nil
+}
+
+func testAccBlockStorageV3DeleteVolumeAndSnapshot(t *testing.T, volumeID, snapshotID string) {
+	config, err := testAccAuthFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bsClient, err := config.blockStorageV3Client(OS_REGION_NAME)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = snapshots.Delete(bsClient, snapshotID).ExtractErr()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = snapshots.WaitForStatus(bsClient, snapshotID, "DELETED", 60)
+	if err != nil {
+		if _, ok := err.(gophercloud.ErrDefault404); !ok {
+			t.Fatal(err)
+		}
+	}
+
+	err = volumes.Delete(bsClient, volumeID).ExtractErr()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = volumes.WaitForStatus(bsClient, volumeID, "DELETED", 60)
+	if err != nil {
+		if _, ok := err.(gophercloud.ErrDefault404); !ok {
+			t.Fatal(err)
+		}
+	}
+}
+
+func testAccCheckBlockStorageV3SnapshotDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find snapshot data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Snapshot data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccBlockStorageV3SnapshotDataSource_basic(snapshotName string) string {
+	return fmt.Sprintf(`
+    data "openstack_blockstorage_snapshot_v3" "snapshot_1" {
+      name = "%s"
+    }
+  `, snapshotName)
+}

--- a/openstack/data_source_openstack_blockstorage_snapshot_v3_test.go
+++ b/openstack/data_source_openstack_blockstorage_snapshot_v3_test.go
@@ -112,7 +112,7 @@ func testAccBlockStorageV3DeleteVolumeAndSnapshot(t *testing.T, volumeID, snapsh
 		}
 	}
 
-	err = volumes.Delete(bsClient, volumeID).ExtractErr()
+	err = volumes.Delete(bsClient, volumeID, nil).ExtractErr()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -185,6 +185,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"openstack_blockstorage_snapshot_v2":          dataSourceBlockStorageSnapshotV2(),
 			"openstack_compute_flavor_v2":                 dataSourceComputeFlavorV2(),
 			"openstack_compute_keypair_v2":                dataSourceComputeKeypairV2(),
 			"openstack_containerinfra_clustertemplate_v1": dataSourceContainerInfraClusterTemplateV1(),

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -186,6 +186,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"openstack_blockstorage_snapshot_v2":          dataSourceBlockStorageSnapshotV2(),
+			"openstack_blockstorage_snapshot_v3":          dataSourceBlockStorageSnapshotV3(),
 			"openstack_compute_flavor_v2":                 dataSourceComputeFlavorV2(),
 			"openstack_compute_keypair_v2":                dataSourceComputeKeypairV2(),
 			"openstack_containerinfra_clustertemplate_v1": dataSourceContainerInfraClusterTemplateV1(),

--- a/openstack/provider_test.go
+++ b/openstack/provider_test.go
@@ -334,3 +334,44 @@ func envVarFile(varName string) (string, error) {
 	}
 	return tmpFile.Name(), nil
 }
+
+func testAccAuthFromEnv() (*Config, error) {
+	tenantID := os.Getenv("OS_TENANT_ID")
+	if tenantID == "" {
+		tenantID = os.Getenv("OS_PROJECT_ID")
+	}
+
+	tenantName := os.Getenv("OS_TENANT_NAME")
+	if tenantName == "" {
+		tenantName = os.Getenv("OS_PROJECT_NAME")
+	}
+
+	config := Config{
+		CACertFile:        os.Getenv("OS_CACERT"),
+		ClientCertFile:    os.Getenv("OS_CERT"),
+		ClientKeyFile:     os.Getenv("OS_KEY"),
+		Cloud:             os.Getenv("OS_CLOUD"),
+		DefaultDomain:     os.Getenv("OS_DEFAULT_DOMAIN"),
+		DomainID:          os.Getenv("OS_DOMAIN_ID"),
+		DomainName:        os.Getenv("OS_DOMAIN_NAME"),
+		EndpointType:      os.Getenv("OS_ENDPOINT_TYPE"),
+		IdentityEndpoint:  os.Getenv("OS_AUTH_URL"),
+		Password:          os.Getenv("OS_PASSWORD"),
+		ProjectDomainID:   os.Getenv("OS_PROJECT_DOMAIN_ID"),
+		ProjectDomainName: os.Getenv("OS_PROJECT_DOMAIN_NAME"),
+		Region:            os.Getenv("OS_REGION"),
+		Token:             os.Getenv("OS_TOKEN"),
+		TenantID:          tenantID,
+		TenantName:        tenantName,
+		UserDomainID:      os.Getenv("OS_USER_DOMAIN_ID"),
+		UserDomainName:    os.Getenv("OS_USER_DOMAIN_NAME"),
+		Username:          os.Getenv("OS_USERNAME"),
+		UserID:            os.Getenv("OS_USER_ID"),
+	}
+
+	if err := config.LoadAndValidate(); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}

--- a/openstack/types.go
+++ b/openstack/types.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	snapshots_v2 "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots"
+	snapshots_v3 "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets"
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/zones"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls"
@@ -386,6 +387,24 @@ func (snaphot blockStorageV2SnapshotSort) Swap(i, j int) {
 }
 
 func (snaphot blockStorageV2SnapshotSort) Less(i, j int) bool {
+	itime := snaphot[i].CreatedAt
+	jtime := snaphot[j].CreatedAt
+	return itime.Unix() < jtime.Unix()
+}
+
+// blockStorageV3SnapshotSort represents a sortable slice of block storage
+// v3 snapshots.
+type blockStorageV3SnapshotSort []snapshots_v3.Snapshot
+
+func (snaphot blockStorageV3SnapshotSort) Len() int {
+	return len(snaphot)
+}
+
+func (snaphot blockStorageV3SnapshotSort) Swap(i, j int) {
+	snaphot[i], snaphot[j] = snaphot[j], snaphot[i]
+}
+
+func (snaphot blockStorageV3SnapshotSort) Less(i, j int) bool {
 	itime := snaphot[i].CreatedAt
 	jtime := snaphot[j].CreatedAt
 	return itime.Unix() < jtime.Unix()

--- a/openstack/types.go
+++ b/openstack/types.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strings"
 
+	snapshots_v2 "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots"
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets"
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/zones"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls"
@@ -370,4 +371,22 @@ type EndpointGroupCreateOpts struct {
 type SiteConnectionCreateOpts struct {
 	siteconnections.CreateOpts
 	ValueSpecs map[string]string `json:"value_specs,omitempty"`
+}
+
+// blockStorageV2SnapshotSort represents a sortable slice of block storage
+// v2 snapshots.
+type blockStorageV2SnapshotSort []snapshots_v2.Snapshot
+
+func (snaphot blockStorageV2SnapshotSort) Len() int {
+	return len(snaphot)
+}
+
+func (snaphot blockStorageV2SnapshotSort) Swap(i, j int) {
+	snaphot[i], snaphot[j] = snaphot[j], snaphot[i]
+}
+
+func (snaphot blockStorageV2SnapshotSort) Less(i, j int) bool {
+	itime := snaphot[i].CreatedAt
+	jtime := snaphot[j].CreatedAt
+	return itime.Unix() < jtime.Unix()
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots/doc.go
@@ -1,0 +1,5 @@
+// Package snapshots provides information and interaction with snapshots in the
+// OpenStack Block Storage service. A snapshot is a point in time copy of the
+// data contained in an external storage volume, and can be controlled
+// programmatically.
+package snapshots

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots/requests.go
@@ -1,0 +1,175 @@
+package snapshots
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToSnapshotCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains options for creating a Snapshot. This object is passed to
+// the snapshots.Create function. For more information about these parameters,
+// see the Snapshot object.
+type CreateOpts struct {
+	VolumeID    string            `json:"volume_id" required:"true"`
+	Force       bool              `json:"force,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// ToSnapshotCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToSnapshotCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "snapshot")
+}
+
+// Create will create a new Snapshot based on the values in CreateOpts. To
+// extract the Snapshot object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToSnapshotCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// Delete will delete the existing Snapshot with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}
+
+// Get retrieves the Snapshot with the provided ID. To extract the Snapshot
+// object from the response, call the Extract method on the GetResult.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToSnapshotListQuery() (string, error)
+}
+
+// ListOpts hold options for listing Snapshots. It is passed to the
+// snapshots.List function.
+type ListOpts struct {
+	// AllTenants will retrieve snapshots of all tenants/projects.
+	AllTenants bool `q:"all_tenants"`
+
+	// Name will filter by the specified snapshot name.
+	Name string `q:"name"`
+
+	// Status will filter by the specified status.
+	Status string `q:"status"`
+
+	// TenantID will filter by a specific tenant/project ID.
+	// Setting AllTenants is required to use this.
+	TenantID string `q:"project_id"`
+
+	// VolumeID will filter by a specified volume ID.
+	VolumeID string `q:"volume_id"`
+}
+
+// ToSnapshotListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToSnapshotListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns Snapshots optionally limited by the conditions provided in
+// ListOpts.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToSnapshotListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return SnapshotPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// UpdateMetadataOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateMetadataOptsBuilder interface {
+	ToSnapshotUpdateMetadataMap() (map[string]interface{}, error)
+}
+
+// UpdateMetadataOpts contain options for updating an existing Snapshot. This
+// object is passed to the snapshots.Update function. For more information
+// about the parameters, see the Snapshot object.
+type UpdateMetadataOpts struct {
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// ToSnapshotUpdateMetadataMap assembles a request body based on the contents of
+// an UpdateMetadataOpts.
+func (opts UpdateMetadataOpts) ToSnapshotUpdateMetadataMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// UpdateMetadata will update the Snapshot with provided information. To
+// extract the updated Snapshot from the response, call the ExtractMetadata
+// method on the UpdateMetadataResult.
+func UpdateMetadata(client *gophercloud.ServiceClient, id string, opts UpdateMetadataOptsBuilder) (r UpdateMetadataResult) {
+	b, err := opts.ToSnapshotUpdateMetadataMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateMetadataURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// IDFromName is a convienience function that returns a snapshot's ID given its name.
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractSnapshots(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "snapshot"}
+	case 1:
+		return id, nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "snapshot"}
+	}
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots/results.go
@@ -1,0 +1,120 @@
+package snapshots
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Snapshot contains all the information associated with a Cinder Snapshot.
+type Snapshot struct {
+	// Unique identifier.
+	ID string `json:"id"`
+
+	// Date created.
+	CreatedAt time.Time `json:"-"`
+
+	// Date updated.
+	UpdatedAt time.Time `json:"-"`
+
+	// Display name.
+	Name string `json:"name"`
+
+	// Display description.
+	Description string `json:"description"`
+
+	// ID of the Volume from which this Snapshot was created.
+	VolumeID string `json:"volume_id"`
+
+	// Currect status of the Snapshot.
+	Status string `json:"status"`
+
+	// Size of the Snapshot, in GB.
+	Size int `json:"size"`
+
+	// User-defined key-value pairs.
+	Metadata map[string]string `json:"metadata"`
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// SnapshotPage is a pagination.Pager that is returned from a call to the List function.
+type SnapshotPage struct {
+	pagination.SinglePageBase
+}
+
+func (r *Snapshot) UnmarshalJSON(b []byte) error {
+	type tmp Snapshot
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Snapshot(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return err
+}
+
+// IsEmpty returns true if a SnapshotPage contains no Snapshots.
+func (r SnapshotPage) IsEmpty() (bool, error) {
+	volumes, err := ExtractSnapshots(r)
+	return len(volumes) == 0, err
+}
+
+// ExtractSnapshots extracts and returns Snapshots. It is used while iterating over a snapshots.List call.
+func ExtractSnapshots(r pagination.Page) ([]Snapshot, error) {
+	var s struct {
+		Snapshots []Snapshot `json:"snapshots"`
+	}
+	err := (r.(SnapshotPage)).ExtractInto(&s)
+	return s.Snapshots, err
+}
+
+// UpdateMetadataResult contains the response body and error from an UpdateMetadata request.
+type UpdateMetadataResult struct {
+	commonResult
+}
+
+// ExtractMetadata returns the metadata from a response from snapshots.UpdateMetadata.
+func (r UpdateMetadataResult) ExtractMetadata() (map[string]interface{}, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	m := r.Body.(map[string]interface{})["metadata"]
+	return m.(map[string]interface{}), nil
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the Snapshot object out of the commonResult object.
+func (r commonResult) Extract() (*Snapshot, error) {
+	var s struct {
+		Snapshot *Snapshot `json:"snapshot"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Snapshot, err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots/urls.go
@@ -1,0 +1,27 @@
+package snapshots
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("snapshots")
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("snapshots", id)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return createURL(c)
+}
+
+func metadataURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("snapshots", id, "metadata")
+}
+
+func updateMetadataURL(c *gophercloud.ServiceClient, id string) string {
+	return metadataURL(c, id)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots/util.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots/util.go
@@ -1,0 +1,22 @@
+package snapshots
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// WaitForStatus will continually poll the resource, checking for a particular
+// status. It will do this for the amount of seconds defined.
+func WaitForStatus(c *gophercloud.ServiceClient, id, status string, secs int) error {
+	return gophercloud.WaitFor(secs, func() (bool, error) {
+		current, err := Get(c, id).Extract()
+		if err != nil {
+			return false, err
+		}
+
+		if current.Status == status {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/doc.go
@@ -1,0 +1,5 @@
+// Package snapshots provides information and interaction with snapshots in the
+// OpenStack Block Storage service. A snapshot is a point in time copy of the
+// data contained in an external storage volume, and can be controlled
+// programmatically.
+package snapshots

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/requests.go
@@ -1,0 +1,186 @@
+package snapshots
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToSnapshotCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains options for creating a Snapshot. This object is passed to
+// the snapshots.Create function. For more information about these parameters,
+// see the Snapshot object.
+type CreateOpts struct {
+	VolumeID    string            `json:"volume_id" required:"true"`
+	Force       bool              `json:"force,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// ToSnapshotCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToSnapshotCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "snapshot")
+}
+
+// Create will create a new Snapshot based on the values in CreateOpts. To
+// extract the Snapshot object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToSnapshotCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// Delete will delete the existing Snapshot with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}
+
+// Get retrieves the Snapshot with the provided ID. To extract the Snapshot
+// object from the response, call the Extract method on the GetResult.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToSnapshotListQuery() (string, error)
+}
+
+type ListOpts struct {
+	// AllTenants will retrieve snapshots of all tenants/projects.
+	AllTenants bool `q:"all_tenants"`
+
+	// Name will filter by the specified snapshot name.
+	Name string `q:"name"`
+
+	// Status will filter by the specified status.
+	Status string `q:"status"`
+
+	// TenantID will filter by a specific tenant/project ID.
+	// Setting AllTenants is required to use this.
+	TenantID string `q:"project_id"`
+
+	// VolumeID will filter by a specified volume ID.
+	VolumeID string `q:"volume_id"`
+
+	// Comma-separated list of sort keys and optional sort directions in the
+	// form of <key>[:<direction>].
+	Sort string `q:"sort"`
+
+	// Requests a page size of items.
+	Limit int `q:"limit"`
+
+	// Used in conjunction with limit to return a slice of items.
+	Offset int `q:"offset"`
+
+	// The ID of the last-seen item.
+	Marker string `q:"marker"`
+}
+
+// ToSnapshotListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToSnapshotListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns Snapshots optionally limited by the conditions provided in
+// ListOpts.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToSnapshotListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return SnapshotPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// UpdateMetadataOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateMetadataOptsBuilder interface {
+	ToSnapshotUpdateMetadataMap() (map[string]interface{}, error)
+}
+
+// UpdateMetadataOpts contain options for updating an existing Snapshot. This
+// object is passed to the snapshots.Update function. For more information
+// about the parameters, see the Snapshot object.
+type UpdateMetadataOpts struct {
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// ToSnapshotUpdateMetadataMap assembles a request body based on the contents of
+// an UpdateMetadataOpts.
+func (opts UpdateMetadataOpts) ToSnapshotUpdateMetadataMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// UpdateMetadata will update the Snapshot with provided information. To
+// extract the updated Snapshot from the response, call the ExtractMetadata
+// method on the UpdateMetadataResult.
+func UpdateMetadata(client *gophercloud.ServiceClient, id string, opts UpdateMetadataOptsBuilder) (r UpdateMetadataResult) {
+	b, err := opts.ToSnapshotUpdateMetadataMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateMetadataURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// IDFromName is a convienience function that returns a snapshot's ID given its name.
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractSnapshots(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "snapshot"}
+	case 1:
+		return id, nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "snapshot"}
+	}
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/results.go
@@ -1,0 +1,132 @@
+package snapshots
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Snapshot contains all the information associated with a Cinder Snapshot.
+type Snapshot struct {
+	// Unique identifier.
+	ID string `json:"id"`
+
+	// Date created.
+	CreatedAt time.Time `json:"-"`
+
+	// Date updated.
+	UpdatedAt time.Time `json:"-"`
+
+	// Display name.
+	Name string `json:"name"`
+
+	// Display description.
+	Description string `json:"description"`
+
+	// ID of the Volume from which this Snapshot was created.
+	VolumeID string `json:"volume_id"`
+
+	// Currect status of the Snapshot.
+	Status string `json:"status"`
+
+	// Size of the Snapshot, in GB.
+	Size int `json:"size"`
+
+	// User-defined key-value pairs.
+	Metadata map[string]string `json:"metadata"`
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// SnapshotPage is a pagination.Pager that is returned from a call to the List function.
+type SnapshotPage struct {
+	pagination.LinkedPageBase
+}
+
+// UnmarshalJSON converts our JSON API response into our snapshot struct
+func (r *Snapshot) UnmarshalJSON(b []byte) error {
+	type tmp Snapshot
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Snapshot(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return err
+}
+
+// IsEmpty returns true if a SnapshotPage contains no Snapshots.
+func (r SnapshotPage) IsEmpty() (bool, error) {
+	volumes, err := ExtractSnapshots(r)
+	return len(volumes) == 0, err
+}
+
+func (page SnapshotPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"snapshots_links"`
+	}
+	err := page.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// ExtractSnapshots extracts and returns Snapshots. It is used while iterating over a snapshots.List call.
+func ExtractSnapshots(r pagination.Page) ([]Snapshot, error) {
+	var s struct {
+		Snapshots []Snapshot `json:"snapshots"`
+	}
+	err := (r.(SnapshotPage)).ExtractInto(&s)
+	return s.Snapshots, err
+}
+
+// UpdateMetadataResult contains the response body and error from an UpdateMetadata request.
+type UpdateMetadataResult struct {
+	commonResult
+}
+
+// ExtractMetadata returns the metadata from a response from snapshots.UpdateMetadata.
+func (r UpdateMetadataResult) ExtractMetadata() (map[string]interface{}, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	m := r.Body.(map[string]interface{})["metadata"]
+	return m.(map[string]interface{}), nil
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the Snapshot object out of the commonResult object.
+func (r commonResult) Extract() (*Snapshot, error) {
+	var s struct {
+		Snapshot *Snapshot `json:"snapshot"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Snapshot, err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/urls.go
@@ -1,0 +1,27 @@
+package snapshots
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("snapshots")
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("snapshots", id)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return createURL(c)
+}
+
+func metadataURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("snapshots", id, "metadata")
+}
+
+func updateMetadataURL(c *gophercloud.ServiceClient, id string) string {
+	return metadataURL(c, id)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/util.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/util.go
@@ -1,0 +1,22 @@
+package snapshots
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// WaitForStatus will continually poll the resource, checking for a particular
+// status. It will do this for the amount of seconds defined.
+func WaitForStatus(c *gophercloud.ServiceClient, id, status string, secs int) error {
+	return gophercloud.WaitFor(secs, func() (bool, error) {
+		current, err := Get(c, id).Extract()
+		if err != nil {
+			return false, err
+		}
+
+		if current.Status == status {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -343,8 +343,20 @@
 			"revisionTime": "2018-11-14T20:47:05Z"
 		},
 		{
+			"checksumSHA1": "SDNVeLqHv7OhjKCAU0/McJUeWgo=",
+			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots",
+			"revision": "3a7818a07cfc862267a0b03635075a444c92dcda",
+			"revisionTime": "2018-11-14T20:47:05Z"
+		},
+		{
 			"checksumSHA1": "ZpRvYEfOMMeugDA7yd+QgxSApsk=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes",
+			"revision": "3a7818a07cfc862267a0b03635075a444c92dcda",
+			"revisionTime": "2018-11-14T20:47:05Z"
+		},
+		{
+			"checksumSHA1": "vw46Q7Z5GKbrutRNXVqobqQcLdA=",
+			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots",
 			"revision": "3a7818a07cfc862267a0b03635075a444c92dcda",
 			"revisionTime": "2018-11-14T20:47:05Z"
 		},

--- a/website/docs/d/blockstorage_snapshot_v2.html.markdown
+++ b/website/docs/d/blockstorage_snapshot_v2.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_blockstorage_snapshot_v2"
+sidebar_current: "docs-openstack-datasource-blockstorage-snapshot-v2"
+description: |-
+  Get information on an OpenStack Snapshot.
+---
+
+# openstack\_blockstorage\_snapshot\_v2
+
+Use this data source to get information about an existing snapshot.
+
+## Example Usage
+
+```hcl
+data "openstack_blockstorage_snapshot_v2" "snapshot_1" {
+  name        = "snapshot_1"
+  most_recent = true
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional) The region in which to obtain the V2 Block Storage
+    client. If omitted, the `region` argument of the provider is used.
+
+* `name` - (Optional) The name of the snapshot.
+
+* `status` - (Optional) The status of the snapshot.
+
+* `volume_id` - (Optional) The ID of the snapshot's volume.
+
+* `most_recent` - (Optional) Pick the most recently created snapshot if there
+    are multiple results.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `status` - See Argument Reference above.
+* `volume_id` - See Argument Reference above.
+* `description` - The snapshot's description.
+* `size` - The size of the snapshot.
+* `metadata` - The snapshot's metadata.

--- a/website/docs/d/blockstorage_snapshot_v3.html.markdown
+++ b/website/docs/d/blockstorage_snapshot_v3.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_blockstorage_snapshot_v3"
+sidebar_current: "docs-openstack-datasource-blockstorage-snapshot-v3"
+description: |-
+  Get information on an OpenStack Snapshot.
+---
+
+# openstack\_blockstorage\_snapshot\_v3
+
+Use this data source to get information about an existing snapshot.
+
+## Example Usage
+
+```hcl
+data "openstack_blockstorage_snapshot_v3" "snapshot_1" {
+  name        = "snapshot_1"
+  most_recent = true
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional) The region in which to obtain the V3 Block Storage
+    client. If omitted, the `region` argument of the provider is used.
+
+* `name` - (Optional) The name of the snapshot.
+
+* `status` - (Optional) The status of the snapshot.
+
+* `volume_id` - (Optional) The ID of the snapshot's volume.
+
+* `most_recent` - (Optional) Pick the most recently created snapshot if there
+    are multiple results.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `status` - See Argument Reference above.
+* `volume_id` - See Argument Reference above.
+* `description` - The snapshot's description.
+* `size` - The size of the snapshot.
+* `metadata` - The snapshot's metadata.

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -16,6 +16,9 @@
             <li<%= sidebar_current("docs-openstack-datasource-blockstorage-snapshot-v2") %>>
               <a href="/docs/providers/openstack/d/blockstorage_snapshot_v2.html">openstack_blockstorage_snapshot_v2</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-datasource-blockstorage-snapshot-v3") %>>
+              <a href="/docs/providers/openstack/d/blockstorage_snapshot_v3.html">openstack_blockstorage_snapshot_v3</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-datasource-compute-flavor-v2") %>>
               <a href="/docs/providers/openstack/d/compute_flavor_v2.html">openstack_compute_flavor_v2</a>
             </li>

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -13,6 +13,9 @@
         <li<%= sidebar_current("docs-openstack-datasource") %>>
           <a href="#">Data Sources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-openstack-datasource-blockstorage-snapshot-v2") %>>
+              <a href="/docs/providers/openstack/d/blockstorage_snapshot_v2.html">openstack_blockstorage_snapshot_v2</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-datasource-compute-flavor-v2") %>>
               <a href="/docs/providers/openstack/d/compute_flavor_v2.html">openstack_compute_flavor_v2</a>
             </li>


### PR DESCRIPTION
For #354 

There are two resources here, but they are almost identical - the only difference is v2 / v3.

The acceptance tests are done uniquely from other tests: a volume and snapshot are created outside of Terraform. This is because Terraform doesn't have an `openstack_blockstorage_snapshot_v2/3` resource, which makes sense because creating and managing snapshots is a hard thing for Terraform to do.