### PR TITLE
Internal: compute v2 secgroup cleanup

### DIFF
--- a/openstack/compute_secgroup_v2.go
+++ b/openstack/compute_secgroup_v2.go
@@ -51,10 +51,10 @@ func computeSecGroupV2RulesCheckForErrors(d *schema.ResourceData) error {
 }
 
 func expandComputeSecGroupV2CreateRules(d *schema.ResourceData) []secgroups.CreateRuleOpts {
-	rawRules := d.Get("rule").(*schema.Set)
-	createRuleOptsList := make([]secgroups.CreateRuleOpts, rawRules.Len())
+	rawRules := d.Get("rule").(*schema.Set).List()
+	createRuleOptsList := make([]secgroups.CreateRuleOpts, len(rawRules))
 
-	for i, rawRule := range rawRules.List() {
+	for i, rawRule := range rawRules {
 		createRuleOptsList[i] = expandComputeSecGroupV2CreateRule(d, rawRule)
 	}
 

--- a/openstack/compute_secgroup_v2.go
+++ b/openstack/compute_secgroup_v2.go
@@ -1,0 +1,171 @@
+package openstack
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func computeSecGroupV2RulesCheckForErrors(d *schema.ResourceData) error {
+	rawRules := d.Get("rule").(*schema.Set).List()
+
+	for _, rawRule := range rawRules {
+		rawRuleMap := rawRule.(map[string]interface{})
+
+		// only one of cidr, from_group_id, or self can be set
+		cidr := rawRuleMap["cidr"].(string)
+		groupId := rawRuleMap["from_group_id"].(string)
+		self := rawRuleMap["self"].(bool)
+		errorMessage := fmt.Errorf("Only one of cidr, from_group_id, or self can be set.")
+
+		// if cidr is set, from_group_id and self cannot be set
+		if cidr != "" {
+			if groupId != "" || self {
+				return errorMessage
+			}
+		}
+
+		// if from_group_id is set, cidr and self cannot be set
+		if groupId != "" {
+			if cidr != "" || self {
+				return errorMessage
+			}
+		}
+
+		// if self is set, cidr and from_group_id cannot be set
+		if self {
+			if cidr != "" || groupId != "" {
+				return errorMessage
+			}
+		}
+	}
+
+	return nil
+}
+
+func expandComputeSecGroupV2CreateRules(d *schema.ResourceData) []secgroups.CreateRuleOpts {
+	rawRules := d.Get("rule").(*schema.Set)
+	createRuleOptsList := make([]secgroups.CreateRuleOpts, rawRules.Len())
+
+	for i, rawRule := range rawRules.List() {
+		createRuleOptsList[i] = expandComputeSecGroupV2CreateRule(d, rawRule)
+	}
+
+	return createRuleOptsList
+}
+
+func expandComputeSecGroupV2CreateRule(d *schema.ResourceData, rawRule interface{}) secgroups.CreateRuleOpts {
+	rawRuleMap := rawRule.(map[string]interface{})
+	groupId := rawRuleMap["from_group_id"].(string)
+	if rawRuleMap["self"].(bool) {
+		groupId = d.Id()
+	}
+	return secgroups.CreateRuleOpts{
+		ParentGroupID: d.Id(),
+		FromPort:      rawRuleMap["from_port"].(int),
+		ToPort:        rawRuleMap["to_port"].(int),
+		IPProtocol:    rawRuleMap["ip_protocol"].(string),
+		CIDR:          rawRuleMap["cidr"].(string),
+		FromGroupID:   groupId,
+	}
+}
+
+func expandComputeSecGroupV2Rule(d *schema.ResourceData, rawRule interface{}) secgroups.Rule {
+	rawRuleMap := rawRule.(map[string]interface{})
+	return secgroups.Rule{
+		ID:            rawRuleMap["id"].(string),
+		ParentGroupID: d.Id(),
+		FromPort:      rawRuleMap["from_port"].(int),
+		ToPort:        rawRuleMap["to_port"].(int),
+		IPProtocol:    rawRuleMap["ip_protocol"].(string),
+		IPRange:       secgroups.IPRange{CIDR: rawRuleMap["cidr"].(string)},
+	}
+}
+
+func flattenComputeSecGroupV2Rules(computeClient *gophercloud.ServiceClient, d *schema.ResourceData, sgrs []secgroups.Rule) ([]map[string]interface{}, error) {
+	sgrMap := make([]map[string]interface{}, len(sgrs))
+	for i, sgr := range sgrs {
+		groupId := ""
+		self := false
+		if sgr.Group.Name != "" {
+			if sgr.Group.Name == d.Get("name").(string) {
+				self = true
+			} else {
+				// Since Nova only returns the secgroup Name (and not the ID) for the group attribute,
+				// we need to look up all security groups and match the name.
+				// Nevermind that Nova wants the ID when setting the Group *and* that multiple groups
+				// with the same name can exist...
+				allPages, err := secgroups.List(computeClient).AllPages()
+				if err != nil {
+					return nil, err
+				}
+				securityGroups, err := secgroups.ExtractSecurityGroups(allPages)
+				if err != nil {
+					return nil, err
+				}
+
+				for _, sg := range securityGroups {
+					if sg.Name == sgr.Group.Name {
+						groupId = sg.ID
+					}
+				}
+			}
+		}
+
+		sgrMap[i] = map[string]interface{}{
+			"id":            sgr.ID,
+			"from_port":     sgr.FromPort,
+			"to_port":       sgr.ToPort,
+			"ip_protocol":   sgr.IPProtocol,
+			"cidr":          sgr.IPRange.CIDR,
+			"self":          self,
+			"from_group_id": groupId,
+		}
+	}
+	return sgrMap, nil
+}
+
+func computeSecGroupV2RuleHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%d-", m["from_port"].(int)))
+	buf.WriteString(fmt.Sprintf("%d-", m["to_port"].(int)))
+	buf.WriteString(fmt.Sprintf("%s-", m["ip_protocol"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["cidr"].(string))))
+	buf.WriteString(fmt.Sprintf("%s-", m["from_group_id"].(string)))
+	buf.WriteString(fmt.Sprintf("%t-", m["self"].(bool)))
+
+	return hashcode.String(buf.String())
+}
+
+func computeSecGroupV2StateRefreshFunc(computeClient *gophercloud.ServiceClient, d *schema.ResourceData) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		log.Printf("[DEBUG] Attempting to delete openstack_compute_secgroup_v2 %s", d.Id())
+
+		err := secgroups.Delete(computeClient, d.Id()).ExtractErr()
+		if err != nil {
+			return nil, "", err
+		}
+
+		s, err := secgroups.Get(computeClient, d.Id()).Extract()
+		if err != nil {
+			err = CheckDeleted(d, err, "Error retrieving openstack_compute_secgroup_v2")
+			if err != nil {
+				return s, "", err
+			}
+
+			log.Printf("[DEBUG] Successfully deleted openstack_compute_secgroup_v2 %s", d.Id())
+			return s, "DELETED", nil
+		}
+
+		log.Printf("[DEBUG] openstack_compute_secgroup_v2 %s still active", d.Id())
+		return s, "ACTIVE", nil
+	}
+}

