### PR TITLE
Compute v2: Adding fingerprint to keypair data source

### DIFF
--- a/openstack/data_source_openstack_compute_keypair_v2.go
+++ b/openstack/data_source_openstack_compute_keypair_v2.go
@@ -25,6 +25,11 @@ func dataSourceComputeKeypairV2() *schema.Resource {
 			},
 
 			// computed-only
+			"fingerprint": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"public_key": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -50,6 +55,7 @@ func dataSourceComputeKeypairV2Read(d *schema.ResourceData, meta interface{}) er
 
 	log.Printf("[DEBUG] Retrieved openstack_compute_keypair_v2 %s: %#v", d.Id(), kp)
 
+	d.Set("fingerprint", kp.Fingerprint)
 	d.Set("public_key", kp.PublicKey)
 	d.Set("region", GetRegion(d, config))
 

--- a/openstack/data_source_openstack_compute_keypair_v2_test.go
+++ b/openstack/data_source_openstack_compute_keypair_v2_test.go
@@ -21,6 +21,8 @@ func TestAccComputeV2KeypairDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.openstack_compute_keypair_v2.kp", "name", "the-key-name"),
 					resource.TestCheckResourceAttr(
+						"data.openstack_compute_keypair_v2.kp", "fingerprint", "78:a9:d0:f9:af:a8:1b:ca:bb:9f:65:88:47:af:1d:a9"),
+					resource.TestCheckResourceAttr(
 						"data.openstack_compute_keypair_v2.kp", "public_key", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"),
 				),
 			},

--- a/website/docs/d/compute_keypair_v2.html.markdown
+++ b/website/docs/d/compute_keypair_v2.html.markdown
@@ -32,4 +32,5 @@ The following attributes are exported:
 
 * `region` - See Argument Reference above.
 * `name` - See Argument Reference above.
+* `fingerprint` - The fingerprint of the OpenSSH key.
 * `public_key` - The OpenSSH-formatted public key of the keypair.


### PR DESCRIPTION
For #475 