### PR TITLE
Internal: cleanup Networking V2 Ports

### DIFF
--- a/openstack/data_source_openstack_networking_port_ids_v2.go
+++ b/openstack/data_source_openstack_networking_port_ids_v2.go
@@ -180,16 +180,16 @@ func dataSourceNetworkingPortIDsV2Read(d *schema.ResourceData, meta interface{})
 
 	allPages, err := ports.List(networkingClient, listOpts).AllPages()
 	if err != nil {
-		return fmt.Errorf("Unable to list Ports: %s", err)
+		return fmt.Errorf("Unable to list openstack_networking_ports_v2: %s", err)
 	}
 
 	allPorts, err := ports.ExtractPorts(allPages)
 	if err != nil {
-		return fmt.Errorf("Unable to retrieve Ports: %s", err)
+		return fmt.Errorf("Unable to retrieve openstack_networking_ports_v2: %s", err)
 	}
 
 	if len(allPorts) == 0 {
-		return fmt.Errorf("No Port found")
+		return fmt.Errorf("No openstack_networking_port_v2 found")
 	}
 
 	var portsList []ports.Port
@@ -209,8 +209,8 @@ func dataSourceNetworkingPortIDsV2Read(d *schema.ResourceData, meta interface{})
 			}
 		}
 		if len(portsList) == 0 {
-			log.Printf("No Port found after the 'fixed_ip' filter")
-			return fmt.Errorf("No Port found")
+			log.Printf("No openstack_networking_port_v2 found after the 'fixed_ip' filter")
+			return fmt.Errorf("No openstack_networking_port_v2 found")
 		}
 	} else {
 		portsList = allPorts
@@ -227,8 +227,8 @@ func dataSourceNetworkingPortIDsV2Read(d *schema.ResourceData, meta interface{})
 			}
 		}
 		if len(sgPorts) == 0 {
-			log.Printf("No Port found after the 'security_group_ids' filter")
-			return fmt.Errorf("No Port found")
+			log.Printf("No openstack_networking_port_v2 found after the 'security_group_ids' filter")
+			return fmt.Errorf("No openstack_networking_port_v2 found")
 		}
 		portsList = sgPorts
 	}
@@ -237,7 +237,7 @@ func dataSourceNetworkingPortIDsV2Read(d *schema.ResourceData, meta interface{})
 		portIDs = append(portIDs, p.ID)
 	}
 
-	log.Printf("[DEBUG] Retrieved %d Ports: %+v", len(portsList), portsList)
+	log.Printf("[DEBUG] Retrieved %d openstack_networking_port_v2: %+v", len(portsList), portsList)
 
 	d.SetId(fmt.Sprintf("%d", hashcode.String(strings.Join(portIDs, ""))))
 	d.Set("ids", portIDs)

--- a/openstack/data_source_openstack_networking_port_ids_v2.go
+++ b/openstack/data_source_openstack_networking_port_ids_v2.go
@@ -216,8 +216,7 @@ func dataSourceNetworkingPortIDsV2Read(d *schema.ResourceData, meta interface{})
 		portsList = allPorts
 	}
 
