### PR TITLE
LBaaSv2: Detect individual LB object statuses, don't rely on LB status

### DIFF
--- a/openstack/lb_v2_shared.go
+++ b/openstack/lb_v2_shared.go
@@ -20,7 +20,7 @@ import (
 var lbPendingStatuses = []string{"PENDING_CREATE", "PENDING_UPDATE"}
 
 // lbPendingDeleteStatuses are the valid statuses a LoadBalancer will be before delete
-var lbPendingDeleteStatuses = []string{"PENDING_UPDATE", "PENDING_DELETE", "ACTIVE"}
+var lbPendingDeleteStatuses = []string{"ERROR", "PENDING_UPDATE", "PENDING_DELETE", "ACTIVE"}
 
 // chooseLBV2Client will determine which load balacing client to use:
 // Either the Octavia/LBaaS client or the Neutron/Networking v2 client.

--- a/openstack/lb_v2_shared.go
+++ b/openstack/lb_v2_shared.go
@@ -137,7 +137,7 @@ func waitForLBV2Member(lbClient *gophercloud.ServiceClient, parentPool *pools.Po
 
 	var refreshFunc resource.StateRefreshFunc
 	if member.ProvisioningStatus != "" {
-		refreshFunc = resourceLBV2MemberRefreshFunc(lbClient, member.PoolID, member.ID)
+		refreshFunc = resourceLBV2MemberRefreshFunc(lbClient, parentPool.ID, member.ID)
 	} else {
 		lbID, err := lbV2FindLBIDviaPool(lbClient, parentPool)
 		if err != nil {

--- a/openstack/lb_v2_shared.go
+++ b/openstack/lb_v2_shared.go
@@ -42,13 +42,27 @@ func chooseLBV2AccTestClient(config *Config, region string) (*gophercloud.Servic
 	return config.networkingV2Client(region)
 }
 
-func waitForLBV2Listener(lbClient *gophercloud.ServiceClient, id string, lbID *string, target string, pending []string, timeout time.Duration) error {
-	log.Printf("[DEBUG] Waiting for listener %s to become %s.", id, target)
+func waitForLBV2Listener(lbClient *gophercloud.ServiceClient, listener *listeners.Listener, target string, pending []string, timeout time.Duration) error {
+	log.Printf("[DEBUG] Waiting for listener %s to become %s.", listener.ID, target)
+
+	var refreshFunc resource.StateRefreshFunc
+	if listener.ProvisioningStatus != "" {
+		refreshFunc = resourceLBV2ListenerRefreshFunc(lbClient, listener.ID)
+	} else {
+		if len(listener.Loadbalancers) > 0 {
+			lbID := listener.Loadbalancers[0].ID
+			refreshFunc = resourceLBV2LoadBalancerStatusRefreshFunc(lbClient, lbID, "listener", listener.ID)
+		}
+	}
+
+	if refreshFunc == nil {
+		return fmt.Errorf("Unable to determine how to check listener status")
+	}
 
 	stateConf := &resource.StateChangeConf{
 		Target:     []string{target},
 		Pending:    pending,
-		Refresh:    resourceLBV2ListenerRefreshFunc(lbClient, id, lbID, target),
+		Refresh:    refreshFunc,
 		Timeout:    timeout,
 		Delay:      1 * time.Second,
 		MinTimeout: 1 * time.Second,
@@ -57,46 +71,25 @@ func waitForLBV2Listener(lbClient *gophercloud.ServiceClient, id string, lbID *s
 	_, err := stateConf.WaitForState()
 	if err != nil {
 		if _, ok := err.(gophercloud.ErrDefault404); ok {
-			switch target {
-			case "DELETED":
+			if target == "DELETED" {
 				return nil
-			default:
-				return fmt.Errorf("Error: listener %s not found: %s", id, err)
 			}
 		}
-		return fmt.Errorf("Error waiting for listener %s to become %s: %s", id, target, err)
+
+		return fmt.Errorf("Error waiting for listener %s to become %s: %s", listener.ID, target, err)
 	}
 
 	return nil
 }
 
-func resourceLBV2ListenerRefreshFunc(lbClient *gophercloud.ServiceClient, id string, lbID *string, target string) resource.StateRefreshFunc {
+func resourceLBV2ListenerRefreshFunc(lbClient *gophercloud.ServiceClient, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		// Status func to get Listener's status
-		statusFunc := func(lbClient *gophercloud.ServiceClient, loadbalancerID *string) (interface{}, string, error) {
-			listener, err := listeners.Get(lbClient, id).Extract()
-			if err != nil {
-				return nil, "", err
-			}
-
-			if listener.ProvisioningStatus != "" {
-				return listener, listener.ProvisioningStatus, nil
-			}
-
-			// First run without knowing parent Load Balancer ID
-			if len(listener.Loadbalancers) > 0 {
-				// Avoid situations, when nil, but not empty string, has been passed
-				if loadbalancerID != nil {
-					*loadbalancerID = listener.Loadbalancers[0].ID
-					// Cache parent Load Balancer ID
-					log.Printf("[DEBUG] Cached %s Load Balancer ID", *loadbalancerID)
-				}
-			}
-
-			return nil, "", fmt.Errorf("Unable to detect provisioning status for the %s listener", id)
+		lb, err := listeners.Get(lbClient, id).Extract()
+		if err != nil {
+			return nil, "", err
 		}
 
-		return lbV2GetProvisioningStatus(lbClient, statusFunc, id, lbID, target)
+		return lb, lb.ProvisioningStatus, nil
 	}
 }
 
@@ -139,13 +132,25 @@ func resourceLBV2LoadBalancerRefreshFunc(lbClient *gophercloud.ServiceClient, id
 	}
 }
 
-func waitForLBV2Member(lbClient *gophercloud.ServiceClient, poolID, memberID string, lbID *string, target string, pending []string, timeout time.Duration) error {
-	log.Printf("[DEBUG] Waiting for member %s to become %s.", memberID, target)
+func waitForLBV2Member(lbClient *gophercloud.ServiceClient, parentPool *pools.Pool, member *pools.Member, target string, pending []string, timeout time.Duration) error {
+	log.Printf("[DEBUG] Waiting for member %s to become %s.", member.ID, target)
+
+	var refreshFunc resource.StateRefreshFunc
+	if member.ProvisioningStatus != "" {
+		refreshFunc = resourceLBV2MemberRefreshFunc(lbClient, member.PoolID, member.ID)
+	} else {
+		lbID, err := lbV2FindLBIDviaPool(lbClient, parentPool)
+		if err != nil {
+			return err
+		}
+
+		refreshFunc = resourceLBV2LoadBalancerStatusRefreshFunc(lbClient, lbID, "member", member.ID)
+	}
 
 	stateConf := &resource.StateChangeConf{
 		Target:     []string{target},
 		Pending:    pending,
-		Refresh:    resourceLBV2MemberRefreshFunc(lbClient, poolID, memberID, lbID, target),
+		Refresh:    refreshFunc,
 		Timeout:    timeout,
 		Delay:      1 * time.Second,
 		MinTimeout: 1 * time.Second,
@@ -154,46 +159,47 @@ func waitForLBV2Member(lbClient *gophercloud.ServiceClient, poolID, memberID str
 	_, err := stateConf.WaitForState()
 	if err != nil {
 		if _, ok := err.(gophercloud.ErrDefault404); ok {
-			switch target {
-			case "DELETED":
+			if target == "DELETED" {
 				return nil
-			default:
-				return fmt.Errorf("Error: member %s not found: %s", memberID, err)
 			}
 		}
-		return fmt.Errorf("Error waiting for member %s to become %s: %s", memberID, target, err)
+
+		return fmt.Errorf("Error waiting for member %s to become %s: %s", member.ID, target, err)
 	}
 
 	return nil
 }
 
-func resourceLBV2MemberRefreshFunc(lbClient *gophercloud.ServiceClient, poolID, memberID string, lbID *string, target string) resource.StateRefreshFunc {
+func resourceLBV2MemberRefreshFunc(lbClient *gophercloud.ServiceClient, poolID, memberID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		// Status func to get Pool member's status
-		statusFunc := func(lbClient *gophercloud.ServiceClient, loadbalancerID *string) (interface{}, string, error) {
-			member, err := pools.GetMember(lbClient, poolID, memberID).Extract()
-			if err != nil {
-				return nil, "", err
-			}
-
-			if member.ProvisioningStatus != "" {
-				return member, member.ProvisioningStatus, nil
-			}
-
-			return nil, "", fmt.Errorf("Unable to detect provisioning status for the %s pool's %s member", poolID, memberID)
+		member, err := pools.GetMember(lbClient, poolID, memberID).Extract()
+		if err != nil {
+			return nil, "", err
 		}
 
-		return lbV2GetProvisioningStatus(lbClient, statusFunc, memberID, lbID, target)
+		return member, member.ProvisioningStatus, nil
 	}
 }
 
-func waitForLBV2Monitor(lbClient *gophercloud.ServiceClient, id string, lbID *string, target string, pending []string, timeout time.Duration) error {
-	log.Printf("[DEBUG] Waiting for monitor %s to become %s.", id, target)
+func waitForLBV2Monitor(lbClient *gophercloud.ServiceClient, parentPool *pools.Pool, monitor *monitors.Monitor, target string, pending []string, timeout time.Duration) error {
+	log.Printf("[DEBUG] Waiting for monitor %s to become %s.", monitor.ID, target)
+
+	var refreshFunc resource.StateRefreshFunc
+	if monitor.ProvisioningStatus != "" {
+		refreshFunc = resourceLBV2MonitorRefreshFunc(lbClient, monitor.ID)
+	} else {
+		lbID, err := lbV2FindLBIDviaPool(lbClient, parentPool)
+		if err != nil {
+			return err
+		}
+
+		refreshFunc = resourceLBV2LoadBalancerStatusRefreshFunc(lbClient, lbID, "monitor", monitor.ID)
+	}
 
 	stateConf := &resource.StateChangeConf{
 		Target:     []string{target},
 		Pending:    pending,
-		Refresh:    resourceLBV2MonitorRefreshFunc(lbClient, id, lbID, target),
+		Refresh:    refreshFunc,
 		Timeout:    timeout,
 		Delay:      1 * time.Second,
 		MinTimeout: 1 * time.Second,
@@ -202,46 +208,46 @@ func waitForLBV2Monitor(lbClient *gophercloud.ServiceClient, id string, lbID *st
 	_, err := stateConf.WaitForState()
 	if err != nil {
 		if _, ok := err.(gophercloud.ErrDefault404); ok {
-			switch target {
-			case "DELETED":
+			if target == "DELETED" {
 				return nil
-			default:
-				return fmt.Errorf("Error: monitor %s not found: %s", id, err)
 			}
 		}
-		return fmt.Errorf("Error waiting for monitor %s to become %s: %s", id, target, err)
+		return fmt.Errorf("Error waiting for monitor %s to become %s: %s", monitor.ID, target, err)
 	}
 
 	return nil
 }
 
-func resourceLBV2MonitorRefreshFunc(lbClient *gophercloud.ServiceClient, id string, lbID *string, target string) resource.StateRefreshFunc {
+func resourceLBV2MonitorRefreshFunc(lbClient *gophercloud.ServiceClient, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		// Status func to get Listener's status
-		statusFunc := func(lbClient *gophercloud.ServiceClient, loadbalancerID *string) (interface{}, string, error) {
-			monitor, err := monitors.Get(lbClient, id).Extract()
-			if err != nil {
-				return nil, "", err
-			}
-
-			if monitor.ProvisioningStatus != "" {
-				return monitor, monitor.ProvisioningStatus, nil
-			}
-
-			return nil, "", fmt.Errorf("Unable to detect provisioning status for the %s monitor", id)
+		monitor, err := monitors.Get(lbClient, id).Extract()
+		if err != nil {
+			return nil, "", err
 		}
 
-		return lbV2GetProvisioningStatus(lbClient, statusFunc, id, lbID, target)
+		return monitor, monitor.ProvisioningStatus, nil
 	}
 }
 
-func waitForLBV2Pool(lbClient *gophercloud.ServiceClient, id string, lbID *string, target string, pending []string, timeout time.Duration) error {
-	log.Printf("[DEBUG] Waiting for pool %s to become %s.", id, target)
+func waitForLBV2Pool(lbClient *gophercloud.ServiceClient, pool *pools.Pool, target string, pending []string, timeout time.Duration) error {
+	log.Printf("[DEBUG] Waiting for pool %s to become %s.", pool.ID, target)
+
+	var refreshFunc resource.StateRefreshFunc
+	if pool.ProvisioningStatus != "" {
+		refreshFunc = resourceLBV2PoolRefreshFunc(lbClient, pool.ID)
+	} else {
+		lbID, err := lbV2FindLBIDviaPool(lbClient, pool)
+		if err != nil {
+			return err
+		}
+
+		refreshFunc = resourceLBV2LoadBalancerStatusRefreshFunc(lbClient, lbID, "pool", pool.ID)
+	}
 
 	stateConf := &resource.StateChangeConf{
 		Target:     []string{target},
 		Pending:    pending,
-		Refresh:    resourceLBV2PoolRefreshFunc(lbClient, id, lbID, target),
+		Refresh:    refreshFunc,
 		Timeout:    timeout,
 		Delay:      1 * time.Second,
 		MinTimeout: 1 * time.Second,
@@ -250,195 +256,102 @@ func waitForLBV2Pool(lbClient *gophercloud.ServiceClient, id string, lbID *strin
 	_, err := stateConf.WaitForState()
 	if err != nil {
 		if _, ok := err.(gophercloud.ErrDefault404); ok {
-			switch target {
-			case "DELETED":
+			if target == "DELETED" {
 				return nil
-			default:
-				return fmt.Errorf("Error: pool %s not found: %s", id, err)
 			}
 		}
-		return fmt.Errorf("Error waiting for pool %s to become %s: %s", id, target, err)
+
+		return fmt.Errorf("Error waiting for pool %s to become %s: %s", pool.ID, target, err)
 	}
 
 	return nil
 }
 
-func resourceLBV2PoolRefreshFunc(lbClient *gophercloud.ServiceClient, poolID string, lbID *string, target string) resource.StateRefreshFunc {
+func resourceLBV2PoolRefreshFunc(lbClient *gophercloud.ServiceClient, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		// Status func to get Pools's status
-		statusFunc := func(lbClient *gophercloud.ServiceClient, loadbalancerID *string) (interface{}, string, error) {
-			pool, err := pools.Get(lbClient, poolID).Extract()
-			if err != nil {
-				return nil, "", err
-			}
-
-			if pool.ProvisioningStatus != "" {
-				return pool, pool.ProvisioningStatus, nil
-			}
-
-			// First run without knowing parent Load Balancer ID
-			if len(pool.Loadbalancers) > 0 {
-				// Avoid situations, when nil, but not empty string, has been passed
-				if loadbalancerID != nil {
-					*loadbalancerID = pool.Loadbalancers[0].ID
-					// Cache parent Load Balancer ID
-					log.Printf("[DEBUG] Cached %s Load Balancer ID", *loadbalancerID)
-				}
-			}
-
-			return nil, "", fmt.Errorf("Unable to detect provisioning status for the %s pool", poolID)
+		pool, err := pools.Get(lbClient, id).Extract()
+		if err != nil {
+			return nil, "", err
 		}
 
-		return lbV2GetProvisioningStatus(lbClient, statusFunc, poolID, lbID, target)
+		return pool, pool.ProvisioningStatus, nil
 	}
 }
 
-func waitForLBV2viaListenerOrLB(lbClient *gophercloud.ServiceClient, listenerID string, lbID *string, target string, pending []string, timeout time.Duration) error {
-	if listenerID != "" {
-		return waitForLBV2Listener(lbClient, listenerID, lbID, target, pending, timeout)
+func lbV2FindLBIDviaPool(lbClient *gophercloud.ServiceClient, pool *pools.Pool) (string, error) {
+	if len(pool.Loadbalancers) > 0 {
+		return pool.Loadbalancers[0].ID, nil
 	}
-	if *lbID != "" {
-		return waitForLBV2LoadBalancer(lbClient, *lbID, target, pending, timeout)
+
+	if len(pool.Listeners) > 0 {
+		listenerID := pool.Listeners[0].ID
+		listener, err := listeners.Get(lbClient, listenerID).Extract()
+		if err != nil {
+			return "", err
+		}
+
+		if len(listener.Loadbalancers) > 0 {
+			return listener.Loadbalancers[0].ID, nil
+		}
 	}
-	return fmt.Errorf("Neither Listener ID nor Load Balancer ID were provided")
+
+	return "", fmt.Errorf("Unable to determine loadbalancer ID from pool %s", pool.ID)
 }
 
-// Function to detect the LB element provisioning status
-func lbV2GetProvisioningStatus(lbClient *gophercloud.ServiceClient,
-	statusFunc func(*gophercloud.ServiceClient, *string) (interface{}, string, error),
-	id string,
-	lbID *string,
-	target string) (interface{}, string, error) {
-
-	log.Printf("[DEBUG] Detecting LBaaSv2 status for the %s using the %s client", id, lbClient.Type)
-
-	res, status, err := statusFunc(lbClient, lbID)
-	if status != "" {
-		return res, status, err
-	}
-
-	log.Printf("[DEBUG] %s, falling back to resolve function", err)
-
-	if lbID != nil && *lbID != "" {
-		return lbV2GetProvisioningStatusViaLB(lbClient, id, *lbID)
-	}
-
-	log.Printf("[DEBUG] %s, falling back to heavy resolve function", err)
-
-	// Heavy API calls begin
-	lbsPages, err := loadbalancers.List(lbClient, loadbalancers.ListOpts{}).AllPages()
-	if err != nil {
-		return nil, "", fmt.Errorf("Failed to list Load Balancers: %s", err)
-	}
-
-	lbs, err := loadbalancers.ExtractLoadBalancers(lbsPages)
-	if err != nil {
-		return nil, "", fmt.Errorf("Failed to extract Load Balancers list into the object: %s", err)
-	}
-
-	for _, lb := range lbs {
-		// Query each Load Balancer we have
-		res, status, err := lbV2GetProvisioningStatusViaLB(lbClient, id, lb.ID)
-		if err == nil {
-			if lbID != nil {
-				*lbID = lb.ID
-				// Cache parent Load Balancer ID
-				log.Printf("[DEBUG] Cached %s Load Balancer ID", *lbID)
-			}
-			return res, status, nil
+func resourceLBV2LoadBalancerStatusRefreshFunc(lbClient *gophercloud.ServiceClient, lbID, resourceType, resourceID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		statuses, err := loadbalancers.GetStatuses(lbClient, lbID).Extract()
+		if err != nil {
+			return nil, "", fmt.Errorf("Unable to get statuses from the Load Balancer %s statuses tree: %s", lbID, err)
 		}
-		log.Printf("[DEBUG] %s", err)
-	}
 
-	err404 := gophercloud.ErrDefault404{
-		gophercloud.ErrUnexpectedResponseCode{
-			BaseError: gophercloud.BaseError{
-				DefaultErrString: fmt.Sprintf("No %s resource found", id)},
-		},
-	}
-
-	return nil, "", err404
-}
-
-func lbV2GetProvisioningStatusViaLB(lbClient *gophercloud.ServiceClient, id string, lbID string) (interface{}, string, error) {
-	log.Printf("[DEBUG] Trying to detect %s object status from the Load Balancer %s statuses tree", id, lbID)
-	statuses, err := loadbalancers.GetStatuses(lbClient, lbID).Extract()
-	if err != nil {
-		return nil, "", fmt.Errorf("Unable to get statuses from the Load Balancer %s statuses tree: %s", lbID, err)
-	}
-
-	for _, listener := range statuses.Loadbalancer.Listeners {
-		if listener.ID == id {
-			if listener.ProvisioningStatus == "" {
-				log.Printf("[DEBUG] Got an empty provisioning status response for the %s Listener, falling back to ACTIVE", id)
-				return listener, "ACTIVE", nil
-			}
-			log.Printf("[DEBUG] Found %s provisioning status for the %s Listener", listener.ProvisioningStatus, id)
-			return listener, listener.ProvisioningStatus, nil
-		}
-		/* Waiting for https://github.com/gophercloud/gophercloud/issues/1366
-		for _, l7policy := range listener.L7Policies {
-			if l7policy.ID == id {
-				if l7policy.ProvisioningStatus == "" {
-					log.Printf("[DEBUG] Got an empty provisioning status response for the %s L7 Policy, falling back to ACTIVE", id)
-					return l7policy, "ACTIVE", nil
-				}
-				log.Printf("[DEBUG] Found %s provisioning status for the %s L7 Policy", l7policy.ProvisioningStatus, id)
-				return l7policy, l7policy.ProvisioningStatus, nil
-			}
-
-			for _, l7rule := range l7policy.L7rules {
-				if l7rule.ID == id {
-					if l7rule.ProvisioningStatus == "" {
-						log.Printf("[DEBUG] Got an empty provisioning status response for the %s L7 Rule, falling back to ACTIVE", id)
-						return l7rule, "ACTIVE", nil
+		switch resourceType {
+		case "listener":
+			for _, listener := range statuses.Loadbalancer.Listeners {
+				if listener.ID == resourceID {
+					if listener.ProvisioningStatus != "" {
+						return listener, listener.ProvisioningStatus, nil
 					}
-					log.Printf("[DEBUG] Found %s provisioning status for the %s L7 Rule", l7rule.ProvisioningStatus, id)
-					return l7rule, l7rule.ProvisioningStatus, nil
 				}
 			}
-		}
-		*/
-	}
+			listener, err := listeners.Get(lbClient, resourceID).Extract()
+			return listener, "ACTIVE", err
 
-	/* Waiting for https://github.com/gophercloud/gophercloud/issues/1366 */
-	for _, pool := range statuses.Loadbalancer.Pools {
-		if pool.ID == id {
-			if pool.ProvisioningStatus == "" {
-				log.Printf("[DEBUG] Got an empty provisioning status response for the %s Pool, falling back to ACTIVE", id)
-				return pool, "ACTIVE", nil
-			}
-			log.Printf("[DEBUG] Found %s provisioning status for the %s Pool", pool.ProvisioningStatus, id)
-			return pool, pool.ProvisioningStatus, nil
-		}
-
-		if pool.Monitor.ID == id {
-			if pool.Monitor.ProvisioningStatus == "" {
-				log.Printf("[DEBUG] Got an empty provisioning status response for the %s Monitor, falling back to ACTIVE", id)
-				return pool.Monitor, "ACTIVE", nil
-			}
-			log.Printf("[DEBUG] Found %s provisioning status for the %s Monitor", pool.Monitor.ProvisioningStatus, id)
-			return pool.Monitor, pool.Monitor.ProvisioningStatus, nil
-		}
-
-		for _, member := range pool.Members {
-			if member.ID == id {
-				if member.ProvisioningStatus == "" {
-					log.Printf("[DEBUG] Got an empty provisioning status response for the %s Member, falling back to ACTIVE", id)
-					return member, "ACTIVE", nil
+		case "pool":
+			for _, pool := range statuses.Loadbalancer.Pools {
+				if pool.ID == resourceID {
+					if pool.ProvisioningStatus != "" {
+						return pool, pool.ProvisioningStatus, nil
+					}
 				}
-				log.Printf("[DEBUG] Found %s provisioning status for the %s member", member.ProvisioningStatus, id)
-				return member, member.ProvisioningStatus, nil
 			}
+			pool, err := pools.Get(lbClient, resourceID).Extract()
+			return pool, "ACTIVE", err
+
+		case "monitor":
+			for _, pool := range statuses.Loadbalancer.Pools {
+				if pool.Monitor.ID == resourceID {
+					if pool.Monitor.ProvisioningStatus != "" {
+						return pool.Monitor, pool.Monitor.ProvisioningStatus, nil
+					}
+				}
+			}
+			monitor, err := monitors.Get(lbClient, resourceID).Extract()
+			return monitor, "ACTIVE", err
+
+		case "member":
+			for _, pool := range statuses.Loadbalancer.Pools {
+				for _, member := range pool.Members {
+					if member.ID == resourceID {
+						if member.ProvisioningStatus != "" {
+							return member, member.ProvisioningStatus, nil
+						}
+					}
+				}
+			}
+			return "", "DELETED", nil
 		}
-	}
 
-	err404 := gophercloud.ErrDefault404{
-		gophercloud.ErrUnexpectedResponseCode{
-			BaseError: gophercloud.BaseError{
-				DefaultErrString: fmt.Sprintf("Unable to to find the %s object from the Load Balancer %s statuses tree", id, lbID)},
-		},
+		return nil, "", fmt.Errorf("An unexpected error occurred querying the status of %s %s by loadbalancer %s", resourceType, resourceID, lbID)
 	}
-
-	return nil, "", err404
 }

--- a/openstack/resource_openstack_lb_listener_v2.go
+++ b/openstack/resource_openstack_lb_listener_v2.go
@@ -165,8 +165,8 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating listener: %s", err)
 	}
 
-	// Wait for LoadBalancer to become active again before continuing
-	err = waitForLBV2LoadBalancer(lbClient, lbID, "ACTIVE", lbPendingStatuses, timeout)
+	// Wait for Listener to become active before continuing
+	err = waitForLBV2Listener(lbClient, listener.ID, &lbID, "ACTIVE", lbPendingStatuses, timeout)
 	if err != nil {
 		return err
 	}

--- a/openstack/resource_openstack_lb_listener_v2.go
+++ b/openstack/resource_openstack_lb_listener_v2.go
@@ -295,12 +295,7 @@ func resourceListenerV2Delete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Unable to retrieve listener %s: %s", d.Id(), err)
 	}
 
-	// Wait for the listener to become ACTIVE.
 	timeout := d.Timeout(schema.TimeoutDelete)
-	err = waitForLBV2Listener(lbClient, listener, "ACTIVE", lbPendingStatuses, timeout)
-	if err != nil {
-		return err
-	}
 
 	log.Printf("[DEBUG] Deleting listener %s", d.Id())
 	err = resource.Retry(timeout, func() *resource.RetryError {
@@ -315,7 +310,7 @@ func resourceListenerV2Delete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error deleting listener %s: %s", d.Id(), err)
 	}
 
-	// Wait for the listener to become ACTIVE.
+	// Wait for the listener to become DELETED.
 	err = waitForLBV2Listener(lbClient, listener, "DELETED", lbPendingDeleteStatuses, timeout)
 	if err != nil {
 		return err

--- a/openstack/resource_openstack_lb_member_v2.go
+++ b/openstack/resource_openstack_lb_member_v2.go
@@ -278,12 +278,6 @@ func resourceMemberV2Delete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	// Wait for the member to become active before continuing.
-	err = waitForLBV2Member(lbClient, parentPool, member, "ACTIVE", lbPendingStatuses, timeout)
-	if err != nil {
-		return err
-	}
-
 	log.Printf("[DEBUG] Attempting to delete member %s", d.Id())
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err = pools.DeleteMember(lbClient, poolID, d.Id()).ExtractErr()
@@ -297,7 +291,7 @@ func resourceMemberV2Delete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Unable to delete member %s: %s", d.Id(), err)
 	}
 
-	// Wait for the member to become active before continuing.
+	// Wait for the member to become DELETED.
 	err = waitForLBV2Member(lbClient, parentPool, member, "DELETED", lbPendingDeleteStatuses, timeout)
 	if err != nil {
 		return err

--- a/openstack/resource_openstack_lb_member_v2.go
+++ b/openstack/resource_openstack_lb_member_v2.go
@@ -265,7 +265,7 @@ func resourceMemberV2Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for member to become DELETED
-	err = waitForLBV2Member(lbClient, poolID, d.Id(), &lbID, "DELETED", lbPendingStatuses, timeout)
+	err = waitForLBV2Member(lbClient, poolID, d.Id(), &lbID, "DELETED", lbPendingDeleteStatuses, timeout)
 	if err != nil {
 		return err
 	}

--- a/openstack/resource_openstack_lb_monitor_v2.go
+++ b/openstack/resource_openstack_lb_monitor_v2.go
@@ -300,12 +300,6 @@ func resourceMonitorV2Delete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	// Wait for monitor to become active before continuing
-	err = waitForLBV2Monitor(lbClient, parentPool, monitor, "ACTIVE", lbPendingStatuses, timeout)
-	if err != nil {
-		return err
-	}
-
 	log.Printf("[DEBUG] Deleting monitor %s", d.Id())
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err = monitors.Delete(lbClient, d.Id()).ExtractErr()

--- a/openstack/resource_openstack_lb_monitor_v2.go
+++ b/openstack/resource_openstack_lb_monitor_v2.go
@@ -286,7 +286,7 @@ func resourceMonitorV2Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for monitor to become DELETED
-	err = waitForLBV2Monitor(lbClient, d.Id(), &lbID, "DELETED", lbPendingStatuses, timeout)
+	err = waitForLBV2Monitor(lbClient, d.Id(), &lbID, "DELETED", lbPendingDeleteStatuses, timeout)
 	if err != nil {
 		return err
 	}

--- a/openstack/resource_openstack_lb_pool_v2.go
+++ b/openstack/resource_openstack_lb_pool_v2.go
@@ -325,12 +325,6 @@ func resourcePoolV2Delete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Unable to retrieve pool %s: %s", d.Id(), err)
 	}
 
-	// Wait for pool to become active before continuing
-	err = waitForLBV2Pool(lbClient, pool, "ACTIVE", lbPendingStatuses, timeout)
-	if err != nil {
-		return err
-	}
-
 	log.Printf("[DEBUG] Attempting to delete pool %s", d.Id())
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err = pools.Delete(lbClient, d.Id()).ExtractErr()

--- a/openstack/resource_openstack_lb_pool_v2.go
+++ b/openstack/resource_openstack_lb_pool_v2.go
@@ -182,7 +182,7 @@ func resourcePoolV2Create(d *schema.ResourceData, meta interface{}) error {
 	timeout := d.Timeout(schema.TimeoutCreate)
 
 	// Wait for LoadBalancer to become active before continuing
-	err = waitForLBV2viaLBorListener(lbClient, lbID, listenerID, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2viaListenerOrLB(lbClient, listenerID, &lbID, "ACTIVE", lbPendingStatuses, timeout)
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ func resourcePoolV2Create(d *schema.ResourceData, meta interface{}) error {
 
 	// Pools was successfully created
 	// Wait for LoadBalancer to become active before continuing
-	err = waitForLBV2viaLBorListener(lbClient, lbID, listenerID, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2viaListenerOrLB(lbClient, listenerID, &lbID, "ACTIVE", lbPendingStatuses, timeout)
 	if err != nil {
 		return err
 	}
@@ -267,7 +267,7 @@ func resourcePoolV2Update(d *schema.ResourceData, meta interface{}) error {
 
 	// Wait for LoadBalancer to become active before continuing
 	timeout := d.Timeout(schema.TimeoutUpdate)
-	err = waitForLBV2viaLBorListener(lbClient, lbID, listenerID, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2viaListenerOrLB(lbClient, listenerID, &lbID, "ACTIVE", lbPendingStatuses, timeout)
 	if err != nil {
 		return err
 	}
@@ -286,7 +286,7 @@ func resourcePoolV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for LoadBalancer to become active before continuing
-	err = waitForLBV2viaLBorListener(lbClient, lbID, listenerID, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2viaListenerOrLB(lbClient, listenerID, &lbID, "ACTIVE", lbPendingStatuses, timeout)
 	if err != nil {
 		return err
 	}
@@ -306,7 +306,7 @@ func resourcePoolV2Delete(d *schema.ResourceData, meta interface{}) error {
 	timeout := d.Timeout(schema.TimeoutDelete)
 
 	// Wait for LoadBalancer to become active before continuing
-	err = waitForLBV2viaLBorListener(lbClient, lbID, listenerID, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2viaListenerOrLB(lbClient, listenerID, &lbID, "ACTIVE", lbPendingStatuses, timeout)
 	if err != nil {
 		return err
 	}
@@ -325,12 +325,7 @@ func resourcePoolV2Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for Pool to delete
-	err = waitForLBV2Pool(lbClient, d.Id(), "DELETED", nil, timeout)
-	if err != nil {
-		return err
-	}
-
-	err = waitForLBV2viaLBorListener(lbClient, lbID, listenerID, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Pool(lbClient, d.Id(), &lbID, "DELETED", nil, timeout)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/gophercloud/gophercloud/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/doc.go
@@ -41,7 +41,7 @@ pass in the parent provider, like so:
 
   opts := gophercloud.EndpointOpts{Region: "RegionOne"}
 
-  client := openstack.NewComputeV2(provider, opts)
+  client, err := openstack.NewComputeV2(provider, opts)
 
 Resources
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/l7policies/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/l7policies/results.go
@@ -41,6 +41,17 @@ type L7Policy struct {
 	// The administrative state of the L7 policy, which is up (true) or down (false).
 	AdminStateUp bool `json:"admin_state_up"`
 
+	// The provisioning status of the L7 policy.
+	// This value is ACTIVE, PENDING_* or ERROR.
+	// This field seems to only be returned during a call to a load balancer's /status
+	// see: https://github.com/gophercloud/gophercloud/issues/1362
+	ProvisioningStatus string `json:"provisioning_status"`
+
+	// The operating status of the L7 policy.
+	// This field seems to only be returned during a call to a load balancer's /status
+	// see: https://github.com/gophercloud/gophercloud/issues/1362
+	OperatingStatus string `json:"operating_status"`
+
 	// Rules are List of associated L7 rule IDs.
 	Rules []Rule `json:"rules"`
 }
@@ -72,6 +83,17 @@ type Rule struct {
 
 	// The administrative state of the L7 rule, which is up (true) or down (false).
 	AdminStateUp bool `json:"admin_state_up"`
+
+	// The provisioning status of the L7 rule.
+	// This value is ACTIVE, PENDING_* or ERROR.
+	// This field seems to only be returned during a call to a load balancer's /status
+	// see: https://github.com/gophercloud/gophercloud/issues/1362
+	ProvisioningStatus string `json:"provisioning_status"`
+
+	// The operating status of the L7 policy.
+	// This field seems to only be returned during a call to a load balancer's /status
+	// see: https://github.com/gophercloud/gophercloud/issues/1362
+	OperatingStatus string `json:"operating_status"`
 }
 
 type commonResult struct {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/results.go
@@ -3,6 +3,7 @@ package loadbalancers
 import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
@@ -51,6 +52,9 @@ type LoadBalancer struct {
 
 	// Listeners are the listeners related to this Loadbalancer.
 	Listeners []listeners.Listener `json:"listeners"`
+
+	// Pools are the pools related to this Loadbalancer.
+	Pools []pools.Pool `json:"pools"`
 }
 
 // StatusTree represents the status of a loadbalancer.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools/results.go
@@ -96,6 +96,11 @@ type Pool struct {
 	// The provisioning status of the pool.
 	// This value is ACTIVE, PENDING_* or ERROR.
 	ProvisioningStatus string `json:"provisioning_status"`
+
+	// The operating status of the pool.
+	// This field seems to only be returned during a call to a load balancer's /status
+	// see: https://github.com/gophercloud/gophercloud/issues/1362
+	OperatingStatus string `json:"operating_status"`
 }
 
 // PoolPage is the page returned by a pager when traversing over a
@@ -204,6 +209,11 @@ type Member struct {
 	// The provisioning status of the member.
 	// This value is ACTIVE, PENDING_* or ERROR.
 	ProvisioningStatus string `json:"provisioning_status"`
+
+	// The operating status of the member.
+	// This field seems to only be returned during a call to a load balancer's /status
+	// see: https://github.com/gophercloud/gophercloud/issues/1362
+	OperatingStatus string `json:"operating_status"`
 }
 
 // MemberPage is the page returned by a pager when traversing over a

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -313,520 +313,520 @@
 			"revisionTime": "2018-03-28T16:31:53Z"
 		},
 		{
-			"checksumSHA1": "LHc0znP07eeF+l2aJlggfw2L9+k=",
+			"checksumSHA1": "mxnleftS/IKLireRFde56VPFc8U=",
 			"path": "github.com/gophercloud/gophercloud",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "b7g9TcU1OmW7e2UySYeOAmcfHpY=",
 			"path": "github.com/gophercloud/gophercloud/internal",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "zDja+rJdiRPG4YeVdt21YX1J8bk=",
 			"path": "github.com/gophercloud/gophercloud/openstack",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "8YtBD+Um7I8ee1Xf1ZAWu74eP7w=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "MzOt8P1f2e0vX58I0l02+5AZ7rc=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v1/volumes",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "SDNVeLqHv7OhjKCAU0/McJUeWgo=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "lP4ajY5LWcqx5qFMCZ56FOTdJxo=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "vw46Q7Z5GKbrutRNXVqobqQcLdA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "buHPuL/qGZ2AlDdB/1KOjVISmsM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "VVSFrp4kBIDK62D+uCgV8IScwD0=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "tHW4ajx6KpesbhMfizNicJ6g9Ks=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces/testing",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "nQlviweyWynvpsXf1Ms0AecMzO8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "La8c0H0Eds4MmAKJ9lPdDgJDjSk=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "vFS5BwnCdQIfKm1nNWrR+ijsAZA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "lAQuKIqTuQ9JuMgN0pPkNtRH2RM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "+hlElX7o8ULWTc0r7oGyDlOnwWM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "jeRy+dt5B0E3ba5u/lzV+/lJn4c=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "PWbrce9A6LMWIGr0fK04AEEuQec=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "qfVZltu1fYTYXS97WbjeLuLPgUc=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/startstop",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "+Gif+WFd0WVjefjvmlR7jyTrdzQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/tenantnetworks",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "TMkBTIrYeL78yJ6wZNJQqG0tHR4=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "tRY1hWvCAjOtcouMKA9V6Aq9Afo=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/flavors",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "CSnfH01hSas0bdc/3m/f5Rt6SFY=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/images",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "gxNCsaZKNT2SUIUtirxfEcLn9jw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/servers",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "j2li+asUKunCgz691sa92VOjAvg=",
 			"path": "github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "VxqXejG0O0WC7oYiC1V4Hx2OKTU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "2RFHGbTIBvTz5oIuFc5DtVFiQYE=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/configurations",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "jdKwC7fxB11ACuo8CUH2VoleJao=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/databases",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "sQjGBGkPPevEYcyWz/7BN7inFbo=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/datastores",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "OufByUxj+IvLN5K7XcVVziy28Pw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/instances",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "62KZtZ4VoCLsOrXxcFTpp0qJEgw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/users",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "nulZDXleFwq5Kk4Fm3xEXI5+SWw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "Cl13L7gpdQvfVTpQL4K0GkoSpiA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/dns/v2/zones",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "n7u1Hvuzxzhfghka+7JpqoNtRhI=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v2/tenants",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "z5NsqMZX3TLMzpmwzOOXE4M5D9w=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "Qzlv/69tlr+1r6W28WrOEEqT9EU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "y+w9UFsEgYvgQ5EaClNor1D95tw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/groups",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "46oS/lG/aAhCLVafeiJPNMv2DiQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/projects",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "ZG+k94WuW6QA8ttJMRvNT5kqI9g=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/roles",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "qOc+KYPka86DtcDnpvBuKdCb8jk=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/services",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "HNLKHXv7aYtKnRMo3msTbdGE5H8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "uGWuvrL9DW4CjMubbXSM6rVlm3Q=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/users",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "4Ci0F5SJgiJCXyDuxTQZYvwA00s=",
 			"path": "github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "ysiv+OUUPt6HfAKlWbR9w0QP4YU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/imageservice/v2/images",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "2KyigRom9gcqgGSRPm5pJFtmrdY=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "x6lD4wQOZc1rtm6kMaUBMwLxAlA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "ITDrcTALUPkyNYR3DB/xnrquSpc=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/extradhcpopts",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "iEycbTwNfi2VM+8KCJX2rkWoN1g=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "ROBaakcMIVCb0405H8/UuttEZtA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "FDgt1WaVGbp8w6vyCJbtkbsbWBc=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/routerinsertion",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "uZ5/gCROQHaiHpXfoLrfisRzbAU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "6CAupuagxLITVHlIraEiS9gc9i4=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "5nK6eV4Qr+XpVN+U0GsrW6vq+yA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "HiGzZXGIxrItijPCH+L7EbbCb9w=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/members",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "KZJLk70d5SX8TQO1q0MLAxGEBCU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/monitors",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "WYktmBouYI04KbKqDqHpgyMzZtQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/pools",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "3QfwJnsJHohoYV16/BOtDXpNEYI=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/vips",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
-			"checksumSHA1": "lyWpm/su17KwpHUsVGBkyXqFCvY=",
+			"checksumSHA1": "cnxAG0MRNpeg2Fqc1f2M40N2sc0=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/l7policies",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "//oZPYIT/hd1Y1YKzTUOiCpjO6o=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
-			"checksumSHA1": "qwkbXT16v2/oKlxqfD41arG8E4M=",
+			"checksumSHA1": "DSn8Qz8UTQvehEoAIfi49tl3c4w=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "4JRkgqSuMmKmWmQvQpCTnKjDoVU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/monitors",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
-			"checksumSHA1": "sZlV128TS9rAyuQVX+Olxgm1YFc=",
+			"checksumSHA1": "+Em48dU1PW4UMeGoaK7lkDoVqGM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "eUvwdXvz/Zkckr/isvP+2nXY2J8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/provider",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "3D3gnim5Al9npZZe+N6UyJfW1Dc=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "KI8KPllJwaS8Fzf5T5XcbbsHr1U=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "83WYX5SPirCgxPgjUsiihw6W3C8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "8BfPHfYcCbdSoLj/LJEjZx+MDTM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "grviOYvybawC80v7Fmw0XOBwr0A=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/endpointgroups",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "HhRP7Hw7cS7RM4cxGmQYk/vI8uM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/ikepolicies",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "NRvuezUVg0gU4CIZkWHnMhIYXx8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/ipsecpolicies",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "RnSw4UFgNNxmOuobe7c0GxGWwKM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/services",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "4H6GsYh9zKxk8Z/Gs8NdMtMCVvQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/siteconnections",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "Mb510qurNKkP9f6cjZqK66ag4Ns=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/networks",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "KHyErSX8Lz8O4ipt/ZApFeqvCiQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/ports",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "C/o7XkvWASk9X080jbXU87BaNvw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "v0EdYYIyrzR6j8tAiVkl2AQzmao=",
 			"path": "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "yD33+7iNdUykXt9qunPntb63Oqk=",
 			"path": "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "RswTYBtPwd1KE8EpLpHhsvO1Jtw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "aODoF15ZwA4XJOWciguaAJRq/6o=",
 			"path": "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/swauth",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "cGyXqdYGrNLd3zAbwCmxbeVtPMk=",
 			"path": "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/apiversions",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "eglgBdlffyYTo1SDz3Wb7IEE25o=",
 			"path": "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/securityservices",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "6ImzhiIe7n87OGSV9YskZRIsdg4=",
 			"path": "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharenetworks",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "nkRXTSQyEk7yy+4u4/yC1kdvpaE=",
 			"path": "github.com/gophercloud/gophercloud/openstack/utils",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "/Wkc4WKxF/P87dOmUh5XUXcfmz8=",
 			"path": "github.com/gophercloud/gophercloud/pagination",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "b8tetZflGv6Pg22zYyodQGce7nc=",
 			"path": "github.com/gophercloud/gophercloud/testhelper",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "XHWKJUGCvXQNDmRrev0ZOVcISSM=",
 			"path": "github.com/gophercloud/gophercloud/testhelper/client",
-			"revision": "bdd8b1ecd793ffb03d43314c66565be3d6a7a582",
-			"revisionTime": "2018-12-15T22:49:39Z"
+			"revision": "52046867450031e40bd4e94332fe5dbdf5cf51ca",
+			"revisionTime": "2018-12-20T15:44:12Z"
 		},
 		{
 			"checksumSHA1": "JvMurZXDftdGc7f8PzE7EjXbuOw=",


### PR DESCRIPTION
Part of #546

@jtopjian, please watch your eyes :) This is the best what I could do to detect proper statuses. With this PR, situation described in #546 won't happen. Terraform will update LB objects independently on the LB overall status.

This PR is based on #547, so take a look on the second commit. It also depends on https://github.com/gophercloud/gophercloud/pull/1367

My gut feeling says that there could be pitfalls, let's wait for tests.