--- a/openstack/compute_secgroup_v2_test.go
+++ b/openstack/compute_secgroup_v2_test.go
@@ -68,3 +68,32 @@ func TestExpandComputeSecGroupV2CreateRules(t *testing.T) {
 		t.Fatalf("Rules differ. Want: %#v, but got: %#v", expectedRules, actualRules)
 	}
 }
+
+func TestExpandComputeSecGroupV2Rule(t *testing.T) {
+	r := resourceComputeSecGroupV2()
+	d := r.TestResourceData()
+	d.SetId("1")
+
+	rule1 := map[string]interface{}{
+		"id":          "2",
+		"from_port":   22,
+		"to_port":     22,
+		"ip_protocol": "tcp",
+		"cidr":        "0.0.0.0/0",
+	}
+
+	expectedRules := secgroups.Rule{
+		ParentGroupID: "1",
+		ID:            "2",
+		FromPort:      22,
+		ToPort:        22,
+		IPProtocol:    "tcp",
+		IPRange:       secgroups.IPRange{CIDR: "0.0.0.0/0"},
+	}
+
+	actualRules := expandComputeSecGroupV2Rule(d, rule1)
+
+	if !reflect.DeepEqual(expectedRules, actualRules) {
+		t.Fatalf("Results differ. Want: %#v, but got: %#v", expectedRules, actualRules)
+	}
+}