-	v := d.Get("security_group_ids").(*schema.Set)
-	securityGroups := resourcePortSecurityGroupsV2(v)
+	securityGroups := expandToStringSlice(d.Get("security_group_ids").(*schema.Set).List())
 	if len(securityGroups) > 0 {
 		var sgPorts []ports.Port
 		for _, p := range portsList {

--- a/openstack/data_source_openstack_networking_port_v2.go
+++ b/openstack/data_source_openstack_networking_port_v2.go
@@ -112,7 +112,7 @@ func dataSourceNetworkingPortV2() *schema.Resource {
 			},
 
 			"all_fixed_ips": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/openstack/data_source_openstack_networking_port_v2.go
+++ b/openstack/data_source_openstack_networking_port_v2.go
@@ -97,7 +97,6 @@ func dataSourceNetworkingPortV2() *schema.Resource {
 			"allowed_address_pairs": {
 				Type:     schema.TypeSet,
 				Computed: true,
-				Set:      allowedAddressPairsHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ip_address": {
@@ -250,8 +249,7 @@ func dataSourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) er
 		portsList = allPorts
 	}
 
-	v := d.Get("security_group_ids").(*schema.Set)
-	securityGroups := resourcePortSecurityGroupsV2(v)
+	securityGroups := expandToStringSlice(d.Get("security_group_ids").(*schema.Set).List())
 	if len(securityGroups) > 0 {
 		var sgPorts []extraPort
 		for _, p := range portsList {

--- a/openstack/data_source_openstack_networking_port_v2.go
+++ b/openstack/data_source_openstack_networking_port_v2.go
@@ -112,7 +112,7 @@ func dataSourceNetworkingPortV2() *schema.Resource {
 			},
 
 			"all_fixed_ips": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/openstack/data_source_openstack_networking_port_v2.go
+++ b/openstack/data_source_openstack_networking_port_v2.go
@@ -208,18 +208,18 @@ func dataSourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) er
 
 	allPages, err := ports.List(networkingClient, listOpts).AllPages()
 	if err != nil {
-		return fmt.Errorf("Unable to list Ports: %s", err)
+		return fmt.Errorf("Unable to list openstack_networking_ports_v2: %s", err)
 	}
 
 	var allPorts []extraPort
 
 	err = ports.ExtractPortsInto(allPages, &allPorts)
 	if err != nil {
-		return fmt.Errorf("Unable to retrieve Ports: %s", err)
+		return fmt.Errorf("Unable to retrieve openstack_networking_ports_v2: %s", err)
 	}
 
 	if len(allPorts) == 0 {
-		return fmt.Errorf("No Port found")
+		return fmt.Errorf("No openstack_networking_port_v2 found")
 	}
 
 	var portsList []extraPort
@@ -242,8 +242,8 @@ func dataSourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) er
 			}
 		}
 		if len(portsList) == 0 {
-			log.Printf("No Port found after the 'fixed_ip' filter")
-			return fmt.Errorf("No Port found")
+			log.Printf("No openstack_networking_port_v2 found after the 'fixed_ip' filter")
+			return fmt.Errorf("No openstack_networking_port_v2 found")
 		}
 	} else {
 		portsList = allPorts
@@ -260,19 +260,19 @@ func dataSourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) er
 			}
 		}
 		if len(sgPorts) == 0 {
-			log.Printf("[DEBUG] No Port found after the 'security_group_ids' filter")
-			return fmt.Errorf("No Port found")
+			log.Printf("[DEBUG] No openstack_networking_port_v2 found after the 'security_group_ids' filter")
+			return fmt.Errorf("No openstack_networking_port_v2 found")
 		}
 		portsList = sgPorts
 	}
 
 	if len(portsList) > 1 {
-		return fmt.Errorf("More than one Port found (%d)", len(portsList))
+		return fmt.Errorf("More than one openstack_networking_port_v2 found (%d)", len(portsList))
 	}
 
 	port := portsList[0]
 
-	log.Printf("[DEBUG] Retrieved Port %s: %+v", port.ID, port)
+	log.Printf("[DEBUG] Retrieved openstack_networking_port_v2 %s: %+v", port.ID, port)
 	d.SetId(port.ID)
 
 	d.Set("port_id", port.ID)

--- a/openstack/networking_port_v2.go
+++ b/openstack/networking_port_v2.go
@@ -1,9 +1,13 @@
 package openstack
 
 import (
+	"bytes"
+	"fmt"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/extradhcpopts"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -156,4 +160,12 @@ func expandNetworkingPortFixedIPV2(d *schema.ResourceData) interface{} {
 		}
 	}
 	return ip
+}
+
+func resourceNetworkingPortV2AllowedAddressPairsHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-%s", m["ip_address"].(string), m["mac_address"].(string)))
+
+	return hashcode.String(buf.String())
 }

--- a/openstack/networking_port_v2.go
+++ b/openstack/networking_port_v2.go
@@ -130,7 +130,7 @@ func flattenNetworkingPortAllowedAddressPairsV2(mac string, allowedAddressPairs 
 	return pairs
 }
 
