### PR TITLE
LBaaS: Allow LB listener default pool update without the listener re-creation

### DIFF
--- a/openstack/resource_openstack_lb_listener_v2.go
+++ b/openstack/resource_openstack_lb_listener_v2.go
@@ -75,7 +75,6 @@ func resourceListenerV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 
 			"description": &schema.Schema{
@@ -223,6 +222,10 @@ func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("connection_limit") {
 		connLimit := d.Get("connection_limit").(int)
 		updateOpts.ConnLimit = &connLimit
+	}
+	if d.HasChange("default_pool_id") {
+		defaultPoolID := d.Get("default_pool_id").(string)
+		updateOpts.DefaultPoolID = &defaultPoolID
 	}
 	if d.HasChange("default_tls_container_ref") {
 		updateOpts.DefaultTlsContainerRef = d.Get("default_tls_container_ref").(string)

--- a/openstack/resource_openstack_lb_listener_v2_test.go
+++ b/openstack/resource_openstack_lb_listener_v2_test.go
@@ -109,10 +109,18 @@ resource "openstack_lb_loadbalancer_v2" "loadbalancer_1" {
   vip_subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
 }
 
+resource "openstack_lb_pool_v2" "pool_1" {
+  name            = "pool_1"
+  protocol        = "HTTP"
+  lb_method       = "ROUND_ROBIN"
+  loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"
+}
+
 resource "openstack_lb_listener_v2" "listener_1" {
   name = "listener_1"
   protocol = "HTTP"
   protocol_port = 8080
+  default_pool_id = "${openstack_lb_pool_v2.pool_1.id}"
   loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"
 
 	timeouts {
@@ -147,6 +155,7 @@ resource "openstack_lb_listener_v2" "listener_1" {
   protocol_port = 8080
   connection_limit = 100
   admin_state_up = "true"
+  default_pool_id = ""
   loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"
 
 	timeouts {

--- a/openstack/resource_openstack_lb_loadbalancer_v2.go
+++ b/openstack/resource_openstack_lb_loadbalancer_v2.go
@@ -215,26 +215,28 @@ func resourceLoadBalancerV2Update(d *schema.ResourceData, meta interface{}) erro
 		updateOpts.AdminStateUp = &asu
 	}
 
-	// Wait for LoadBalancer to become active before continuing
-	timeout := d.Timeout(schema.TimeoutUpdate)
-	err = waitForLBV2LoadBalancer(lbClient, d.Id(), "ACTIVE", nil, timeout)
-	if err != nil {
-		return err
-	}
-
-	log.Printf("[DEBUG] Updating loadbalancer %s with options: %#v", d.Id(), updateOpts)
-	err = resource.Retry(timeout, func() *resource.RetryError {
-		_, err = loadbalancers.Update(lbClient, d.Id(), updateOpts).Extract()
+	if updateOpts != (loadbalancers.UpdateOpts{}) {
+		// Wait for LoadBalancer to become active before continuing
+		timeout := d.Timeout(schema.TimeoutUpdate)
+		err = waitForLBV2LoadBalancer(lbClient, d.Id(), "ACTIVE", nil, timeout)
 		if err != nil {
-			return checkForRetryableError(err)
+			return err
 		}
-		return nil
-	})
 
-	// Wait for LoadBalancer to become active before continuing
-	err = waitForLBV2LoadBalancer(lbClient, d.Id(), "ACTIVE", nil, timeout)
-	if err != nil {
-		return err
+		log.Printf("[DEBUG] Updating loadbalancer %s with options: %#v", d.Id(), updateOpts)
+		err = resource.Retry(timeout, func() *resource.RetryError {
+			_, err = loadbalancers.Update(lbClient, d.Id(), updateOpts).Extract()
+			if err != nil {
+				return checkForRetryableError(err)
+			}
+			return nil
+		})
+
+		// Wait for LoadBalancer to become active before continuing
+		err = waitForLBV2LoadBalancer(lbClient, d.Id(), "ACTIVE", nil, timeout)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Security Groups get updated separately

--- a/website/docs/r/lb_listener_v2.html.markdown
+++ b/website/docs/r/lb_listener_v2.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
     to be unique.
 
 * `default_pool_id` - (Optional) The ID of the default pool with which the
-    Listener is associated. Changing this creates a new Listener.
+    Listener is associated.
 
 * `description` - (Optional) Human-readable description for the Listener.
 


### PR DESCRIPTION
for #507
depends on #509