### PR TITLE
Internal: Update CheckDeleted message

### DIFF
--- a/openstack/resource_openstack_blockstorage_volume_v1.go
+++ b/openstack/resource_openstack_blockstorage_volume_v1.go
@@ -175,7 +175,8 @@ func resourceBlockStorageVolumeV1Read(d *schema.ResourceData, meta interface{}) 
 
 	v, err := volumes.Get(blockStorageClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving openstack_blockstorage_volume_v1")
+		msg := fmt.Sprintf("Error retrieving openstack_blockstorage_volume_v1 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	log.Printf("[DEBUG] Retrieved openstack_blockstorage_volume_v1 %s: %#v", d.Id(), v)
@@ -236,7 +237,8 @@ func resourceBlockStorageVolumeV1Delete(d *schema.ResourceData, meta interface{}
 
 	v, err := volumes.Get(blockStorageClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving openstack_blockstorage_volume_v1")
+		msg := fmt.Sprintf("Error retrieving openstack_blockstorage_volume_v1 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	// Make sure this volume is detached from all instances before deleting.
@@ -278,7 +280,8 @@ func resourceBlockStorageVolumeV1Delete(d *schema.ResourceData, meta interface{}
 	// If this is true, just move on. It'll eventually delete.
 	if v.Status != "deleting" {
 		if err := volumes.Delete(blockStorageClient, d.Id()).ExtractErr(); err != nil {
-			return CheckDeleted(d, err, "Error deleting openstack_blockstorage_volume_v1")
+			msg := fmt.Sprintf("Error deleting openstack_blockstorage_volume_v1 %s", d.Id())
+			return CheckDeleted(d, err, msg)
 		}
 	}
 

--- a/openstack/resource_openstack_blockstorage_volume_v2.go
+++ b/openstack/resource_openstack_blockstorage_volume_v2.go
@@ -188,7 +188,8 @@ func resourceBlockStorageVolumeV2Read(d *schema.ResourceData, meta interface{}) 
 
 	v, err := volumes.Get(blockStorageClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving openstack_blockstorage_volume_v2")
+		msg := fmt.Sprintf("Error retrieving openstack_blockstorage_volume_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	log.Printf("[DEBUG] Retrieved openstack_blockstorage_volume_v2 %s: %#v", d.Id(), v)
@@ -249,7 +250,8 @@ func resourceBlockStorageVolumeV2Delete(d *schema.ResourceData, meta interface{}
 
 	v, err := volumes.Get(blockStorageClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving openstack_blockstorage_volume_v2")
+		msg := fmt.Sprintf("Error retrieving openstack_blockstorage_volume_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	// Make sure this volume is detached from all instances before deleting.
@@ -291,7 +293,8 @@ func resourceBlockStorageVolumeV2Delete(d *schema.ResourceData, meta interface{}
 	// If this is true, just move on. It'll eventually delete.
 	if v.Status != "deleting" {
 		if err := volumes.Delete(blockStorageClient, d.Id(), nil).ExtractErr(); err != nil {
-			return CheckDeleted(d, err, "Error deleting openstack_blockstorage_volume_v2")
+			msg := fmt.Sprintf("Error deleting openstack_blockstorage_volume_v2 %s", d.Id())
+			return CheckDeleted(d, err, msg)
 		}
 	}
 

--- a/openstack/resource_openstack_blockstorage_volume_v3.go
+++ b/openstack/resource_openstack_blockstorage_volume_v3.go
@@ -199,7 +199,8 @@ func resourceBlockStorageVolumeV3Read(d *schema.ResourceData, meta interface{}) 
 
 	v, err := volumes.Get(blockStorageClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving openstack_blockstorage_volume_v3")
+		msg := fmt.Sprintf("Error retrieving openstack_blockstorage_volume_v3 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	log.Printf("[DEBUG] Retrieved openstack_blockstorage_volume_v3 %s: %#v", d.Id(), v)
@@ -304,7 +305,8 @@ func resourceBlockStorageVolumeV3Delete(d *schema.ResourceData, meta interface{}
 
 	v, err := volumes.Get(blockStorageClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving openstack_blockstorage_volume_v3")
+		msg := fmt.Sprintf("Error retrieving openstack_blockstorage_volume_v3 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	// make sure this volume is detached from all instances before deleting
@@ -346,7 +348,8 @@ func resourceBlockStorageVolumeV3Delete(d *schema.ResourceData, meta interface{}
 	// If this is true, just move on. It'll eventually delete.
 	if v.Status != "deleting" {
 		if err := volumes.Delete(blockStorageClient, d.Id(), nil).ExtractErr(); err != nil {
-			return CheckDeleted(d, err, "Error deleting openstack_blockstorage_volume_v3")
+			msg := fmt.Sprintf("Error deleting openstack_blockstorage_volume_v3 %s", d.Id())
+			return CheckDeleted(d, err, msg)
 		}
 	}
 

--- a/openstack/resource_openstack_compute_flavor_v2.go
+++ b/openstack/resource_openstack_compute_flavor_v2.go
@@ -137,7 +137,8 @@ func resourceComputeFlavorV2Read(d *schema.ResourceData, meta interface{}) error
 
 	fl, err := flavors.Get(computeClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving openstack_compute_flavor_v2")
+		msg := fmt.Sprintf("Error retrieving openstack_compute_flavor_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	log.Printf("[DEBUG] Retrieved openstack_compute_flavor_v2 %s: %#v", d.Id(), fl)
@@ -205,7 +206,8 @@ func resourceComputeFlavorV2Delete(d *schema.ResourceData, meta interface{}) err
 
 	err = flavors.Delete(computeClient, d.Id()).ExtractErr()
 	if err != nil {
-		return fmt.Errorf("Error deleting openstack_compute_flavor_v2 %s: %s", d.Id(), err)
+		msg := fmt.Sprintf("Error deleting openstack_compute_flavor_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	return nil

--- a/openstack/resource_openstack_compute_floatingip_v2.go
+++ b/openstack/resource_openstack_compute_floatingip_v2.go
@@ -83,7 +83,8 @@ func resourceComputeFloatingIPV2Read(d *schema.ResourceData, meta interface{}) e
 
 	fip, err := floatingips.Get(computeClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving openstack_compute_floatingip_v2")
+		msg := fmt.Sprintf("Error retrieving openstack_compute_floatingip_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	log.Printf("[DEBUG] Retrieved openstack_compute_floatingip_v2 %s: %#v", d.Id(), fip)
@@ -105,7 +106,8 @@ func resourceComputeFloatingIPV2Delete(d *schema.ResourceData, meta interface{})
 	}
 
 	if err := floatingips.Delete(computeClient, d.Id()).ExtractErr(); err != nil {
-		return fmt.Errorf("Error deleting openstack_compute_floatingip_v2: %s", err)
+		msg := fmt.Sprintf("Error deleting openstack_compute_floatingip_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	return nil

--- a/openstack/resource_openstack_compute_interface_attach_v2.go
+++ b/openstack/resource_openstack_compute_interface_attach_v2.go
@@ -143,7 +143,8 @@ func resourceComputeInterfaceAttachV2Read(d *schema.ResourceData, meta interface
 
 	attachment, err := attachinterfaces.Get(computeClient, instanceId, attachmentId).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving openstack_compute_interface_attach_v2")
+		msg := fmt.Sprintf("Error retrieving openstack_compute_interface_attach_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	log.Printf("[DEBUG] Retrieved openstack_compute_interface_attach_v2 %s: %#v", d.Id(), attachment)

--- a/openstack/resource_openstack_compute_keypair_v2.go
+++ b/openstack/resource_openstack_compute_keypair_v2.go
@@ -98,7 +98,8 @@ func resourceComputeKeypairV2Read(d *schema.ResourceData, meta interface{}) erro
 
 	kp, err := keypairs.Get(computeClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving openstack_compute_keypair_v2")
+		msg := fmt.Sprintf("Error retrieving openstack_compute_keypair_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	log.Printf("[DEBUG] Retrieved openstack_compute_keypair_v2 %s: %#v", d.Id(), kp)
@@ -120,7 +121,8 @@ func resourceComputeKeypairV2Delete(d *schema.ResourceData, meta interface{}) er
 
 	err = keypairs.Delete(computeClient, d.Id()).ExtractErr()
 	if err != nil {
-		return fmt.Errorf("Error deleting openstack_compute_keypair_v2 %s: %s", d.Id(), err)
+		msg := fmt.Sprintf("Error deleting openstack_compute_keypair_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	return nil

--- a/openstack/resource_openstack_compute_secgroup_v2.go
+++ b/openstack/resource_openstack_compute_secgroup_v2.go
@@ -153,7 +153,8 @@ func resourceComputeSecGroupV2Read(d *schema.ResourceData, meta interface{}) err
 
 	sg, err := secgroups.Get(computeClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving openstack_compute_secgroup_v2")
+		msg := fmt.Sprintf("Error retrieving openstack_compute_secgroup_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	d.Set("name", sg.Name)
@@ -222,7 +223,7 @@ func resourceComputeSecGroupV2Update(d *schema.ResourceData, meta interface{}) e
 					continue
 				}
 
-				return fmt.Errorf("Error removing rule %s from openstack_compute_secgroup_v2 %s", rule.ID, d.Id())
+				return fmt.Errorf("Error removing rule %s from openstack_compute_secgroup_v2 %s: %s", rule.ID, d.Id(), err)
 			}
 		}
 	}
@@ -248,7 +249,8 @@ func resourceComputeSecGroupV2Delete(d *schema.ResourceData, meta interface{}) e
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error deleting openstack_compute_secgroup_v2: %s", err)
+		msg := fmt.Sprintf("Error deleting openstack_compute_secgroup_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	return nil

--- a/openstack/resource_openstack_compute_servergroup_v2.go
+++ b/openstack/resource_openstack_compute_servergroup_v2.go
@@ -94,7 +94,8 @@ func resourceComputeServerGroupV2Read(d *schema.ResourceData, meta interface{}) 
 
 	sg, err := servergroups.Get(computeClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving openstack_compute_servergroup_v2")
+		msg := fmt.Sprintf("Error retrieving openstack_compute_servergroup_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	log.Printf("[DEBUG] Retrieved openstack_compute_servergroup_v2 %s: %#v", d.Id(), sg)
@@ -116,7 +117,8 @@ func resourceComputeServerGroupV2Delete(d *schema.ResourceData, meta interface{}
 	}
 
 	if err := servergroups.Delete(computeClient, d.Id()).ExtractErr(); err != nil {
-		return fmt.Errorf("Error deleting openstack_compute_servergroup_v2: %s", err)
+		msg := fmt.Sprintf("Error deleting openstack_compute_servergroup_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	return nil

--- a/openstack/resource_openstack_compute_volume_attach_v2.go
+++ b/openstack/resource_openstack_compute_volume_attach_v2.go
@@ -127,7 +127,8 @@ func resourceComputeVolumeAttachV2Read(d *schema.ResourceData, meta interface{})
 
 	attachment, err := volumeattach.Get(computeClient, instanceId, attachmentId).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving openstack_compute_volume_attach_v2")
+		msg := fmt.Sprintf("Error retrieving openstack_compute_volume_attach_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	log.Printf("[DEBUG] Retrieved openstack_compute_volume_attach_v2 %s: %#v", d.Id(), attachment)

--- a/openstack/resource_openstack_containerinfra_cluster_v1.go
+++ b/openstack/resource_openstack_containerinfra_cluster_v1.go
@@ -269,7 +269,8 @@ func resourceContainerInfraClusterV1Read(d *schema.ResourceData, meta interface{
 
 	s, err := clusters.Get(containerInfraClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving openstack_containerinfra_cluster_v1")
+		msg := fmt.Sprintf("Error retrieving openstack_containerinfra_cluster_v1 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	log.Printf("[DEBUG] Retrieved openstack_containerinfra_cluster_v1 %s: %#v", d.Id(), s)
@@ -357,7 +358,8 @@ func resourceContainerInfraClusterV1Delete(d *schema.ResourceData, meta interfac
 	}
 
 	if err := clusters.Delete(containerInfraClient, d.Id()).ExtractErr(); err != nil {
-		return CheckDeleted(d, err, "Error deleting openstack_containerinfra_cluster_v1")
+		msg := fmt.Sprintf("Error deleting openstack_containerinfra_cluster_v1 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	stateConf := &resource.StateChangeConf{

--- a/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
+++ b/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
@@ -310,7 +310,8 @@ func resourceContainerInfraClusterTemplateV1Read(d *schema.ResourceData, meta in
 
 	s, err := clustertemplates.Get(containerInfraClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving openstack_containerinfra_clustertemplate_v1")
+		msg := fmt.Sprintf("Error retrieving openstack_containerinfra_clustertemplate_v1 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	log.Printf("[DEBUG] Retrieved openstack_containerinfra_clustertemplate_v1 %s: %#v", d.Id(), s)
@@ -538,7 +539,8 @@ func resourceContainerInfraClusterTemplateV1Delete(d *schema.ResourceData, meta 
 	}
 
 	if err := clustertemplates.Delete(containerInfraClient, d.Id()).ExtractErr(); err != nil {
-		return CheckDeleted(d, err, "Error deleting openstack_containerinfra_clustertemplate_v1")
+		msg := fmt.Sprintf("Error deleting openstack_containerinfra_clustertemplate_v1 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	return nil

--- a/openstack/resource_openstack_dns_recordset_v2.go
+++ b/openstack/resource_openstack_dns_recordset_v2.go
@@ -145,7 +145,8 @@ func resourceDNSRecordSetV2Read(d *schema.ResourceData, meta interface{}) error 
 
 	n, err := recordsets.Get(dnsClient, zoneID, recordsetID).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving openstack_dns_recordset_v2")
+		msg := fmt.Sprintf("Error retrieving openstack_dns_recordset_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	log.Printf("[DEBUG] Retrieved openstack_dns_recordset_v2 %s: %#v", recordsetID, n)
@@ -225,7 +226,8 @@ func resourceDNSRecordSetV2Delete(d *schema.ResourceData, meta interface{}) erro
 
 	err = recordsets.Delete(dnsClient, zoneID, recordsetID).ExtractErr()
 	if err != nil {
-		return fmt.Errorf("Error deleting openstack_dns_recordset_v2 %s: %s", d.Id(), err)
+		msg := fmt.Sprintf("Error deleting openstack_dns_recordset_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	stateConf := &resource.StateChangeConf{

--- a/openstack/resource_openstack_dns_zone_v2.go
+++ b/openstack/resource_openstack_dns_zone_v2.go
@@ -146,7 +146,8 @@ func resourceDNSZoneV2Read(d *schema.ResourceData, meta interface{}) error {
 
 	n, err := zones.Get(dnsClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving openstack_dns_zone_v2")
+		msg := fmt.Sprintf("Error retrieving openstack_dns_zone_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	log.Printf("[DEBUG] Retrieved openstack_dns_zone_v2 %s: %#v", d.Id(), n)
@@ -218,7 +219,8 @@ func resourceDNSZoneV2Delete(d *schema.ResourceData, meta interface{}) error {
 
 	_, err = zones.Delete(dnsClient, d.Id()).Extract()
 	if err != nil {
-		return fmt.Errorf("Error deleting openstack_dns_zone_v2 %s: %s", d.Id(), err)
+		msg := fmt.Sprintf("Error deleting openstack_dns_zone_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	stateConf := &resource.StateChangeConf{

--- a/openstack/resource_openstack_networking_floatingip_associate_v2.go
+++ b/openstack/resource_openstack_networking_floatingip_associate_v2.go
@@ -83,7 +83,8 @@ func resourceNetworkingFloatingIPAssociateV2Read(d *schema.ResourceData, meta in
 
 	fip, err := floatingips.Get(networkingClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error getting openstack_networking_floatingip_v2")
+		msg := fmt.Sprintf("Error retrieving openstack_networking_floatingip_v2 %s", d.Id())
+		return CheckDeleted(d, err, msg)
 	}
 
 	log.Printf("[DEBUG] Retrieved openstack_networking_floatingip_v2 %s: %#v", d.Id(), fip)


### PR DESCRIPTION
This commit revises the CheckDeleted message of cleaned up resources.

For #456 

@ozerovandrei This adds `CheckDeleted` to the `Delete` function when it's appropriate to do so. It also adds the ID of the resource to the message - this would have bugged me until I fixed it :)