-func expandNetworkingPortFixedIpsV2(d *schema.ResourceData) interface{} {
+func expandNetworkingPortFixedIPV2(d *schema.ResourceData) interface{} {
 	// If no_fixed_ip was specified, then just return an empty array.
 	// Since no_fixed_ip is mutually exclusive to fixed_ip,
 	// we can safely do this.
@@ -141,7 +141,7 @@ func expandNetworkingPortFixedIpsV2(d *schema.ResourceData) interface{} {
 		return []interface{}{}
 	}
 
-	rawIP := d.Get("fixed_ip").(*schema.Set).List()
+	rawIP := d.Get("fixed_ip").([]interface{})
 
 	if len(rawIP) == 0 {
 		return nil

--- a/openstack/networking_port_v2.go
+++ b/openstack/networking_port_v2.go
@@ -4,8 +4,24 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/extradhcpopts"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
+
+func resourceNetworkingPortV2StateRefreshFunc(client *gophercloud.ServiceClient, portID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		n, err := ports.Get(client, portID).Extract()
+		if err != nil {
+			if _, ok := err.(gophercloud.ErrDefault404); ok {
+				return n, "DELETED", nil
+			}
+
+			return n, "", err
+		}
+
+		return n, n.Status, nil
+	}
+}
 
 func expandNetworkingPortDHCPOptsV2Create(dhcpOpts *schema.Set) []extradhcpopts.CreateExtraDHCPOpt {
 	rawDHCPOpts := dhcpOpts.List()
@@ -112,4 +128,32 @@ func flattenNetworkingPortAllowedAddressPairsV2(mac string, allowedAddressPairs 
 	}
 
 	return pairs
+}
+
+func expandNetworkingPortFixedIpsV2(d *schema.ResourceData) interface{} {
+	// If no_fixed_ip was specified, then just return an empty array.
+	// Since no_fixed_ip is mutually exclusive to fixed_ip,
+	// we can safely do this.
+	//
+	// Since we're only concerned about no_fixed_ip being set to "true",
+	// GetOk is used.
+	if _, ok := d.GetOk("no_fixed_ip"); ok {
+		return []interface{}{}
+	}
+
+	rawIP := d.Get("fixed_ip").(*schema.Set).List()
+
+	if len(rawIP) == 0 {
+		return nil
+	}
+
+	ip := make([]ports.IP, len(rawIP))
+	for i, raw := range rawIP {
+		rawMap := raw.(map[string]interface{})
+		ip[i] = ports.IP{
+			SubnetID:  rawMap["subnet_id"].(string),
+			IPAddress: rawMap["ip_address"].(string),
+		}
+	}
+	return ip
 }

--- a/openstack/networking_port_v2_test.go
+++ b/openstack/networking_port_v2_test.go
@@ -230,3 +230,45 @@ func TestFlattenNetworkingPortAllowedAddressPairsV2(t *testing.T) {
 
 	assert.ElementsMatch(t, expectedAllowedAddressPairs, actualAllowedAddressPairs)
 }
+
+func TestExpandNetworkingPortFixedIPV2NoFixedIPs(t *testing.T) {
+	r := resourceNetworkingPortV2()
+	d := r.TestResourceData()
+	d.SetId("1")
+	d.Set("no_fixed_ip", true)
+
+	actualFixedIP := expandNetworkingPortFixedIPV2(d)
+
+	assert.Empty(t, actualFixedIP)
+}
+
+func TestExpandNetworkingPortFixedIPV2SomeFixedIPs(t *testing.T) {
+	r := resourceNetworkingPortV2()
+	d := r.TestResourceData()
+	d.SetId("1")
+	fixedIP1 := map[string]interface{}{
+		"subnet_id":  "aaa",
+		"ip_address": "192.0.201.101",
+	}
+	fixedIP2 := map[string]interface{}{
+		"subnet_id":  "bbb",
+		"ip_address": "192.0.202.102",
+	}
+	fixedIP := []map[string]interface{}{fixedIP1, fixedIP2}
+	d.Set("fixed_ip", fixedIP)
+
+	expectedFixedIP := []ports.IP{
+		{
+			SubnetID:  "aaa",
+			IPAddress: "192.0.201.101",
+		},
+		{
+			SubnetID:  "bbb",
+			IPAddress: "192.0.202.102",
+		},
+	}
+
+	actualFixedIP := expandNetworkingPortFixedIPV2(d)
+
+	assert.ElementsMatch(t, expectedFixedIP, actualFixedIP)
+}

--- a/openstack/resource_openstack_lb_loadbalancer_v2.go
+++ b/openstack/resource_openstack_lb_loadbalancer_v2.go
@@ -294,7 +294,7 @@ func resourceLoadBalancerV2Delete(d *schema.ResourceData, meta interface{}) erro
 func resourceLoadBalancerV2SecurityGroups(networkingClient *gophercloud.ServiceClient, vipPortID string, d *schema.ResourceData) error {
 	if vipPortID != "" {
 		if v, ok := d.GetOk("security_group_ids"); ok {
-			securityGroups := resourcePortSecurityGroupsV2(v.(*schema.Set))
+			securityGroups := expandToStringSlice(v.(*schema.Set).List())
 			updateOpts := ports.UpdateOpts{
 				SecurityGroups: &securityGroups,
 			}

--- a/openstack/resource_openstack_networking_port_v2.go
+++ b/openstack/resource_openstack_networking_port_v2.go
@@ -175,7 +175,7 @@ func resourceNetworkingPortV2() *schema.Resource {
 			},
 
 			"all_fixed_ips": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/openstack/resource_openstack_networking_port_v2.go
+++ b/openstack/resource_openstack_networking_port_v2.go
@@ -175,7 +175,7 @@ func resourceNetworkingPortV2() *schema.Resource {
 			},
 
 			"all_fixed_ips": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/openstack/resource_openstack_networking_port_v2.go
+++ b/openstack/resource_openstack_networking_port_v2.go
@@ -1,16 +1,13 @@
 package openstack
 
 import (
-	"bytes"
 	"fmt"
 	"log"
 	"time"
 
-	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/extradhcpopts"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
-	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -37,44 +34,52 @@ func resourceNetworkingPortV2() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
 			},
+
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
 			"network_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
+
 			"admin_state_up": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: false,
 				Computed: true,
 			},
+
 			"mac_address": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
+
 			"tenant_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
+
 			"device_owner": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
+
 			"security_group_ids": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -82,19 +87,22 @@ func resourceNetworkingPortV2() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
+
 			"no_security_groups": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: false,
 			},
+
 			"device_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
+
 			"fixed_ip": {
-				Type:          schema.TypeList,
+				Type:          schema.TypeSet,
 				Optional:      true,
 				ForceNew:      false,
 				ConflictsWith: []string{"no_fixed_ip"},
@@ -111,17 +119,18 @@ func resourceNetworkingPortV2() *schema.Resource {
 					},
 				},
 			},
+
 			"no_fixed_ip": {
 				Type:          schema.TypeBool,
 				Optional:      true,
 				ForceNew:      false,
 				ConflictsWith: []string{"fixed_ip"},
 			},
+
 			"allowed_address_pairs": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: false,
-				Set:      allowedAddressPairsHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ip_address": {
@@ -135,6 +144,7 @@ func resourceNetworkingPortV2() *schema.Resource {
 					},
 				},
 			},
