### PR TITLE
Provider: Fix flavor detection

### DIFF
--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -65,18 +65,16 @@ func resourceComputeInstanceV2() *schema.Resource {
 				Computed: true,
 			},
 			"flavor_id": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    false,
-				Computed:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_FLAVOR_ID", nil),
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
 			},
 			"flavor_name": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    false,
-				Computed:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_FLAVOR_NAME", nil),
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
 			},
 			"floating_ip": &schema.Schema{
 				Type:     schema.TypeString,
@@ -394,6 +392,9 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
+	// Determines the Flavor ID using the following rules:
+	// If a flavor_id was specified, use it.
+	// If a flavor_name was specified, lookup the flavor ID, report if error.
 	flavorId, err := getFlavorID(computeClient, d)
 	if err != nil {
 		return err
@@ -1124,15 +1125,33 @@ func setImageInformation(computeClient *gophercloud.ServiceClient, server *serve
 	return nil
 }
 
-func getFlavorID(client *gophercloud.ServiceClient, d *schema.ResourceData) (string, error) {
-	flavorId := d.Get("flavor_id").(string)
-
-	if flavorId != "" {
+func getFlavorID(computeClient *gophercloud.ServiceClient, d *schema.ResourceData) (string, error) {
+	if flavorId := d.Get("flavor_id").(string); flavorId != "" {
 		return flavorId, nil
+	} else {
+		// Try the OS_FLAVOR_ID environment variable
+		if v := os.Getenv("OS_FLAVOR_ID"); v != "" {
+			return v, nil
+		}
 	}
 
 	flavorName := d.Get("flavor_name").(string)
-	return flavors.IDFromName(client, flavorName)
+	if flavorName == "" {
+		// Try the OS_FLAVOR_NAME environment variable
+		if v := os.Getenv("OS_FLAVOR_NAME"); v != "" {
+			flavorName = v
+		}
+	}
+
+	if flavorName != "" {
+		flavorId, err := flavors.IDFromName(computeClient, flavorName)
+		if err != nil {
+			return "", err
+		}
+		return flavorId, nil
+	}
+
+	return "", fmt.Errorf("Neither a flavor_id or flavor_id could be determined.")
 }
 
 func resourceComputeSchedulerHintsHash(v interface{}) int {

--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -1151,7 +1151,7 @@ func getFlavorID(computeClient *gophercloud.ServiceClient, d *schema.ResourceDat
 		return flavorId, nil
 	}
 
-	return "", fmt.Errorf("Neither a flavor_id or flavor_id could be determined.")
+	return "", fmt.Errorf("Neither a flavor_id or flavor_name could be determined.")
 }
 
 func resourceComputeSchedulerHintsHash(v interface{}) int {

--- a/openstack/resource_openstack_compute_instance_v2_test.go
+++ b/openstack/resource_openstack_compute_instance_v2_test.go
@@ -728,7 +728,7 @@ var testAccComputeV2Instance_basic = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
-  metadata {
+  metadata = {
     foo = "bar"
   }
   network {
@@ -1070,7 +1070,7 @@ var testAccComputeV2Instance_metadataRemove_1 = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
-  metadata {
+  metadata = {
     foo = "bar"
     abc = "def"
   }
@@ -1084,7 +1084,7 @@ var testAccComputeV2Instance_metadataRemove_2 = fmt.Sprintf(`
 resource "openstack_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
-  metadata {
+  metadata = {
     foo = "bar"
     ghi = "jkl"
   }


### PR DESCRIPTION
For #548 

It appears that Terraform v0.12 won't use DefaultFunc when the field is
set to computed. While this might be a bug, we only have a few
occurrences of this in the provider, so I'm opting to work around this
instead of reporting it upstream and possibly have a legacy measure put
in place.

This commit will have the flavors still use the correct environment
variables. Detection is just deferred to outside the schema.

In addition, I made an update to the compute instance test fixtures so they work in v0.12.

@ozerovandrei These changes probably conflict with #545, but this PR should take priority. I will resolve any conflicts with #545 afterwards.