### PR TITLE
Add tags support for Neutron floatingips

### DIFF
--- a/openstack/resource_openstack_networking_tags_v2_test.go
+++ b/openstack/resource_openstack_networking_tags_v2_test.go
@@ -31,6 +31,9 @@ func TestAccNetworkingV2_tags(t *testing.T) {
 					testAccCheckNetworkingV2Tags(
 						"openstack_networking_secgroup_v2.secgroup_1",
 						[]string{"a", "b", "c"}),
+					testAccCheckNetworkingV2Tags(
+						"openstack_networking_floatingip_v2.fip_1",
+						[]string{"a", "b", "c"}),
 				),
 			},
 			resource.TestStep{
@@ -50,6 +53,9 @@ func TestAccNetworkingV2_tags(t *testing.T) {
 						[]string{"a", "b", "c", "d"}),
 					testAccCheckNetworkingV2Tags(
 						"openstack_networking_secgroup_v2.secgroup_1",
+						[]string{"a", "b", "c", "d"}),
+					testAccCheckNetworkingV2Tags(
+						"openstack_networking_floatingip_v2.fip_1",
 						[]string{"a", "b", "c", "d"}),
 				),
 			},
@@ -110,6 +116,10 @@ resource "openstack_networking_secgroup_v2" "secgroup_1" {
   name = "security_group"
   description = "terraform security group acceptance test"
   tags = %[1]s
+}
+
+resource "openstack_networking_floatingip_v2" "fip_1" {
+	    tags = %[1]s
 }
 `
 

--- a/website/docs/r/networking_floatingip_v2.html.markdown
+++ b/website/docs/r/networking_floatingip_v2.html.markdown
@@ -55,6 +55,8 @@ The following arguments are supported:
 
 * `value_specs` - (Optional) Map of additional options.
 
+* `tags` - (Optional) A set of string tags for the floating IP.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -65,6 +67,7 @@ The following attributes are exported:
 * `port_id` - ID of associated port.
 * `tenant_id` - the ID of the tenant in which to create the floating IP.
 * `fixed_ip` - The fixed IP which the floating IP maps to.
+* `tags` - See Argument Reference above.
 
 ## Import
 


### PR DESCRIPTION
This allows us to set/get tags for floatingips via terraform templates,
and requires the recently added changes to gophercloud that enable
the relevant features of the Neutron APIs to be accessed.

Issue: #453