+
 			"extra_dhcp_option": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -157,22 +167,26 @@ func resourceNetworkingPortV2() *schema.Resource {
 					},
 				},
 			},
+
 			"value_specs": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
 			},
+
 			"all_fixed_ips": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+
 			"all_security_group_ids": {
 				Type:     schema.TypeSet,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
+
 			"tags": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -189,14 +203,12 @@ func resourceNetworkingPortV2Create(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
-	var securityGroups []string
-	v := d.Get("security_group_ids")
-	securityGroups = resourcePortSecurityGroupsV2(v.(*schema.Set))
+	securityGroups := expandToStringSlice(d.Get("security_group_ids").(*schema.Set).List())
 	noSecurityGroups := d.Get("no_security_groups").(bool)
 
 	// Check and make sure an invalid security group configuration wasn't given.
 	if noSecurityGroups && len(securityGroups) > 0 {
-		return fmt.Errorf("Cannot have both no_security_groups and security_group_ids set")
+		return fmt.Errorf("Cannot have both no_security_groups and security_group_ids set for openstack_networking_port_v2")
 	}
 
 	allowedAddressPairs := d.Get("allowed_address_pairs").(*schema.Set)
@@ -209,7 +221,7 @@ func resourceNetworkingPortV2Create(d *schema.ResourceData, meta interface{}) er
 			TenantID:            d.Get("tenant_id").(string),
 			DeviceOwner:         d.Get("device_owner").(string),
 			DeviceID:            d.Get("device_id").(string),
-			FixedIPs:            resourcePortFixedIpsV2(d),
+			FixedIPs:            expandNetworkingPortFixedIpsV2(d),
 			AllowedAddressPairs: expandNetworkingPortAllowedAddressPairsV2(allowedAddressPairs),
 		},
 		MapValueSpecs(d),
@@ -232,7 +244,7 @@ func resourceNetworkingPortV2Create(d *schema.ResourceData, meta interface{}) er
 	}
 
 	// Declare a finalCreateOpts interface to hold either the
