### PR TITLE
Internal: port allowed address pairs cleanup

### DIFF
--- a/openstack/networking_port_v2.go
+++ b/openstack/networking_port_v2.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/extradhcpopts"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -79,4 +80,36 @@ func flattenNetworkingPortDHCPOptsV2(dhcpOpts extradhcpopts.ExtraDHCPOptsExt) []
 	}
 
 	return dhcpOptsSet
+}
+
+func expandNetworkingPortAllowedAddressPairsV2(allowedAddressPairs *schema.Set) []ports.AddressPair {
+	rawPairs := allowedAddressPairs.List()
+
+	pairs := make([]ports.AddressPair, len(rawPairs))
+	for i, raw := range rawPairs {
+		rawMap := raw.(map[string]interface{})
+		pairs[i] = ports.AddressPair{
+			IPAddress:  rawMap["ip_address"].(string),
+			MACAddress: rawMap["mac_address"].(string),
+		}
+	}
+
+	return pairs
+}
+
+func flattenNetworkingPortAllowedAddressPairsV2(mac string, allowedAddressPairs []ports.AddressPair) []map[string]interface{} {
+	pairs := make([]map[string]interface{}, len(allowedAddressPairs))
+
+	for i, pair := range allowedAddressPairs {
+		pairs[i] = map[string]interface{}{
+			"ip_address": pair.IPAddress,
+		}
+		// Only set the MAC address if it is different than the
+		// port's MAC. This means that a specific MAC was set.
+		if pair.MACAddress != mac {
+			pairs[i]["mac_address"] = pair.MACAddress
+		}
+	}
+
+	return pairs
 }

--- a/openstack/networking_port_v2_test.go
+++ b/openstack/networking_port_v2_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/extradhcpopts"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -185,5 +186,71 @@ func TestFlattenNetworkingPort2DHCPOptionsV2(t *testing.T) {
 	if !reflect.DeepEqual(actualDHCPOptions, expectedDHCPOptions) {
 		t.Fatalf("DHCP options set differs, want: %+v, but got: %+v",
 			expectedDHCPOptions, actualDHCPOptions)
+	}
+}
+
+func TestExpandNetworkingPortAllowedAddressPairsV2(t *testing.T) {
+	r := resourceNetworkingPortV2()
+	d := r.TestResourceData()
+	d.SetId("1")
+	addressPairs1 := map[string]interface{}{
+		"ip_address":  "192.0.2.1",
+		"mac_address": "mac1",
+	}
+	addressPairs2 := map[string]interface{}{
+		"ip_address":  "198.51.100.1",
+		"mac_address": "mac2",
+	}
+	allowedAddressPairs := []map[string]interface{}{addressPairs1, addressPairs2}
+	d.Set("allowed_address_pairs", allowedAddressPairs)
+
+	expectedAllowedAddressPairs := []ports.AddressPair{
+		{
+			IPAddress:  "192.0.2.1",
+			MACAddress: "mac1",
+		},
+		{
+			IPAddress:  "198.51.100.1",
+			MACAddress: "mac2",
+		},
+	}
+
+	actualAllowedAddressPairs := expandNetworkingPortAllowedAddressPairsV2(d.Get("allowed_address_pairs").(*schema.Set))
+
+	if !reflect.DeepEqual(expectedAllowedAddressPairs, actualAllowedAddressPairs) {
+		t.Fatalf("Allowed address pairs differs, want: %+v, but got: %+v",
+			expectedAllowedAddressPairs, actualAllowedAddressPairs)
+	}
+}
+
+func TestFlattenNetworkingPortAllowedAddressPairsV2(t *testing.T) {
+	allowedAddressPairs := []ports.AddressPair{
+		{
+			IPAddress:  "192.0.2.1",
+			MACAddress: "mac1",
+		},
+		{
+			IPAddress:  "198.51.100.1",
+			MACAddress: "mac2",
+		},
+	}
+	mac := "mac3"
+
+	expectedAllowedAddressPairs := []map[string]interface{}{
+		map[string]interface{}{
+			"ip_address":  "192.0.2.1",
+			"mac_address": "mac1",
+		},
+		map[string]interface{}{
+			"ip_address":  "198.51.100.1",
+			"mac_address": "mac2",
+		},
+	}
+
+	actualAllowedAddressPairs := flattenNetworkingPortAllowedAddressPairsV2(mac, allowedAddressPairs)
+
+	if !reflect.DeepEqual(actualAllowedAddressPairs, expectedAllowedAddressPairs) {
+		t.Fatalf("Allowed address pairs differs, want: %+v, but got: %+v",
+			expectedAllowedAddressPairs, actualAllowedAddressPairs)
 	}
 }

