### PR TITLE
Add tags support for Neutron Networks

### DIFF
--- a/openstack/resource_openstack_networking_tags_v2_test.go
+++ b/openstack/resource_openstack_networking_tags_v2_test.go
@@ -1,0 +1,49 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccNetworkingV2_tags(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2NetworkDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2_tags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2Tags(
+						"openstack_networking_network_v2.network_1",
+						[]string{"a", "b", "c"}),
+				),
+			},
+			resource.TestStep{
+				Config: testAccNetworkingV2_tags_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2Tags(
+						"openstack_networking_network_v2.network_1",
+						[]string{"a", "b", "c", "d"}),
+				),
+			},
+		},
+	})
+}
+
+const testAccNetworkingV2_tags = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+  tags = ["a", "b", "c"]
+}
+`
+
+const testAccNetworkingV2_tags_update = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+  tags = ["a", "b", "c", "d"]
+}
+`

--- a/website/docs/r/networking_network_v2.html.markdown
+++ b/website/docs/r/networking_network_v2.html.markdown
@@ -95,6 +95,8 @@ The following arguments are supported:
     so that they are scheduled on different availability zones. Changing this 
     creates a new network.
 
+* `tags` - (Optional) A set of string tags for the network. 
+
 The `segments` block supports:
 
 * `physical_network` - The phisical network where this network is implemented.
@@ -112,6 +114,7 @@ The following attributes are exported:
 * `tenant_id` - See Argument Reference above.
 * `admin_state_up` - See Argument Reference above.
 * `availability_zone_hints` - See Argument Reference above.
+* `tags` - See Argument Reference above.
 
 ## Import
 


### PR DESCRIPTION
This adds support for tags to networks, note this is branched from PR #446 since that already adds initial support for tags for the trunk resource, and a couple of functions are reused here.

Subsequent PRs will add support for the other neutron resources which support standard attribute tags as described in Issue #453 

Issue #453 