-	// base create options or the extended dhcp options.
+	// base create options or the extended DHCP options.
 	var finalCreateOpts ports.CreateOptsBuilder
 	finalCreateOpts = createOpts
 
@@ -244,7 +256,7 @@ func resourceNetworkingPortV2Create(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	log.Printf("[DEBUG] Create Options: %#v", finalCreateOpts)
+	log.Printf("[DEBUG] openstack_networking_port_v2 create options: %#v", finalCreateOpts)
 
 	// Create a Neutron port and set extra DHCP options if they're specified.
 	var p struct {
@@ -254,22 +266,23 @@ func resourceNetworkingPortV2Create(d *schema.ResourceData, meta interface{}) er
 
 	err = ports.Create(networkingClient, finalCreateOpts).ExtractInto(&p)
 	if err != nil {
-		return fmt.Errorf("Error creating OpenStack Neutron port: %s", err)
+		return fmt.Errorf("Error creating openstack_networking_port_v2: %s", err)
 	}
 
-	log.Printf("[INFO] Network ID: %s", p.ID)
-
-	log.Printf("[DEBUG] Waiting for OpenStack Neutron Port (%s) to become available.", p.ID)
+	log.Printf("[DEBUG] Waiting for openstack_networking_port_v2 %s to become available.", p.ID)
 
 	stateConf := &resource.StateChangeConf{
-		Target:     []string{"ACTIVE"},
-		Refresh:    waitForNetworkPortActive(networkingClient, p.ID),
+		Target:     []string{"ACTIVE", "DOWN"},
+		Refresh:    resourceNetworkingPortV2StateRefreshFunc(networkingClient, p.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      5 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}
 
 	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for openstack_networking_port_v2 %s to become available: %s", p.ID, err)
+	}
 
 	d.SetId(p.ID)
 
@@ -278,11 +291,12 @@ func resourceNetworkingPortV2Create(d *schema.ResourceData, meta interface{}) er
 		tagOpts := attributestags.ReplaceAllOpts{Tags: tags}
 		tags, err := attributestags.ReplaceAll(networkingClient, "ports", p.ID, tagOpts).Extract()
 		if err != nil {
-			return fmt.Errorf("Error creating Tags on Port: %s", err)
+			return fmt.Errorf("Error setting tags on openstack_networking_port_v2 %s: %s", p.ID, err)
 		}
-		log.Printf("[DEBUG] Set Tags = %+v on Port %+v", tags, p.ID)
+		log.Printf("[DEBUG] Set tags %s on openstack_networking_port_v2 %s", tags, p.ID)
 	}
 
+	log.Printf("[DEBUG] Created openstack_networking_port_v2 %s: %#v", p.ID, p)
 	return resourceNetworkingPortV2Read(d, meta)
 }
 
