### PR TITLE
Compute v2: Fix Instance NIC indexing

### DIFF
--- a/openstack/compute_instance_v2_networking.go
+++ b/openstack/compute_instance_v2_networking.go
@@ -463,6 +463,11 @@ func flattenInstanceNetworks(
 	// Loop through all networks and addresses, merge relevant address details.
 	for _, instanceNetwork := range allInstanceNetworks {
 		for _, instanceAddresses := range allInstanceAddresses {
+			// Skip if instanceAddresses has no NICs
+			if len(instanceAddresses.InstanceNICs) == 0 {
+				continue
+			}
+
 			if instanceNetwork.Name == instanceAddresses.NetworkName {
 				// Only use one NIC since it's possible the user defined another NIC
 				// on this same network in another Terraform network block.


### PR DESCRIPTION
At the time of the panic, the Compute API did not return any addresses
of the instance. This might have been a transient error, but even if so,
we should ensure proper checks are in place to prevent such panics.

Fixes #506 