### PR TITLE
ComputeV2: fix interface attach importing

### DIFF
--- a/openstack/import_openstack_compute_interface_attach_v2_test.go
+++ b/openstack/import_openstack_compute_interface_attach_v2_test.go
@@ -1,0 +1,27 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccComputeV2InterfaceAttachImport_basic(t *testing.T) {
+	resourceName := "openstack_compute_interface_attach_v2.ai_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2InterfaceAttachDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeV2InterfaceAttach_basic,
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/openstack/resource_openstack_compute_interface_attach_v2.go
+++ b/openstack/resource_openstack_compute_interface_attach_v2.go
@@ -148,6 +148,7 @@ func resourceComputeInterfaceAttachV2Read(d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] Retrieved openstack_compute_interface_attach_v2 %s: %#v", d.Id(), attachment)
 
+	d.Set("instance_id", instanceId)
 	d.Set("port_id", attachment.PortID)
 	d.Set("network_id", attachment.NetID)
 	d.Set("region", GetRegion(d, config))


### PR DESCRIPTION
Set "instance_id" attribute while reading
openstack_compute_interface_attach_v2 resource and add basic import
acceptance test for this resource.

For #554