@@ -299,10 +313,10 @@ func resourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) erro
 	}
 	err = ports.Get(networkingClient, d.Id()).ExtractInto(&p)
 	if err != nil {
-		return CheckDeleted(d, err, "port")
+		return CheckDeleted(d, err, "Error getting openstack_networking_port_v2")
 	}
 
-	log.Printf("[DEBUG] Retrieved Port %s: %+v", d.Id(), p)
+	log.Printf("[DEBUG] Retrieved openstack_networking_port_v2 %s: %#v", d.Id(), p)
 
 	d.Set("name", p.Name)
 	d.Set("description", p.Description)
@@ -343,13 +357,12 @@ func resourceNetworkingPortV2Update(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
-	v := d.Get("security_group_ids").(*schema.Set)
-	securityGroups := resourcePortSecurityGroupsV2(v)
+	securityGroups := expandToStringSlice(d.Get("security_group_ids").(*schema.Set).List())
 	noSecurityGroups := d.Get("no_security_groups").(bool)
 
 	// Check and make sure an invalid security group configuration wasn't given.
 	if noSecurityGroups && len(securityGroups) > 0 {
-		return fmt.Errorf("Cannot have both no_security_groups and security_group_ids set")
+		return fmt.Errorf("Cannot have both no_security_groups and security_group_ids set for openstack_networking_port_v2")
 	}
 
 	var hasChange bool
@@ -372,8 +385,6 @@ func resourceNetworkingPortV2Update(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("security_group_ids") {
 		hasChange = true
-		sgs := d.Get("security_group_ids").(*schema.Set)
-		securityGroups := resourcePortSecurityGroupsV2(sgs)
 		updateOpts.SecurityGroups = &securityGroups
 	}
 
@@ -409,11 +420,12 @@ func resourceNetworkingPortV2Update(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("fixed_ip") || d.HasChange("no_fixed_ip") {
 		hasChange = true
-		updateOpts.FixedIPs = resourcePortFixedIpsV2(d)
+		updateOpts.FixedIPs = expandNetworkingPortFixedIpsV2(d)
 	}
 
 	// At this point, perform the update for all "standard" port changes.
 	if hasChange {
+		log.Printf("[DEBUG] openstack_networking_port_v2 %s update options: %#v", d.Id(), updateOpts)
 		_, err = ports.Update(networkingClient, d.Id(), updateOpts).Extract()
 		if err != nil {
 			return fmt.Errorf("Error updating OpenStack Neutron Port: %s", err)
@@ -435,7 +447,7 @@ func resourceNetworkingPortV2Update(d *schema.ResourceData, meta interface{}) er
 				ExtraDHCPOpts:     deleteExtraDHCPOpts,
 			}
 
-			log.Printf("[DEBUG] Deleting old DHCP opts for Port %s", d.Id())
+			log.Printf("[DEBUG] Deleting old DHCP opts for openstack_networking_port_v2 %s", d.Id())
 			_, err = ports.Update(networkingClient, d.Id(), dhcpUpdateOpts).Extract()
 			if err != nil {
 				return fmt.Errorf("Error updating OpenStack Neutron Port: %s", err)
@@ -450,10 +462,10 @@ func resourceNetworkingPortV2Update(d *schema.ResourceData, meta interface{}) er
 				ExtraDHCPOpts:     updateExtraDHCPOpts,
 			}
 
-			log.Printf("[DEBUG] Updating Port %s with options: %+v", d.Id(), dhcpUpdateOpts)
+			log.Printf("[DEBUG] Updating openstack_networking_port_v2 %s with options: %#v", d.Id(), dhcpUpdateOpts)
 			_, err = ports.Update(networkingClient, d.Id(), dhcpUpdateOpts).Extract()
 			if err != nil {
-				return fmt.Errorf("Error updating OpenStack Neutron Port: %s", err)
+				return fmt.Errorf("Error updating openstack_networking_port_v2 %s: %s", d.Id(), err)
 			}
 		}
 	}
@@ -464,9 +476,9 @@ func resourceNetworkingPortV2Update(d *schema.ResourceData, meta interface{}) er
 		tagOpts := attributestags.ReplaceAllOpts{Tags: tags}
 		tags, err := attributestags.ReplaceAll(networkingClient, "ports", d.Id(), tagOpts).Extract()
 		if err != nil {
-			return fmt.Errorf("Error updating Tags on Port: %s", err)
+			return fmt.Errorf("Error setting tags on openstack_networking_port_v2 %s: %s", d.Id(), err)
 		}
-		log.Printf("[DEBUG] Updated Tags = %+v on Port %+v", tags, d.Id())
+		log.Printf("[DEBUG] Set tags %s on openstack_networking_port_v2 %s", tags, d.Id())
 	}
 
 	return resourceNetworkingPortV2Read(d, meta)
@@ -479,10 +491,14 @@ func resourceNetworkingPortV2Delete(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
+	if err := ports.Delete(networkingClient, d.Id()).ExtractErr(); err != nil {
+		return CheckDeleted(d, err, "Error deleting openstack_networking_port_v2")
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE"},
 		Target:     []string{"DELETED"},
-		Refresh:    waitForNetworkPortDelete(networkingClient, d.Id()),
+		Refresh:    resourceNetworkingPortV2StateRefreshFunc(networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      5 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -490,96 +506,9 @@ func resourceNetworkingPortV2Delete(d *schema.ResourceData, meta interface{}) er
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error deleting OpenStack Neutron Network: %s", err)
+		return fmt.Errorf("Error waiting for openstack_networking_port_v2 %s to delete: %s", d.Id(), err)
 	}
 
 	d.SetId("")
 	return nil
-}
-
-func resourcePortSecurityGroupsV2(v *schema.Set) []string {
-	var securityGroups []string
-	for _, v := range v.List() {
-		securityGroups = append(securityGroups, v.(string))
-	}
-	return securityGroups
-}
-
-func resourcePortFixedIpsV2(d *schema.ResourceData) interface{} {
-	// if no_fixed_ip was specified, then just return
-	// an empty array. Since no_fixed_ip is mutually
-	// exclusive to fixed_ip, we can safely do this.
-	//
-	// Since we're only concerned about no_fixed_ip
-	// being set to "true", GetOk is used.
-	if _, ok := d.GetOk("no_fixed_ip"); ok {
-		return []interface{}{}
-	}
-
-	rawIP := d.Get("fixed_ip").([]interface{})
-
-	if len(rawIP) == 0 {
-		return nil
-	}
-
-	ip := make([]ports.IP, len(rawIP))
-	for i, raw := range rawIP {
-		rawMap := raw.(map[string]interface{})
-		ip[i] = ports.IP{
-			SubnetID:  rawMap["subnet_id"].(string),
-			IPAddress: rawMap["ip_address"].(string),
-		}
-	}
-	return ip
-}
-
-func allowedAddressPairsHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-%s", m["ip_address"].(string), m["mac_address"].(string)))
-
-	return hashcode.String(buf.String())
-}
-
-func waitForNetworkPortActive(networkingClient *gophercloud.ServiceClient, portId string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		p, err := ports.Get(networkingClient, portId).Extract()
-		if err != nil {
-			return nil, "", err
-		}
-
-		log.Printf("[DEBUG] OpenStack Neutron Port: %+v", p)
-		if p.Status == "DOWN" || p.Status == "ACTIVE" {
-			return p, "ACTIVE", nil
-		}
-
-		return p, p.Status, nil
-	}
-}
-
-func waitForNetworkPortDelete(networkingClient *gophercloud.ServiceClient, portId string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		log.Printf("[DEBUG] Attempting to delete OpenStack Neutron Port %s", portId)
-
-		p, err := ports.Get(networkingClient, portId).Extract()
-		if err != nil {
-			if _, ok := err.(gophercloud.ErrDefault404); ok {
-				log.Printf("[DEBUG] Successfully deleted OpenStack Port %s", portId)
-				return p, "DELETED", nil
-			}
-			return p, "ACTIVE", err
-		}
-
-		err = ports.Delete(networkingClient, portId).ExtractErr()
-		if err != nil {
-			if _, ok := err.(gophercloud.ErrDefault404); ok {
-				log.Printf("[DEBUG] Successfully deleted OpenStack Port %s", portId)
-				return p, "DELETED", nil
-			}
-			return p, "ACTIVE", err
-		}
-
-		log.Printf("[DEBUG] OpenStack Port %s still active.\n", portId)
-		return p, "ACTIVE", nil
-	}
 }

