### PR TITLE
Add tags support for Neutron Ports

### DIFF
--- a/openstack/resource_openstack_networking_tags_v2_test.go
+++ b/openstack/resource_openstack_networking_tags_v2_test.go
@@ -1,0 +1,49 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccNetworkingV2_tags(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2NetworkDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2_tags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2Tags(
+						"openstack_networking_network_v2.network_1",
+						[]string{"a", "b", "c"}),
+				),
+			},
+			resource.TestStep{
+				Config: testAccNetworkingV2_tags_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2Tags(
+						"openstack_networking_network_v2.network_1",
+						[]string{"a", "b", "c", "d"}),
+				),
+			},
+		},
+	})
+}
+
+const testAccNetworkingV2_tags = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+  tags = ["a", "b", "c"]
+}
+`
+
+const testAccNetworkingV2_tags_update = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+  tags = ["a", "b", "c", "d"]
+}
+`

--- a/openstack/resource_openstack_networking_tags_v2_test.go
+++ b/openstack/resource_openstack_networking_tags_v2_test.go
@@ -25,6 +25,9 @@ func TestAccNetworkingV2_tags(t *testing.T) {
 					testAccCheckNetworkingV2Tags(
 						"openstack_networking_subnetpool_v2.subnetpool_1",
 						[]string{"a", "b", "c"}),
+					testAccCheckNetworkingV2Tags(
+						"openstack_networking_port_v2.port_1",
+						[]string{"a", "b", "c"}),
 				),
 			},
 			resource.TestStep{
@@ -38,6 +41,9 @@ func TestAccNetworkingV2_tags(t *testing.T) {
 						[]string{"a", "b", "c", "d"}),
 					testAccCheckNetworkingV2Tags(
 						"openstack_networking_subnetpool_v2.subnetpool_1",
+						[]string{"a", "b", "c", "d"}),
+					testAccCheckNetworkingV2Tags(
+						"openstack_networking_port_v2.port_1",
 						[]string{"a", "b", "c", "d"}),
 				),
 			},
@@ -79,6 +85,19 @@ resource "openstack_networking_subnetpool_v2" "subnetpool_1" {
     max_prefixlen = 30
 
     tags = %[1]s
+}
+
+resource "openstack_networking_port_v2" "port_1" {
+  name = "port_1"
+  admin_state_up = "true"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+
+  fixed_ip {
+    subnet_id =  "${openstack_networking_subnet_v2.subnet_1.id}"
+    ip_address = "192.168.199.23"
+  }
+
+  tags = %[1]s
 }
 `
 

--- a/openstack/resource_openstack_networking_tags_v2_test.go
+++ b/openstack/resource_openstack_networking_tags_v2_test.go
@@ -22,6 +22,9 @@ func TestAccNetworkingV2_tags(t *testing.T) {
 					testAccCheckNetworkingV2Tags(
 						"openstack_networking_subnet_v2.subnet_1",
 						[]string{"a", "b", "c"}),
+					testAccCheckNetworkingV2Tags(
+						"openstack_networking_subnetpool_v2.subnetpool_1",
+						[]string{"a", "b", "c"}),
 				),
 			},
 			resource.TestStep{
@@ -32,6 +35,9 @@ func TestAccNetworkingV2_tags(t *testing.T) {
 						[]string{"a", "b", "c", "d"}),
 					testAccCheckNetworkingV2Tags(
 						"openstack_networking_subnet_v2.subnet_1",
+						[]string{"a", "b", "c", "d"}),
+					testAccCheckNetworkingV2Tags(
+						"openstack_networking_subnetpool_v2.subnetpool_1",
 						[]string{"a", "b", "c", "d"}),
 				),
 			},
@@ -58,6 +64,21 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
   }
 
   tags = %[1]s
+}
+
+resource "openstack_networking_subnetpool_v2" "subnetpool_1" {
+    name = "subnetpool_1"
+    description = "terraform subnetpool acceptance test"
+
+    prefixes = ["10.10.0.0/16", "10.11.11.0/24"]
+
+    default_quota = 4
+
+    default_prefixlen = 25
+    min_prefixlen = 24
+    max_prefixlen = 30
+
+    tags = %[1]s
 }
 `
 

--- a/openstack/resource_openstack_networking_tags_v2_test.go
+++ b/openstack/resource_openstack_networking_tags_v2_test.go
@@ -1,6 +1,7 @@
 package openstack
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -13,18 +14,24 @@ func TestAccNetworkingV2_tags(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkingV2NetworkDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccNetworkingV2_tags,
+				Config: testAccNetworkingV2_config_create,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2Tags(
 						"openstack_networking_network_v2.network_1",
 						[]string{"a", "b", "c"}),
+					testAccCheckNetworkingV2Tags(
+						"openstack_networking_subnet_v2.subnet_1",
+						[]string{"a", "b", "c"}),
 				),
 			},
 			resource.TestStep{
-				Config: testAccNetworkingV2_tags_update,
+				Config: testAccNetworkingV2_config_update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2Tags(
 						"openstack_networking_network_v2.network_1",
+						[]string{"a", "b", "c", "d"}),
+					testAccCheckNetworkingV2Tags(
+						"openstack_networking_subnet_v2.subnet_1",
 						[]string{"a", "b", "c", "d"}),
 				),
 			},
