### PR TITLE
NetworkingV2: add transparent_vlan network datasource attribute 

### DIFF
--- a/openstack/data_source_openstack_networking_network_v2.go
+++ b/openstack/data_source_openstack_networking_network_v2.go
@@ -69,7 +69,7 @@ func dataSourceNetworkingNetworkV2() *schema.Resource {
 			},
 			"transparent_vlan": &schema.Schema{
 				Type:     schema.TypeBool,
-				Computed: true,
+				Optional: true,
 			},
 		},
 	}

--- a/openstack/data_source_openstack_networking_network_v2.go
+++ b/openstack/data_source_openstack_networking_network_v2.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vlantransparent"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 )
@@ -66,6 +67,10 @@ func dataSourceNetworkingNetworkV2() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"transparent_vlan": &schema.Schema{
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -74,6 +79,7 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 
+	// Prepare basic listOpts.
 	var listOpts networks.ListOptsBuilder
 
 	var status string
@@ -89,11 +95,21 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 		Status:      status,
 	}
 
+	// Add the external attribute if specified.
 	if v, ok := d.GetOkExists("external"); ok {
 		isExternal := v.(bool)
 		listOpts = external.ListOptsExt{
 			ListOptsBuilder: listOpts,
 			External:        &isExternal,
+		}
+	}
+
+	// Add the transparent VLAN attribute if specified.
+	if v, ok := d.GetOkExists("transparent_vlan"); ok {
+		isVLANTransparent := v.(bool)
+		listOpts = vlantransparent.ListOptsExt{
+			ListOptsBuilder: listOpts,
+			VLANTransparent: &isVLANTransparent,
 		}
 	}
 
@@ -117,6 +133,7 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 	type networkWithExternalExt struct {
 		networks.Network
 		external.NetworkExternalExt
+		vlantransparent.TransparentExt
 	}
 	var allNetworks []networkWithExternalExt
 	err = networks.ExtractNetworksInto(pages, &allNetworks)
@@ -170,6 +187,7 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 	d.Set("external", network.External)
 	d.Set("tenant_id", network.TenantID)
 	d.Set("region", GetRegion(d, config))
+	d.Set("transparent_vlan", network.VLANTransparent)
 
 	return nil
 }

--- a/openstack/data_source_openstack_networking_network_v2_test.go
+++ b/openstack/data_source_openstack_networking_network_v2_test.go
@@ -131,18 +131,18 @@ func TestAccOpenStackNetworkingNetworkV2DataSource_transparent_vlan(t *testing.T
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccOpenStackNetworkingNetworkV2DataSource_network,
+				Config: testAccNetworkingV2Network_transparent_vlan,
 			},
 			resource.TestStep{
-				Config: testAccNetworkingV2Network_transparent_vlan,
+				Config: testAccOpenStackNetworkingNetworkV2DataSource_transparent_vlan,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingNetworkV2DataSourceID("data.openstack_networking_network_v2.net"),
 					resource.TestCheckResourceAttr(
-						"data.openstack_networking_network_v2.net", "name", OS_POOL_NAME),
+						"data.openstack_networking_network_v2.network_1", "name", "network_1"),
 					resource.TestCheckResourceAttr(
-						"data.openstack_networking_network_v2.net", "admin_state_up", "true"),
+						"data.openstack_networking_network_v2.network_1", "admin_state_up", "true"),
 					resource.TestCheckResourceAttr(
-						"data.openstack_networking_network_v2.net", "vlan_transparent", "true"),
+						"data.openstack_networking_network_v2.network_1", "transparent_vlan", "true"),
 				),
 			},
 		},
@@ -220,7 +220,7 @@ data "openstack_networking_network_v2" "net" {
 var testAccOpenStackNetworkingNetworkV2DataSource_transparent_vlan = fmt.Sprintf(`
 %s
 
-data "openstack_networking_network_v2" "net" {
-    transparent_vlan = "true"
+data "openstack_networking_network_v2" "network_1" {
+    transparent_vlan = "${openstack_networking_network_v2.network_1.transparent_vlan}"
 }
 `, testAccNetworkingV2Network_transparent_vlan)

--- a/openstack/data_source_openstack_networking_network_v2_test.go
+++ b/openstack/data_source_openstack_networking_network_v2_test.go
@@ -122,6 +122,33 @@ func TestAccOpenStackNetworkingNetworkV2DataSource_externalImplicit(t *testing.T
 	})
 }
 
