### PR TITLE
Enable object versioning

### DIFF
--- a/openstack/resource_openstack_objectstorage_container_v1.go
+++ b/openstack/resource_openstack_objectstorage_container_v1.go
@@ -113,6 +113,8 @@ func resourceObjectStorageContainerV1Create(d *schema.ResourceData, meta interfa
 		switch vParams["type"].(string) {
 		case "versions":
 			createOpts.VersionsLocation = vParams["location"].(string)
+		case "history":
+			createOpts.HistoryLocation = vParams["location"].(string)
 		}
 	}
 
@@ -166,11 +168,14 @@ func resourceObjectStorageContainerV1Update(d *schema.ResourceData, meta interfa
 	if versioning, ok := d.Get("versioning").(*schema.Set); ok && d.HasChange("versioning") {
 		if versioning.Len() == 0 {
 			updateOpts.RemoveVersionsLocation = "true"
+			updateOpts.RemoveHistoryLocation = "true"
 		} else {
 			vParams := versioning.List()[0].(map[string]interface{})
 			switch vParams["type"].(string) {
 			case "versions":
 				updateOpts.VersionsLocation = vParams["location"].(string)
+			case "history":
+				updateOpts.HistoryLocation = vParams["location"].(string)
 			}
 		}
 	}

--- a/openstack/resource_openstack_objectstorage_container_v1.go
+++ b/openstack/resource_openstack_objectstorage_container_v1.go
@@ -55,6 +55,11 @@ func resourceObjectStorageContainerV1() *schema.Resource {
 				Optional: true,
 				ForceNew: false,
 			},
+			"versions_location": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
 			"metadata": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -84,6 +89,7 @@ func resourceObjectStorageContainerV1Create(d *schema.ResourceData, meta interfa
 		ContainerSyncKey: d.Get("container_sync_key").(string),
 		ContainerWrite:   d.Get("container_write").(string),
 		ContentType:      d.Get("content_type").(string),
+		VersionsLocation: d.Get("versions_location").(string),
 		Metadata:         resourceContainerMetadataV2(d),
 	}
 
@@ -132,6 +138,11 @@ func resourceObjectStorageContainerV1Update(d *schema.ResourceData, meta interfa
 		ContainerSyncKey: d.Get("container_sync_key").(string),
 		ContainerWrite:   d.Get("container_write").(string),
 		ContentType:      d.Get("content_type").(string),
+		VersionsLocation: d.Get("versions_location").(string),
+	}
+
+	if d.HasChange("versions_location") && d.Get("versions_location").(string) == "" {
+		updateOpts.RemoveVersionsLocation = "true"
 	}
 
 	if d.HasChange("metadata") {

--- a/website/docs/r/objectstorage_container_v1.html.markdown
+++ b/website/docs/r/objectstorage_container_v1.html.markdown
@@ -50,6 +50,8 @@ The following arguments are supported:
 * `container_write` - (Optional) Sets an ACL that grants write access.
     Changing this updates the access control list write access.
 
+* `versions_location` - (Optional) A container which will store the objects versions.
+
 * `metadata` - (Optional) Custom key/value pairs to associate with the container.
     Changing this updates the existing container metadata.
 
@@ -68,5 +70,6 @@ The following attributes are exported:
 * `container_sync_to` - See Argument Reference above.
 * `container_sync_key` - See Argument Reference above.
 * `container_write` - See Argument Reference above.
+* `versions_location` - See Argument Reference above.
 * `metadata` - See Argument Reference above.
 * `content_type` - See Argument Reference above.

--- a/website/docs/r/objectstorage_container_v1.html.markdown
+++ b/website/docs/r/objectstorage_container_v1.html.markdown
@@ -55,9 +55,7 @@ The following arguments are supported:
 * `container_write` - (Optional) Sets an ACL that grants write access.
     Changing this updates the access control list write access.
 
-* `versioning` - (Optional) Enable object versioning. Two parameters are
-    required: `type` is the type of versioning and only accepts the values `versions` and `history`,
-    `location` is the container in which the versions will be stored.
+* `versioning` - (Optional) Enable object versioning. The structure is described below.
 
 * `metadata` - (Optional) Custom key/value pairs to associate with the container.
     Changing this updates the existing container metadata.
@@ -66,6 +64,12 @@ The following arguments are supported:
     updates the MIME type.
 
 * `force_destroy` -  (Optional, Default:false ) A boolean that indicates all objects should be deleted from the container so that the container can be destroyed without error. These objects are not recoverable.
+
+The `versioning` block supports:
+
+  * `type` - (Required) Versioning type which can be `versions` or `history` according to [Openstack documentation](https://docs.openstack.org/swift/latest/overview_object_versioning.html).
+  * `location` - (Required) Container in which versions will be stored.
+
 
 ## Attributes Reference
 

--- a/website/docs/r/objectstorage_container_v1.html.markdown
+++ b/website/docs/r/objectstorage_container_v1.html.markdown
@@ -22,6 +22,11 @@ resource "openstack_objectstorage_container_v1" "container_1" {
   }
 
   content_type = "application/json"
+
+  versioning {
+    type = "versions"
+    location = "tf-test-container-versions"
+  }
 }
 ```
 
@@ -50,7 +55,9 @@ The following arguments are supported:
 * `container_write` - (Optional) Sets an ACL that grants write access.
     Changing this updates the access control list write access.
 
-* `versions_location` - (Optional) A container which will store the objects versions.
+* `versioning` - (Optional) Enable object versioning. Two parameters are
+    required: `type` is the type of versioning and only accepts the values `versions` and `history`,
+    `location` is the container in which the versions will be stored.
 
 * `metadata` - (Optional) Custom key/value pairs to associate with the container.
     Changing this updates the existing container metadata.
@@ -70,6 +77,6 @@ The following attributes are exported:
 * `container_sync_to` - See Argument Reference above.
 * `container_sync_key` - See Argument Reference above.
 * `container_write` - See Argument Reference above.
-* `versions_location` - See Argument Reference above.
+* `versioning` - See Argument Reference above.
 * `metadata` - See Argument Reference above.
 * `content_type` - See Argument Reference above.


### PR DESCRIPTION
To enable versioning, we must set a HTTP header `X-History-Location` or `X-Versions-Location` while creating or updating the container (cf: [Openstack documentation](https://docs.openstack.org/swift/latest/overview_object_versioning.html)).
This PR adds support of both headers.