--- a/openstack/compute_secgroup_v2_test.go
+++ b/openstack/compute_secgroup_v2_test.go
@@ -1,0 +1,70 @@
+package openstack
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups"
+)
+
+func TestExpandComputeSecGroupV2CreateRules(t *testing.T) {
+	r := resourceComputeSecGroupV2()
+	d := r.TestResourceData()
+	d.SetId("1")
+
+	rule1 := map[string]interface{}{
+		"from_port":   22,
+		"to_port":     22,
+		"ip_protocol": "tcp",
+		"cidr":        "0.0.0.0/0",
+	}
+
+	rule2 := map[string]interface{}{
+		"from_port":   1,
+		"to_port":     65536,
+		"ip_protocol": "udp",
+		"cidr":        "0.0.0.0/0",
+	}
+
+	rule3 := map[string]interface{}{
+		"from_port":   -1,
+		"to_port":     -1,
+		"ip_protocol": "icmp",
+		"cidr":        "0.0.0.0/0",
+	}
+
+	rules := []map[string]interface{}{rule1, rule2, rule3}
+	d.Set("rule", rules)
+
+	expectedRules := []secgroups.CreateRuleOpts{
+		{
+			ParentGroupID: "1",
+			FromPort:      -1,
+			ToPort:        -1,
+			IPProtocol:    "icmp",
+			CIDR:          "0.0.0.0/0",
+		},
+
+		{
+			ParentGroupID: "1",
+			FromPort:      1,
+			ToPort:        65536,
+			IPProtocol:    "udp",
+			CIDR:          "0.0.0.0/0",
+		},
+
+		{
+			ParentGroupID: "1",
+			FromPort:      22,
+			ToPort:        22,
+			IPProtocol:    "tcp",
+			CIDR:          "0.0.0.0/0",
+		},
+	}
+
+	actualRules := expandComputeSecGroupV2CreateRules(d)
+
+	if !reflect.DeepEqual(expectedRules, actualRules) {
+		t.Fatalf("Rules differ. Want: %#v, but got: %#v", expectedRules, actualRules)
+	}
+}

--- a/openstack/resource_openstack_compute_secgroup_v2.go
+++ b/openstack/resource_openstack_compute_secgroup_v2.go
@@ -1,7 +1,6 @@
 package openstack
 
 import (
-	"bytes"
 	"fmt"
 	"log"
 	"strings"
@@ -9,7 +8,6 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups"
-	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -41,36 +39,43 @@ func resourceComputeSecGroupV2() *schema.Resource {
 				Required: true,
 				ForceNew: false,
 			},
+
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: false,
 			},
+
 			"rule": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
+				Set:      computeSecGroupV2RuleHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": &schema.Schema{
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+
 						"from_port": &schema.Schema{
 							Type:     schema.TypeInt,
 							Required: true,
 							ForceNew: false,
 						},
+
 						"to_port": &schema.Schema{
 							Type:     schema.TypeInt,
 							Required: true,
 							ForceNew: false,
 						},
+
 						"ip_protocol": &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: false,
 						},
+
 						"cidr": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
@@ -79,11 +84,13 @@ func resourceComputeSecGroupV2() *schema.Resource {
 								return strings.ToLower(v.(string))
 							},
 						},
+
 						"from_group_id": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: false,
 						},
+
 						"self": &schema.Schema{
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -92,7 +99,6 @@ func resourceComputeSecGroupV2() *schema.Resource {
 						},
 					},
 				},
-				Set: secgroupRuleV2Hash,
 			},
 		},
 	}
@@ -106,30 +112,32 @@ func resourceComputeSecGroupV2Create(d *schema.ResourceData, meta interface{}) e
 	}
 
 	// Before creating the security group, make sure all rules are valid.