--- a/openstack/resource_openstack_networking_port_v2.go
+++ b/openstack/resource_openstack_networking_port_v2.go
@@ -131,6 +131,7 @@ func resourceNetworkingPortV2() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: false,
+				Set:      resourceNetworkingPortV2AllowedAddressPairsHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ip_address": {

--- a/openstack/resource_openstack_networking_port_v2.go
+++ b/openstack/resource_openstack_networking_port_v2.go
@@ -102,7 +102,7 @@ func resourceNetworkingPortV2() *schema.Resource {
 			},
 
 			"fixed_ip": {
-				Type:          schema.TypeSet,
+				Type:          schema.TypeList,
 				Optional:      true,
 				ForceNew:      false,
 				ConflictsWith: []string{"no_fixed_ip"},
@@ -221,7 +221,7 @@ func resourceNetworkingPortV2Create(d *schema.ResourceData, meta interface{}) er
 			TenantID:            d.Get("tenant_id").(string),
 			DeviceOwner:         d.Get("device_owner").(string),
 			DeviceID:            d.Get("device_id").(string),
-			FixedIPs:            expandNetworkingPortFixedIpsV2(d),
+			FixedIPs:            expandNetworkingPortFixedIPV2(d),
 			AllowedAddressPairs: expandNetworkingPortAllowedAddressPairsV2(allowedAddressPairs),
 		},
 		MapValueSpecs(d),
