### PR TITLE
Fix OpenStack single volume attach example

### DIFF
--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -53,7 +53,7 @@ resource "openstack_compute_instance_v2" "myinstance" {
 }
 
 resource "openstack_compute_volume_attach_v2" "attached" {
-  compute_id = "${openstack_compute_instance_v2.myinstance.id}"
+  instance_id = "${openstack_compute_instance_v2.myinstance.id}"
   volume_id = "${openstack_blockstorage_volume_v2.myvol.id}"
 }
 ```


### PR DESCRIPTION
When running the sample code with openstack provider 1.11.0, it errors with:

```
Error: openstack_compute_volume_attach_v2.attached: "instance_id": required field is not set
Error: openstack_compute_volume_attach_v2.attached: : invalid or unknown key: compute_id
```

The [docs for openstack_compute_volume_attach_v2](https://www.terraform.io/docs/providers/openstack/r/compute_volume_attach_v2.html) show the right param.