-	if err := checkSecGroupV2RulesForErrors(d); err != nil {
+	if err := computeSecGroupV2RulesCheckForErrors(d); err != nil {
 		return err
 	}
 
 	// If all rules are valid, proceed with creating the security gruop.
+	name := d.Get("name").(string)
 	createOpts := secgroups.CreateOpts{
-		Name:        d.Get("name").(string),
+		Name:        name,
 		Description: d.Get("description").(string),
 	}
 
-	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	log.Printf("[DEBUG] openstack_compute_secgroup_v2 Create Options: %#v", createOpts)
 	sg, err := secgroups.Create(computeClient, createOpts).Extract()
 	if err != nil {
-		return fmt.Errorf("Error creating OpenStack security group: %s", err)
+		return fmt.Errorf("Error creating openstack_compute_secgroup_v2 %s: %s", name, err)
 	}
 
 	d.SetId(sg.ID)
 
 	// Now that the security group has been created, iterate through each rule and create it
-	createRuleOptsList := resourceSecGroupRulesV2(d)
+	createRuleOptsList := expandComputeSecGroupV2CreateRules(d)
+
 	for _, createRuleOpts := range createRuleOptsList {
 		_, err := secgroups.CreateRule(computeClient, createRuleOpts).Extract()
 		if err != nil {
-			return fmt.Errorf("Error creating OpenStack security group rule: %s", err)
+			return fmt.Errorf("Error creating openstack_compute_secgroup_v2 %s rule: %s", name, err)
 		}
 	}
 
@@ -145,18 +153,22 @@ func resourceComputeSecGroupV2Read(d *schema.ResourceData, meta interface{}) err
 
 	sg, err := secgroups.Get(computeClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "security group")
+		return CheckDeleted(d, err, "Error retrieving openstack_compute_secgroup_v2")
 	}
 
 	d.Set("name", sg.Name)
 	d.Set("description", sg.Description)
 
-	rtm, err := rulesToMap(computeClient, d, sg.Rules)
+	rules, err := flattenComputeSecGroupV2Rules(computeClient, d, sg.Rules)
 	if err != nil {
 		return err
 	}
-	log.Printf("[DEBUG] rulesToMap(sg.Rules): %+v", rtm)
-	d.Set("rule", rtm)
+
+	log.Printf("[DEBUG] Retrieved openstack_compute_secgroup_v2 %s rules: %#v", d.Id(), rules)
+
+	if err := d.Set("rule", rules); err != nil {
+		return fmt.Errorf("Unable to set openstack_compute_secgroup_v2 %s rules: %s", d.Id(), err)
+	}
 
 	d.Set("region", GetRegion(d, config))
 
@@ -175,11 +187,11 @@ func resourceComputeSecGroupV2Update(d *schema.ResourceData, meta interface{}) e
 		Description: d.Get("description").(string),
 	}
 
-	log.Printf("[DEBUG] Updating Security Group (%s) with options: %+v", d.Id(), updateOpts)
+	log.Printf("[DEBUG] openstack_compute_secgroup_v2 %s Update Options: %#v", d.Id(), updateOpts)
 
 	_, err = secgroups.Update(computeClient, d.Id(), updateOpts).Extract()
 	if err != nil {
-		return fmt.Errorf("Error updating OpenStack security group (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error updating openstack_compute_secgroup_v2 %s: %s", d.Id(), err)
 	}
 
 	if d.HasChange("rule") {
@@ -188,29 +200,28 @@ func resourceComputeSecGroupV2Update(d *schema.ResourceData, meta interface{}) e
 		secgrouprulesToAdd := newSGRSet.Difference(oldSGRSet)
 		secgrouprulesToRemove := oldSGRSet.Difference(newSGRSet)
 
-		log.Printf("[DEBUG] Security group rules to add: %v", secgrouprulesToAdd)
-		log.Printf("[DEBUG] Security groups rules to remove: %v", secgrouprulesToRemove)
+		log.Printf("[DEBUG] openstack_compute_secgroup_v2 %s rules to add: %v", d.Id(), secgrouprulesToAdd)
+		log.Printf("[DEBUG] openstack_compute_secgroup_v2 %s rules to remove: %v", d.Id(), secgrouprulesToRemove)
 
 		for _, rawRule := range secgrouprulesToAdd.List() {
-			createRuleOpts := resourceSecGroupRuleCreateOptsV2(d, rawRule)
-			rule, err := secgroups.CreateRule(computeClient, createRuleOpts).Extract()
+			createRuleOpts := expandComputeSecGroupV2CreateRule(d, rawRule)
+
+			_, err := secgroups.CreateRule(computeClient, createRuleOpts).Extract()
 			if err != nil {
-				return fmt.Errorf("Error adding rule to OpenStack security group (%s): %s", d.Id(), err)
+				return fmt.Errorf("Error adding rule to openstack_compute_secgroup_v2 %s: %s", d.Id(), err)
 			}
-			log.Printf("[DEBUG] Added rule (%s) to OpenStack security group (%s) ", rule.ID, d.Id())
 		}
 
 		for _, r := range secgrouprulesToRemove.List() {
-			rule := resourceSecGroupRuleV2(d, r)
+			rule := expandComputeSecGroupV2Rule(d, r)
+
 			err := secgroups.DeleteRule(computeClient, rule.ID).ExtractErr()
 			if err != nil {
 				if _, ok := err.(gophercloud.ErrDefault404); ok {
 					continue
 				}
 
-				return fmt.Errorf("Error removing rule (%s) from OpenStack security group (%s)", rule.ID, d.Id())
-			} else {
-				log.Printf("[DEBUG] Removed rule (%s) from OpenStack security group (%s): %s", rule.ID, d.Id(), err)
+				return fmt.Errorf("Error removing rule %s from openstack_compute_secgroup_v2 %s", rule.ID, d.Id())
 			}
 		}
 	}
