### PR TITLE
ComputeV2: add soft policies

### DIFF
--- a/openstack/compute_servergroup_v2.go
+++ b/openstack/compute_servergroup_v2.go
@@ -1,7 +1,13 @@
 package openstack
 
 import (
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
+)
+
+const (
+	softAntiAffinityPolicy = "soft-anti-affinity"
+	softAffinityPolicy     = "soft-affinity"
 )
 
 // ServerGroupCreateOpts is a custom ServerGroup struct to include the
@@ -17,10 +23,16 @@ func (opts ComputeServerGroupV2CreateOpts) ToServerGroupCreateMap() (map[string]
 	return BuildRequest(opts, "server_group")
 }
 
-func expandComputeServerGroupV2Policies(raw []interface{}) []string {
+func expandComputeServerGroupV2Policies(client *gophercloud.ServiceClient, raw []interface{}) []string {
 	policies := make([]string, len(raw))
 	for i, v := range raw {
-		policies[i] = v.(string)
+		policy := v.(string)
+		policies[i] = policy
+
+		// Set microversion for new policies.
+		if policy == softAntiAffinityPolicy || policy == softAffinityPolicy {
+			client.Microversion = "2.15"
+		}
 	}
 
 	return policies

--- a/openstack/compute_servergroup_v2_test.go
+++ b/openstack/compute_servergroup_v2_test.go
@@ -1,12 +1,12 @@
 package openstack
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	thclient "github.com/gophercloud/gophercloud/testhelper/client"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestComputeServerGroupV2CreateOpts(t *testing.T) {
@@ -29,13 +29,9 @@ func TestComputeServerGroupV2CreateOpts(t *testing.T) {
 	}
 
 	actual, err := createOpts.ToServerGroupCreateMap()
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("Maps differ. Want: %#v, but got: %#v", expected, actual)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
 }
 
 func TestExpandComputeServerGroupV2Policies(t *testing.T) {
@@ -44,20 +40,18 @@ func TestExpandComputeServerGroupV2Policies(t *testing.T) {
 	raw := []interface{}{
 		"affinity",
 	}
+	client := thclient.ServiceClient()
 
-	expected := []string{
+	expectedPolicies := []string{
 		"affinity",
 	}
+	expectedMicroversion := ""
 
-	client := thclient.ServiceClient()
-	actual := expandComputeServerGroupV2Policies(client, raw)
+	actualPolicies := expandComputeServerGroupV2Policies(client, raw)
+	actualMicroversion := client.Microversion
 
-	if client.Microversion != "" {
-		t.Fatalf("Expected no microversion in client, but got %s", client.Microversion)
-	}
-	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("Results differ. Want: #%v, but got %#v", expected, actual)
-	}
+	assert.Equal(t, expectedMicroversion, actualMicroversion)
+	assert.Equal(t, expectedPolicies, actualPolicies)
 }
 
 func TestExpandComputeServerGroupV2PoliciesMicroversions(t *testing.T) {
@@ -68,20 +62,18 @@ func TestExpandComputeServerGroupV2PoliciesMicroversions(t *testing.T) {
 		"soft-anti-affinity",
 		"soft-affinity",
 	}
+	client := thclient.ServiceClient()
 
-	expected := []string{
+	expectedPolicies := []string{
 		"affinity",
 		"soft-anti-affinity",
 		"soft-affinity",
 	}
+	expectedMicroversion := "2.15"
 
-	client := thclient.ServiceClient()
-	actual := expandComputeServerGroupV2Policies(client, raw)
+	actualPolicies := expandComputeServerGroupV2Policies(client, raw)
+	actualMicroversion := client.Microversion
 
-	if client.Microversion != "2.15" {
-		t.Fatalf("Expected 2.15 microversion in client, but got %s", client.Microversion)
-	}
-	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("Results differ. Want: #%v, but got %#v", expected, actual)
-	}
+	assert.Equal(t, expectedMicroversion, actualMicroversion)
+	assert.Equal(t, expectedPolicies, actualPolicies)
 }

--- a/openstack/compute_servergroup_v2_test.go
+++ b/openstack/compute_servergroup_v2_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	thclient "github.com/gophercloud/gophercloud/testhelper/client"
 )
 
 func TestComputeServerGroupV2CreateOpts(t *testing.T) {
@@ -37,6 +39,8 @@ func TestComputeServerGroupV2CreateOpts(t *testing.T) {
 }
 
 func TestExpandComputeServerGroupV2Policies(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
 	raw := []interface{}{
 		"affinity",
 	}
@@ -45,8 +49,38 @@ func TestExpandComputeServerGroupV2Policies(t *testing.T) {
 		"affinity",
 	}
 
-	actual := expandComputeServerGroupV2Policies(raw)
+	client := thclient.ServiceClient()
+	actual := expandComputeServerGroupV2Policies(client, raw)
 
+	if client.Microversion != "" {
+		t.Fatalf("Expected no microversion in client, but got %s", client.Microversion)
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Results differ. Want: #%v, but got %#v", expected, actual)
+	}
+}
+
+func TestExpandComputeServerGroupV2PoliciesMicroversions(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	raw := []interface{}{
+		"affinity",
+		"soft-anti-affinity",
+		"soft-affinity",
+	}
+
+	expected := []string{
+		"affinity",
+		"soft-anti-affinity",
+		"soft-affinity",
+	}
+
+	client := thclient.ServiceClient()
+	actual := expandComputeServerGroupV2Policies(client, raw)
+
+	if client.Microversion != "2.15" {
+		t.Fatalf("Expected 2.15 microversion in client, but got %s", client.Microversion)
+	}
 	if !reflect.DeepEqual(expected, actual) {
 		t.Fatalf("Results differ. Want: #%v, but got %#v", expected, actual)
 	}

--- a/openstack/resource_openstack_compute_servergroup_v2.go
+++ b/openstack/resource_openstack_compute_servergroup_v2.go
@@ -64,7 +64,7 @@ func resourceComputeServerGroupV2Create(d *schema.ResourceData, meta interface{}
 	name := d.Get("name").(string)
 
 	rawPolicies := d.Get("policies").([]interface{})
-	policies := expandComputeServerGroupV2Policies(rawPolicies)
+	policies := expandComputeServerGroupV2Policies(computeClient, rawPolicies)
 
 	createOpts := ComputeServerGroupV2CreateOpts{
 		servergroups.CreateOpts{

--- a/website/docs/r/compute_servergroup_v2.html.markdown
+++ b/website/docs/r/compute_servergroup_v2.html.markdown
@@ -30,10 +30,9 @@ The following arguments are supported:
 * `name` - (Required) A unique name for the server group. Changing this creates
     a new server group.
 
-* `policies` - (Required) The set of policies for the server group. Only two
-    two policies are available right now, and both are mutually exclusive. See
-    the Policies section for more information. Changing this creates a new
-    server group.
+* `policies` - (Required) The set of policies for the server group. All policies
+    are mutually exclusive. See the Policies section for more information.
+    Changing this creates a new server group.
 
 * `value_specs` - (Optional) Map of additional options.
 
@@ -44,6 +43,14 @@ The following arguments are supported:
 
 * `anti-affinity` - All instances/servers launched in this group will be
     hosted on different compute nodes.
+
+* `soft-affinity` - All instances/servers launched in this group will be hosted
+    on the same compute node if possible, but if not possible they
+    still will be scheduled instead of failure.
+
+* `soft-anti-affinity` - All instances/servers launched in this group will be
+    hosted on different compute nodes if possible, but if not possible they
+    still will be scheduled instead of failure.
 
 ## Attributes Reference
 

--- a/website/docs/r/compute_servergroup_v2.html.markdown
+++ b/website/docs/r/compute_servergroup_v2.html.markdown
@@ -46,11 +46,13 @@ The following arguments are supported:
 
 * `soft-affinity` - All instances/servers launched in this group will be hosted
     on the same compute node if possible, but if not possible they
-    still will be scheduled instead of failure.
+    still will be scheduled instead of failure. To use this policy your
+    OpenStack environment should support Compute service API 2.15 or above.
 
 * `soft-anti-affinity` - All instances/servers launched in this group will be
     hosted on different compute nodes if possible, but if not possible they
-    still will be scheduled instead of failure.
+    still will be scheduled instead of failure. To use this policy your
+    OpenStack environment should support Compute service API 2.15 or above.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Set "2.15" microversion for servergroup "soft-anti-affinity" and "soft-affinity" policies.
Add tests and documentation notes.

For #118 