+func TestAccOpenStackNetworkingNetworkV2DataSource_transparent_vlan(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckTransparentVLAN(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOpenStackNetworkingNetworkV2DataSource_network,
+			},
+			resource.TestStep{
+				Config: testAccNetworkingV2Network_transparent_vlan,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingNetworkV2DataSourceID("data.openstack_networking_network_v2.net"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_network_v2.net", "name", OS_POOL_NAME),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_network_v2.net", "admin_state_up", "true"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_network_v2.net", "vlan_transparent", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingNetworkV2DataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -189,3 +216,11 @@ data "openstack_networking_network_v2" "net" {
 	name = "%s"
 }
 `, OS_POOL_NAME)
+
+var testAccOpenStackNetworkingNetworkV2DataSource_transparent_vlan = fmt.Sprintf(`
+%s
+
+data "openstack_networking_network_v2" "net" {
+    transparent_vlan = "true"
+}
+`, testAccNetworkingV2Network_transparent_vlan)

--- a/openstack/data_source_openstack_networking_network_v2_test.go
+++ b/openstack/data_source_openstack_networking_network_v2_test.go
@@ -136,7 +136,7 @@ func TestAccOpenStackNetworkingNetworkV2DataSource_transparent_vlan(t *testing.T
 			resource.TestStep{
 				Config: testAccOpenStackNetworkingNetworkV2DataSource_transparent_vlan,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingNetworkV2DataSourceID("data.openstack_networking_network_v2.net"),
+					testAccCheckNetworkingNetworkV2DataSourceID("data.openstack_networking_network_v2.network_1"),
 					resource.TestCheckResourceAttr(
 						"data.openstack_networking_network_v2.network_1", "name", "network_1"),
 					resource.TestCheckResourceAttr(

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -723,8 +723,8 @@
 		{
 			"checksumSHA1": "TH4LSJLhZlq0fW36UVWltFlM3KA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vlantransparent",
-			"revision": "26de66c23d78a75fc37e5dad5b6f16ffbfe9ee31",
-			"revisionTime": "2018-12-08T02:58:21Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "grviOYvybawC80v7Fmw0XOBwr0A=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -727,6 +727,12 @@
 			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
+			"checksumSHA1": "TH4LSJLhZlq0fW36UVWltFlM3KA=",
+			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vlantransparent",
+			"revision": "26de66c23d78a75fc37e5dad5b6f16ffbfe9ee31",
+			"revisionTime": "2018-12-08T02:58:21Z"
+		},
+		{
 			"checksumSHA1": "grviOYvybawC80v7Fmw0XOBwr0A=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/endpointgroups",
 			"revision": "a1de06b8040b6da28b21c6f32b446b836d475b04",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -717,8 +717,8 @@
 		{
 			"checksumSHA1": "TH4LSJLhZlq0fW36UVWltFlM3KA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vlantransparent",
-			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
-			"revisionTime": "2018-12-20T15:44:12Z"
+			"revision": "a1de06b8040b6da28b21c6f32b446b836d475b04",
+			"revisionTime": "2019-01-04T03:12:19Z"
 		},
 		{
 			"checksumSHA1": "TH4LSJLhZlq0fW36UVWltFlM3KA=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -721,6 +721,12 @@
 			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
+			"checksumSHA1": "TH4LSJLhZlq0fW36UVWltFlM3KA=",
+			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vlantransparent",
+			"revision": "26de66c23d78a75fc37e5dad5b6f16ffbfe9ee31",
+			"revisionTime": "2018-12-08T02:58:21Z"
+		},
+		{
 			"checksumSHA1": "grviOYvybawC80v7Fmw0XOBwr0A=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/endpointgroups",
 			"revision": "a1de06b8040b6da28b21c6f32b446b836d475b04",

--- a/website/docs/d/networking_network_v2.html.markdown
+++ b/website/docs/d/networking_network_v2.html.markdown
@@ -40,6 +40,8 @@ data "openstack_networking_network_v2" "network" {
 
 * `availability_zone_hints` - (Optional) The availability zone candidates for the network.
 
+* `transparent_vlan` - (Optional) The VLAN transparent attribute for the
+  network.
 
 ## Attributes Reference
 
@@ -54,3 +56,4 @@ are exported:
 * `shared` - (Optional)  Specifies whether the network resource can be accessed
     by any tenant or not.
 * `availability_zone_hints` - (Optional) The availability zone candidates for the network.
+* `transparent_vlan` - See Argument Reference above.


### PR DESCRIPTION
Add the "transparent_vlan" attribute into networking_network_v2 datasource.

For #430