@@ -228,171 +239,16 @@ func resourceComputeSecGroupV2Delete(d *schema.ResourceData, meta interface{}) e
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE"},
 		Target:     []string{"DELETED"},
-		Refresh:    SecGroupV2StateRefreshFunc(computeClient, d),
+		Refresh:    computeSecGroupV2StateRefreshFunc(computeClient, d),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      10 * time.Second,
+		Delay:      1 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error deleting OpenStack security group: %s", err)
-	}
-
-	d.SetId("")
-	return nil
-}
-
-func resourceSecGroupRulesV2(d *schema.ResourceData) []secgroups.CreateRuleOpts {
-	rawRules := d.Get("rule").(*schema.Set).List()
-	createRuleOptsList := make([]secgroups.CreateRuleOpts, len(rawRules))
-	for i, rawRule := range rawRules {
-		createRuleOptsList[i] = resourceSecGroupRuleCreateOptsV2(d, rawRule)
-	}
-	return createRuleOptsList
-}
-
-func resourceSecGroupRuleCreateOptsV2(d *schema.ResourceData, rawRule interface{}) secgroups.CreateRuleOpts {
-	rawRuleMap := rawRule.(map[string]interface{})
-	groupId := rawRuleMap["from_group_id"].(string)
-	if rawRuleMap["self"].(bool) {
-		groupId = d.Id()
-	}
-	return secgroups.CreateRuleOpts{
-		ParentGroupID: d.Id(),
-		FromPort:      rawRuleMap["from_port"].(int),
-		ToPort:        rawRuleMap["to_port"].(int),
-		IPProtocol:    rawRuleMap["ip_protocol"].(string),
-		CIDR:          rawRuleMap["cidr"].(string),
-		FromGroupID:   groupId,
-	}
-}
-
-func checkSecGroupV2RulesForErrors(d *schema.ResourceData) error {
-	rawRules := d.Get("rule").(*schema.Set).List()
-	for _, rawRule := range rawRules {
-		rawRuleMap := rawRule.(map[string]interface{})
-
-		// only one of cidr, from_group_id, or self can be set
-		cidr := rawRuleMap["cidr"].(string)
-		groupId := rawRuleMap["from_group_id"].(string)
-		self := rawRuleMap["self"].(bool)
-		errorMessage := fmt.Errorf("Only one of cidr, from_group_id, or self can be set.")
-
-		// if cidr is set, from_group_id and self cannot be set
-		if cidr != "" {
-			if groupId != "" || self {
-				return errorMessage
-			}
-		}
-
-		// if from_group_id is set, cidr and self cannot be set
-		if groupId != "" {
-			if cidr != "" || self {
-				return errorMessage
-			}
-		}
-
-		// if self is set, cidr and from_group_id cannot be set
-		if self {
-			if cidr != "" || groupId != "" {
-				return errorMessage
-			}
-		}
+		return fmt.Errorf("Error deleting openstack_compute_secgroup_v2: %s", err)
 	}
 
 	return nil
-}
-
-func resourceSecGroupRuleV2(d *schema.ResourceData, rawRule interface{}) secgroups.Rule {
-	rawRuleMap := rawRule.(map[string]interface{})
-	return secgroups.Rule{
-		ID:            rawRuleMap["id"].(string),
-		ParentGroupID: d.Id(),
-		FromPort:      rawRuleMap["from_port"].(int),
-		ToPort:        rawRuleMap["to_port"].(int),
-		IPProtocol:    rawRuleMap["ip_protocol"].(string),
-		IPRange:       secgroups.IPRange{CIDR: rawRuleMap["cidr"].(string)},
-	}
-}
-
-func rulesToMap(computeClient *gophercloud.ServiceClient, d *schema.ResourceData, sgrs []secgroups.Rule) ([]map[string]interface{}, error) {
-	sgrMap := make([]map[string]interface{}, len(sgrs))
-	for i, sgr := range sgrs {
-		groupId := ""
-		self := false
-		if sgr.Group.Name != "" {
-			if sgr.Group.Name == d.Get("name").(string) {
-				self = true
-			} else {
-				// Since Nova only returns the secgroup Name (and not the ID) for the group attribute,
-				// we need to look up all security groups and match the name.
-				// Nevermind that Nova wants the ID when setting the Group *and* that multiple groups
-				// with the same name can exist...
-				allPages, err := secgroups.List(computeClient).AllPages()
-				if err != nil {
-					return nil, err
-				}
-				securityGroups, err := secgroups.ExtractSecurityGroups(allPages)
-				if err != nil {
-					return nil, err
-				}
-
-				for _, sg := range securityGroups {
-					if sg.Name == sgr.Group.Name {
-						groupId = sg.ID
-					}
-				}
-			}
-		}
-
-		sgrMap[i] = map[string]interface{}{
-			"id":            sgr.ID,
-			"from_port":     sgr.FromPort,
-			"to_port":       sgr.ToPort,
-			"ip_protocol":   sgr.IPProtocol,
-			"cidr":          sgr.IPRange.CIDR,
-			"self":          self,
-			"from_group_id": groupId,
-		}
-	}
-	return sgrMap, nil
-}
-
-func secgroupRuleV2Hash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%d-", m["from_port"].(int)))
-	buf.WriteString(fmt.Sprintf("%d-", m["to_port"].(int)))
-	buf.WriteString(fmt.Sprintf("%s-", m["ip_protocol"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["cidr"].(string))))
-	buf.WriteString(fmt.Sprintf("%s-", m["from_group_id"].(string)))
-	buf.WriteString(fmt.Sprintf("%t-", m["self"].(bool)))
-
-	return hashcode.String(buf.String())
-}
-
-func SecGroupV2StateRefreshFunc(computeClient *gophercloud.ServiceClient, d *schema.ResourceData) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		log.Printf("[DEBUG] Attempting to delete Security Group %s.\n", d.Id())
-
-		err := secgroups.Delete(computeClient, d.Id()).ExtractErr()
-		if err != nil {
-			return nil, "", err
-		}
-
-		s, err := secgroups.Get(computeClient, d.Id()).Extract()
-		if err != nil {
-			err = CheckDeleted(d, err, "Security Group")
-			if err != nil {
-				return s, "", err
-			} else {
-				log.Printf("[DEBUG] Successfully deleted Security Group %s", d.Id())
-				return s, "DELETED", nil
-			}
-		}
-
-		log.Printf("[DEBUG] Security Group %s still active.\n", d.Id())
-		return s, "ACTIVE", nil
-	}
 }

