### PR TITLE
Internal: Floating IP associate cleanup

### DIFF
--- a/openstack/networking_floatingip_v2.go
+++ b/openstack/networking_floatingip_v2.go
@@ -1,0 +1,34 @@
+package openstack
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
+)
+
+// networkingFloatingIPV2ID retrieves floating IP ID by the provided IP address.
+func networkingFloatingIPV2ID(client *gophercloud.ServiceClient, floatingIP string) (string, error) {
+	listOpts := floatingips.ListOpts{
+		FloatingIP: floatingIP,
+	}
+
+	allPages, err := floatingips.List(client, listOpts).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	allFloatingIPs, err := floatingips.ExtractFloatingIPs(allPages)
+	if err != nil {
+		return "", err
+	}
+
+	if len(allFloatingIPs) == 0 {
+		return "", fmt.Errorf("there are no openstack_networking_floatingip_v2 with %s IP", floatingIP)
+	}
+	if len(allFloatingIPs) > 1 {
+		return "", fmt.Errorf("there are more than one openstack_networking_floatingip_v2 with %s IP", floatingIP)
+	}
+
+	return allFloatingIPs[0].ID, nil
+}

--- a/openstack/resource_openstack_networking_floatingip_associate_v2.go
+++ b/openstack/resource_openstack_networking_floatingip_associate_v2.go
@@ -69,7 +69,9 @@ func resourceNetworkingFloatingIPAssociateV2Create(d *schema.ResourceData, meta 
 
 	d.SetId(fipID)
 
-	return resourceNetworkFloatingIPV2Read(d, meta)
+	log.Printf("[DEBUG] Created association between openstack_networking_floatingip_v2 %s and openstack_networking_port_v2 %s",
+		fipID, portID)
+	return resourceNetworkingFloatingIPAssociateV2Read(d, meta)
 }
 
 func resourceNetworkingFloatingIPAssociateV2Read(d *schema.ResourceData, meta interface{}) error {
@@ -83,6 +85,8 @@ func resourceNetworkingFloatingIPAssociateV2Read(d *schema.ResourceData, meta in
 	if err != nil {
 		return CheckDeleted(d, err, "Error getting openstack_networking_floatingip_v2")
 	}
+
+	log.Printf("[DEBUG] Retrieved openstack_networking_floatingip_v2 %s: %#v", d.Id(), fip)
 
 	d.Set("floating_ip", fip.FloatingIP)
 	d.Set("port_id", fip.PortID)

--- a/openstack/resource_openstack_networking_floatingip_associate_v2_test.go
+++ b/openstack/resource_openstack_networking_floatingip_associate_v2_test.go
@@ -38,7 +38,7 @@ func testAccCheckNetworkingV2FloatingIPAssociateDestroy(s *terraform.State) erro
 	config := testAccProvider.Meta().(*Config)
 	networkClient, err := config.networkingV2Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating OpenStack floating IP: %s", err)
+		return fmt.Errorf("Error creating OpenStack network client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -52,11 +52,11 @@ func testAccCheckNetworkingV2FloatingIPAssociateDestroy(s *terraform.State) erro
 				return nil
 			}
 
-			return fmt.Errorf("Error retrieving floating IP: %s", err)
+			return fmt.Errorf("Error retrieving Floating IP: %s", err)
 		}
 
 		if fip.PortID != "" {
-			return fmt.Errorf("floating IP is still associated")
+			return fmt.Errorf("Floating IP is still associated")
 		}
 	}
 
@@ -86,7 +86,7 @@ func testAccCheckNetworkingV2FloatingIPAssociateExists(n string, fip *floatingip
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmt.Errorf("FloatingIP not found")
+			return fmt.Errorf("Floating IP not found")
 		}
 
 		*fip = *found


### PR DESCRIPTION
Move Networking V2 floating IP helpers functions outside of
resource_openstack_networking_floatingip_associate_v2.go.
Update debug and error messages.

For #456 