### PR TITLE
Provider: Fix default values for boolean arguments

### DIFF
--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -165,14 +165,14 @@ func Provider() terraform.ResourceProvider {
 			"swauth": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_SWAUTH", ""),
+				DefaultFunc: schema.EnvDefaultFunc("OS_SWAUTH", false),
 				Description: descriptions["swauth"],
 			},
 
 			"use_octavia": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_USE_OCTAVIA", ""),
+				DefaultFunc: schema.EnvDefaultFunc("OS_USE_OCTAVIA", false),
 				Description: descriptions["use_octavia"],
 			},
 


### PR DESCRIPTION
This commit fixes the default value for boolean provider arguments. This
is to resolve more strict type features in Terraform v0.12.

/cc @sjwl

I tested this by compiling a new binary with this change and using it on an existing state. No changes were made as these settings are not stored in the state. Therefore, this should not be user impacting.