### PR TITLE
[DNM]Add jobs to integrate terraform-provider-openstack with generic clouds

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -34,3 +34,6 @@
     recheck-fwaas:
       jobs:
         - terraform-provider-openstack-acceptance-test-fwaas
+    check-generic-cloud:
+      jobs:
+        - terraform-provider-openstack-acceptance-test-telefonica


### PR DESCRIPTION
Add jobs to integrate terraform-provider-openstack with
public clouds: telefonica, orange, opentelekomcloud and huaweicloud.

Related-Bug: theopenlab/openlab#125