--- a/openstack/resource_openstack_compute_secgroup_v2_test.go
+++ b/openstack/resource_openstack_compute_secgroup_v2_test.go
@@ -144,24 +144,6 @@ func TestAccComputeV2SecGroup_lowerCaseCIDR(t *testing.T) {
 	})
 }
 
-func TestAccComputeV2SecGroup_timeout(t *testing.T) {
-	var secgroup secgroups.SecurityGroup
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeV2SecGroupDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccComputeV2SecGroup_timeout,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2SecGroupExists("openstack_compute_secgroup_v2.sg_1", &secgroup),
-				),
-			},
-		},
-	})
-}
-
 func testAccCheckComputeV2SecGroupDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	computeClient, err := config.computeV2Client(OS_REGION_NAME)
@@ -388,23 +370,6 @@ resource "openstack_compute_secgroup_v2" "sg_1" {
     to_port = 0
     ip_protocol = "icmp"
     cidr = "2001:558:FC00::/39"
-  }
-}
-`
-
-const testAccComputeV2SecGroup_timeout = `
-resource "openstack_compute_secgroup_v2" "sg_1" {
-  name = "sg_1"
-  description = "first test security group"
-  rule {
-    from_port = 0
-    to_port = 0
-    ip_protocol = "icmp"
-    cidr = "0.0.0.0/0"
-  }
-
-  timeouts {
-    delete = "5m"
   }
 }
 `


### PR DESCRIPTION
For #456 

This one can probably use more refactoring, but I didn't want to make too many changes for fear of breaking something. 

For example, `computeV2SecGroupRulesCheckForErrors` _might_ work as a validation function in the schema. As well, `flattenComputeV2SecGroupRules` might have room for changes.