### PR TITLE
ComputeV2: add "device_type" and "disk_bus" fields

### DIFF
--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -240,6 +240,16 @@ func resourceComputeInstanceV2() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
+						"device_type": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"disk_bus": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
 					},
 				},
 			},
@@ -978,6 +988,8 @@ func resourceInstanceBlockDevicesV2(d *schema.ResourceData, bds []interface{}) (
 			BootIndex:           bdM["boot_index"].(int),
 			DeleteOnTermination: bdM["delete_on_termination"].(bool),
 			GuestFormat:         bdM["guest_format"].(string),
+			DeviceType:          bdM["device_type"].(string),
+			DiskBus:             bdM["disk_bus"].(string),
 		}
 
 		sourceType := bdM["source_type"].(string)

--- a/openstack/resource_openstack_compute_instance_v2_test.go
+++ b/openstack/resource_openstack_compute_instance_v2_test.go
@@ -260,6 +260,24 @@ func TestAccComputeV2Instance_blockDeviceNewVolume(t *testing.T) {
 	})
 }
 
+func TestAccComputeV2Instance_blockDeviceNewVolumeTypeAndBus(t *testing.T) {
+	var instance servers.Server
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeV2Instance_blockDeviceNewVolumeTypeAndBus,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2InstanceExists("openstack_compute_instance_v2.instance_1", &instance),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeV2Instance_blockDeviceExistingVolume(t *testing.T) {
 	var instance servers.Server
 	var volume volumes.Volume
@@ -916,6 +934,34 @@ resource "openstack_compute_instance_v2" "instance_1" {
     volume_size = 1
     boot_index = 1
     delete_on_termination = true
+  }
+  network {
+    uuid = "%s"
+  }
+}
+`, OS_IMAGE_ID, OS_NETWORK_ID)
+
+var testAccComputeV2Instance_blockDeviceNewVolumeTypeAndBus = fmt.Sprintf(`
+resource "openstack_compute_instance_v2" "instance_1" {
+  name = "instance_1"
+  security_groups = ["default"]
+  block_device {
+    uuid = "%s"
+    source_type = "image"
+    destination_type = "local"
+    boot_index = 0
+		delete_on_termination = true
+		device_type = "disk"
+		disk_bus = "virtio"
+  }
+  block_device {
+    source_type = "blank"
+    destination_type = "volume"
+    volume_size = 1
+    boot_index = 1
+		delete_on_termination = true
+		device_type = "disk"
+		disk_bus = "virtio"
   }
   network {
     uuid = "%s"

--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -406,6 +406,12 @@ The `block_device` block supports:
     termination of the instance. Defaults to false. Changing this creates a
     new server.
 
+* `device_type` - (Optional) The low-level device type that will be used. Most
+    common thing is to leave this empty. Changing this creates a new server.
+
+* `disk_bus` - (Optional) The low-level disk bus that will be used. Most common
+    thing is to leave this empty. Changing this creates a new server.
+
 The `scheduler_hints` block supports:
 
 * `group` - (Optional) A UUID of a Server Group. The instance will be placed


### PR DESCRIPTION
Add "device_type" and "disk_bus" fields into the "block_device"
attribute of the Compute V2 Instance resource.

Provide basic acceptance test and documentation.

For #18 