### PR TITLE
Internal: Fix expandContainerInfraV1LabelsString unit test

### DIFF
--- a/openstack/containerinfra_shared_v1_test.go
+++ b/openstack/containerinfra_shared_v1_test.go
@@ -30,11 +30,17 @@ func TestExpandContainerInfraV1LabelsString(t *testing.T) {
 		"bar": "baz",
 	}
 
-	expectedLabels := "foo=bar,bar=baz"
+	expectedLabels_1 := "foo=bar,bar=baz"
+	expectedLabels_2 := "bar=baz,foo=bar"
 
 	actualLabels, err := expandContainerInfraV1LabelsString(labels)
 	assert.Equal(t, err, nil)
-	assert.Equal(t, expectedLabels, actualLabels)
+
+	if actualLabels != expectedLabels_1 && actualLabels != expectedLabels_2 {
+		t.Fatalf("Unexpected labels. Got %s, expected %s or %s",
+			actualLabels, expectedLabels_1, expectedLabels_2)
+	}
+
 }
 
 func TestContainerInfraClusterTemplateV1AppendUpdateOpts(t *testing.T) {


### PR DESCRIPTION
This fix resolves an issue where the actual labels are in a different
order than the expected labels, due to iterating over a map.

The long-term fix might be to sort the keys in
expandContainerInfraV1LabelsString, but this will need some work as it
would be a breaking change.