@@ -32,18 +39,34 @@ func TestAccNetworkingV2_tags(t *testing.T) {
 	})
 }
 
-const testAccNetworkingV2_tags = `
+const testAccNetworkingV2_config = `
 resource "openstack_networking_network_v2" "network_1" {
   name = "network_1"
   admin_state_up = "true"
-  tags = ["a", "b", "c"]
+  tags = %[1]s
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  cidr = "192.168.199.0/24"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+
+  dns_nameservers = ["10.0.16.4", "213.186.33.99"]
+
+  allocation_pools {
+    start = "192.168.199.100"
+    end = "192.168.199.200"
+  }
+
+  tags = %[1]s
 }
 `
 
-const testAccNetworkingV2_tags_update = `
-resource "openstack_networking_network_v2" "network_1" {
-  name = "network_1"
-  admin_state_up = "true"
-  tags = ["a", "b", "c", "d"]
-}
-`
+const testAccNetworkingV2_tags_create = `["a", "b", "c"]`
+
+const testAccNetworkingV2_tags_update = `["a", "b", "c", "d"]`
+
+var testAccNetworkingV2_config_create = fmt.Sprintf(
+	testAccNetworkingV2_config, testAccNetworkingV2_tags_create)
+
+var testAccNetworkingV2_config_update = fmt.Sprintf(
+	testAccNetworkingV2_config, testAccNetworkingV2_tags_update)

--- a/website/docs/r/networking_network_v2.html.markdown
+++ b/website/docs/r/networking_network_v2.html.markdown
@@ -95,6 +95,8 @@ The following arguments are supported:
     so that they are scheduled on different availability zones. Changing this 
     creates a new network.
 
+* `tags` - (Optional) A set of string tags for the network. 
+
 The `segments` block supports:
 
 * `physical_network` - The phisical network where this network is implemented.
@@ -112,6 +114,7 @@ The following attributes are exported:
 * `tenant_id` - See Argument Reference above.
 * `admin_state_up` - See Argument Reference above.
 * `availability_zone_hints` - See Argument Reference above.
+* `tags` - See Argument Reference above.
 
 ## Import
 

--- a/website/docs/r/networking_port_v2.html.markdown
+++ b/website/docs/r/networking_port_v2.html.markdown
@@ -97,6 +97,8 @@ The `allowed_address_pairs` block supports:
 
 * `mac_address` - (Optional) The additional MAC address.
 
+* `tags` - (Optional) A set of string tags for the port.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -113,6 +115,7 @@ The following attributes are exported:
   order returned by the Network v2 API.
 * `all_security_group_ids` - The collection of Security Group IDs on the port
   which have been explicitly and implicitly added.
+* `tags` - See Argument Reference above.
 
 ## Import
 

--- a/website/docs/r/networking_subnet_v2.html.markdown
+++ b/website/docs/r/networking_subnet_v2.html.markdown
@@ -84,6 +84,8 @@ The following arguments are supported:
 
 * `value_specs` - (Optional) Map of additional options.
 
+* `tags` - (Optional) A set of string tags for the subnet.
+
 The `allocation_pools` block supports:
 
 * `start` - (Required) The starting address.
@@ -112,6 +114,7 @@ The following attributes are exported:
 * `dns_nameservers` - See Argument Reference above.
 * `host_routes` - See Argument Reference above.
 * `subnetpool_id` - See Argument Reference above.
+* `tags` - See Argument Reference above.
 
 ## Import
 

--- a/website/docs/r/networking_subnetpool_v2.html.markdown
+++ b/website/docs/r/networking_subnetpool_v2.html.markdown
@@ -99,6 +99,8 @@ The following arguments are supported:
 
 * `value_specs` - (Optional) Map of additional options.
 
+* `tags` - (Optional) A set of string tags for the subnetpool.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -120,6 +122,7 @@ The following attributes are exported:
 * `is_default` - See Argument Reference above.
 * `revision_number` - The revision number of the subnetpool.
 * `value_specs` - See Argument Reference above.
+* `tags` - See Argument Reference above.
 
 ## Import
 


### PR DESCRIPTION
This adds support for tags to ports note this is branched from PR #460

Subsequent PRs will add support for the other neutron resources which support standard attribute tags as described in Issue #453

Issue #453