--- a/openstack/networking_port_v2_test.go
+++ b/openstack/networking_port_v2_test.go
@@ -1,13 +1,13 @@
 package openstack
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/extradhcpopts"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestExpandNetworkingPortDHCPOptsV2Create(t *testing.T) {
@@ -42,10 +42,7 @@ func TestExpandNetworkingPortDHCPOptsV2Create(t *testing.T) {
 
 	actualDHCPOptions := expandNetworkingPortDHCPOptsV2Create(d.Get("extra_dhcp_option").(*schema.Set))
 
-	if !reflect.DeepEqual(expectedDHCPOptions, actualDHCPOptions) {
-		t.Fatalf("DHCP options differs, want: %+v, but got: %+v",
-			expectedDHCPOptions, actualDHCPOptions)
-	}
+	assert.ElementsMatch(t, expectedDHCPOptions, actualDHCPOptions)
 }
 
 func TestExpandNetworkingPortDHCPOptsEmptyV2Create(t *testing.T) {
@@ -57,10 +54,7 @@ func TestExpandNetworkingPortDHCPOptsEmptyV2Create(t *testing.T) {
 
 	actualDHCPOptions := expandNetworkingPortDHCPOptsV2Create(d.Get("extra_dhcp_option").(*schema.Set))
 
-	if !reflect.DeepEqual(expectedDHCPOptions, actualDHCPOptions) {
-		t.Fatalf("DHCP options differs, want: %+v, but got: %+v",
-			expectedDHCPOptions, actualDHCPOptions)
-	}
+	assert.ElementsMatch(t, expectedDHCPOptions, actualDHCPOptions)
 }
 
 func TestExpandNetworkingPortDHCPOptsV2Update(t *testing.T) {
@@ -97,10 +91,7 @@ func TestExpandNetworkingPortDHCPOptsV2Update(t *testing.T) {
 
 	actualDHCPOptions := expandNetworkingPortDHCPOptsV2Update(d.Get("extra_dhcp_option").(*schema.Set))
 
-	if !reflect.DeepEqual(expectedDHCPOptions, actualDHCPOptions) {
-		t.Fatalf("DHCP options differs, want: %+v, but got: %+v",
-			expectedDHCPOptions, actualDHCPOptions)
-	}
+	assert.ElementsMatch(t, expectedDHCPOptions, actualDHCPOptions)
 }
 
 func TestExpandNetworkingPortDHCPOptsEmptyV2Update(t *testing.T) {
@@ -112,10 +103,7 @@ func TestExpandNetworkingPortDHCPOptsEmptyV2Update(t *testing.T) {
 
 	actualDHCPOptions := expandNetworkingPortDHCPOptsV2Update(d.Get("extra_dhcp_option").(*schema.Set))
 
-	if !reflect.DeepEqual(expectedDHCPOptions, actualDHCPOptions) {
-		t.Fatalf("DHCP options differs, want: %+v, but got: %+v",
-			expectedDHCPOptions, actualDHCPOptions)
-	}
+	assert.ElementsMatch(t, expectedDHCPOptions, actualDHCPOptions)
 }
 
 func TestExpandNetworkingPortDHCPOptsV2Delete(t *testing.T) {
@@ -146,10 +134,7 @@ func TestExpandNetworkingPortDHCPOptsV2Delete(t *testing.T) {
 
 	actualDHCPOptions := expandNetworkingPortDHCPOptsV2Delete(d.Get("extra_dhcp_option").(*schema.Set))
 
-	if !reflect.DeepEqual(expectedDHCPOptions, actualDHCPOptions) {
-		t.Fatalf("DHCP options differs, want: %+v, but got: %+v",
-			expectedDHCPOptions, actualDHCPOptions)
-	}
+	assert.ElementsMatch(t, expectedDHCPOptions, actualDHCPOptions)
 }
 
 func TestFlattenNetworkingPort2DHCPOptionsV2(t *testing.T) {
@@ -183,10 +168,7 @@ func TestFlattenNetworkingPort2DHCPOptionsV2(t *testing.T) {
 
 	actualDHCPOptions := flattenNetworkingPortDHCPOptsV2(dhcpOptions)
 
-	if !reflect.DeepEqual(actualDHCPOptions, expectedDHCPOptions) {
-		t.Fatalf("DHCP options set differs, want: %+v, but got: %+v",
-			expectedDHCPOptions, actualDHCPOptions)
-	}
+	assert.ElementsMatch(t, expectedDHCPOptions, actualDHCPOptions)
 }
 
 func TestExpandNetworkingPortAllowedAddressPairsV2(t *testing.T) {
@@ -217,10 +199,7 @@ func TestExpandNetworkingPortAllowedAddressPairsV2(t *testing.T) {
 
 	actualAllowedAddressPairs := expandNetworkingPortAllowedAddressPairsV2(d.Get("allowed_address_pairs").(*schema.Set))
 
-	if !reflect.DeepEqual(expectedAllowedAddressPairs, actualAllowedAddressPairs) {
-		t.Fatalf("Allowed address pairs differs, want: %+v, but got: %+v",
-			expectedAllowedAddressPairs, actualAllowedAddressPairs)
-	}
+	assert.ElementsMatch(t, expectedAllowedAddressPairs, actualAllowedAddressPairs)
 }
 
 func TestFlattenNetworkingPortAllowedAddressPairsV2(t *testing.T) {
@@ -249,8 +228,5 @@ func TestFlattenNetworkingPortAllowedAddressPairsV2(t *testing.T) {
 
 	actualAllowedAddressPairs := flattenNetworkingPortAllowedAddressPairsV2(mac, allowedAddressPairs)
 
-	if !reflect.DeepEqual(actualAllowedAddressPairs, expectedAllowedAddressPairs) {
-		t.Fatalf("Allowed address pairs differs, want: %+v, but got: %+v",
-			expectedAllowedAddressPairs, actualAllowedAddressPairs)
-	}
+	assert.ElementsMatch(t, expectedAllowedAddressPairs, actualAllowedAddressPairs)
 }


### PR DESCRIPTION
Move all Networking port V2 allowed pairs related code into networking_port_v2.go and provide tests to new functions.

Use testify/assert for networking_port_v2_test.go.

For #456, #458