@@ -420,7 +420,7 @@ func resourceNetworkingPortV2Update(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("fixed_ip") || d.HasChange("no_fixed_ip") {
 		hasChange = true
-		updateOpts.FixedIPs = expandNetworkingPortFixedIpsV2(d)
+		updateOpts.FixedIPs = expandNetworkingPortFixedIPV2(d)
 	}
 
 	// At this point, perform the update for all "standard" port changes.

--- a/openstack/util.go
+++ b/openstack/util.go
@@ -239,15 +239,3 @@ func strSliceContains(haystack []string, needle string) bool {
 	}
 	return false
 }
-
-// boolPtrArgument retrieves specified argument from the provided ResourceData
-// and returns pointer to boolean which contains "true" if argument is set.
-func boolPtrArgument(argument string, d *schema.ResourceData) *bool {
-	value := false
-
-	if raw, ok := d.GetOk(argument); ok && raw == true {
-		value = true
-	}
-
-	return &value
-}

--- a/openstack/util.go
+++ b/openstack/util.go
@@ -239,3 +239,15 @@ func strSliceContains(haystack []string, needle string) bool {
 	}
 	return false
 }
+
+// boolPtrArgument retrieves specified argument from the provided ResourceData
+// and returns pointer to boolean which contains "true" if argument is set.
+func boolPtrArgument(argument string, d *schema.ResourceData) *bool {
+	value := false
+
+	if raw, ok := d.GetOk(argument); ok && raw == true {
+		value = true
+	}
+
+	return &value
+}


### PR DESCRIPTION
Add StateRefreshFunc(), expandNetworkingPortFixedIpsV2 into the
"networking_port_v2.go".

Change "fixed_ip" argument type to "TypeSet".

Use "expandToStringSlice()" function to retrieve "security_groups"
value. This change also affects "openstack_lb_loadbalancer_v2" resource
code.

Add common "boolPtrArgument()" into "util.go" to work with some special
arguments like "admin_state_up".

Fix debug and error messages.

For #456 