### PR TITLE
Internal: Add ID to CheckDeleted

### DIFF
--- a/openstack/resource_openstack_compute_flavor_v2.go
+++ b/openstack/resource_openstack_compute_flavor_v2.go
@@ -205,7 +205,7 @@ func resourceComputeFlavorV2Delete(d *schema.ResourceData, meta interface{}) err
 
 	err = flavors.Delete(computeClient, d.Id()).ExtractErr()
 	if err != nil {
-		return fmt.Errorf("Error deleting openstack_compute_flavor_v2 %s: %s", d.Id(), err)
+		return CheckDeleted(d, err, "Error deleting openstack_compute_flavor_v2")
 	}
 
 	return nil

--- a/openstack/resource_openstack_compute_floatingip_v2.go
+++ b/openstack/resource_openstack_compute_floatingip_v2.go
@@ -105,7 +105,7 @@ func resourceComputeFloatingIPV2Delete(d *schema.ResourceData, meta interface{})
 	}
 
 	if err := floatingips.Delete(computeClient, d.Id()).ExtractErr(); err != nil {
-		return fmt.Errorf("Error deleting openstack_compute_floatingip_v2: %s", err)
+		return CheckDeleted(d, err, "Error deleting openstack_compute_floatingip_v2")
 	}
 
 	return nil

--- a/openstack/resource_openstack_compute_keypair_v2.go
+++ b/openstack/resource_openstack_compute_keypair_v2.go
@@ -120,7 +120,7 @@ func resourceComputeKeypairV2Delete(d *schema.ResourceData, meta interface{}) er
 
 	err = keypairs.Delete(computeClient, d.Id()).ExtractErr()
 	if err != nil {
-		return fmt.Errorf("Error deleting openstack_compute_keypair_v2 %s: %s", d.Id(), err)
+		return CheckDeleted(d, err, "Error deleting openstack_compute_keypair_v2")
 	}
 
 	return nil

--- a/openstack/resource_openstack_compute_secgroup_v2.go
+++ b/openstack/resource_openstack_compute_secgroup_v2.go
@@ -222,7 +222,7 @@ func resourceComputeSecGroupV2Update(d *schema.ResourceData, meta interface{}) e
 					continue
 				}
 
-				return fmt.Errorf("Error removing rule %s from openstack_compute_secgroup_v2 %s", rule.ID, d.Id())
+				return fmt.Errorf("Error removing rule %s from openstack_compute_secgroup_v2 %s: %s", rule.ID, d.Id(), err)
 			}
 		}
 	}
@@ -248,7 +248,7 @@ func resourceComputeSecGroupV2Delete(d *schema.ResourceData, meta interface{}) e
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error deleting openstack_compute_secgroup_v2: %s", err)
+		return CheckDeleted(d, err, "Error deleting openstack_compute_secgroup_v2")
 	}
 
 	return nil

--- a/openstack/resource_openstack_compute_servergroup_v2.go
+++ b/openstack/resource_openstack_compute_servergroup_v2.go
@@ -116,7 +116,7 @@ func resourceComputeServerGroupV2Delete(d *schema.ResourceData, meta interface{}
 	}
 
 	if err := servergroups.Delete(computeClient, d.Id()).ExtractErr(); err != nil {
-		return fmt.Errorf("Error deleting openstack_compute_servergroup_v2: %s", err)
+		return CheckDeleted(d, err, "Error deleting openstack_compute_servergroup_v2")
 	}
 
 	return nil

--- a/openstack/resource_openstack_dns_recordset_v2.go
+++ b/openstack/resource_openstack_dns_recordset_v2.go
@@ -225,7 +225,7 @@ func resourceDNSRecordSetV2Delete(d *schema.ResourceData, meta interface{}) erro
 
 	err = recordsets.Delete(dnsClient, zoneID, recordsetID).ExtractErr()
 	if err != nil {
-		return fmt.Errorf("Error deleting openstack_dns_recordset_v2 %s: %s", d.Id(), err)
+		return CheckDeleted(d, err, "Error deleting openstack_dns_recordset_v2")
 	}
 
 	stateConf := &resource.StateChangeConf{

--- a/openstack/resource_openstack_dns_zone_v2.go
+++ b/openstack/resource_openstack_dns_zone_v2.go
@@ -218,7 +218,7 @@ func resourceDNSZoneV2Delete(d *schema.ResourceData, meta interface{}) error {
 
 	_, err = zones.Delete(dnsClient, d.Id()).Extract()
 	if err != nil {
-		return fmt.Errorf("Error deleting openstack_dns_zone_v2 %s: %s", d.Id(), err)
+		return CheckDeleted(d, err, "Error deleting openstack_dns_zone_v2")
 	}
 
 	stateConf := &resource.StateChangeConf{

--- a/openstack/util.go
+++ b/openstack/util.go
@@ -38,7 +38,7 @@ func CheckDeleted(d *schema.ResourceData, err error, msg string) error {
 		return nil
 	}
 
-	return fmt.Errorf("%s: %s", msg, err)
+	return fmt.Errorf("%s %s: %s", msg, d.Id(), err)
 }
 
 // GetRegion returns the region that was specified in the resource. If a


### PR DESCRIPTION
This commit adds the resource ID to all CheckDeleted error messages for
easier detection of what resource the error came from.

It also adds CheckDeleted to the Delete function of missing resources
which have already gone through the cleanup process.

/cc @kayrus 