### PR TITLE
Make the tenantnetworks API not required

### DIFF
--- a/openstack/compute_instance_v2_networking.go
+++ b/openstack/compute_instance_v2_networking.go
@@ -458,7 +458,11 @@ func flattenInstanceNetworks(
 				if err != nil {
 					log.Printf("[WARN] Error getting default network uuid: %s", err)
 				} else {
-					v["uuid"] = networkInfo["uuid"].(string)
+					if v["uuid"] != nil {
+						v["uuid"] = networkInfo["uuid"].(string)
+					} else {
+						log.Printf("[WARN] Could not get default network uuid")
+					}
 				}
 
 				networks = append(networks, v)


### PR DESCRIPTION
Some OpenStack implementations (for instance, at my company) do not
allow the use of the os-tenant-networks API call. This causes a fatal
error when trying to read from an `openstack_compute_instance_v2`
resource. However, this error is not actually fatal as these properties
are not required for destruction. This PR changes the functionality of
the resource to reflect that.

Most of this code was actually removed during the refactor in #39, but it doesn't appear intentional. Hopefully we can bring this back with minimal impact to others.

Fixes #95