### PR TITLE
Networking v2: Fix boolean fields of network resource

### DIFF
--- a/openstack/resource_openstack_networking_network_v2.go
+++ b/openstack/resource_openstack_networking_network_v2.go
@@ -3,7 +3,6 @@ package openstack
 import (
 	"fmt"
 	"log"
-	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -50,13 +49,13 @@ func resourceNetworkingNetworkV2() *schema.Resource {
 				ForceNew: false,
 			},
 			"admin_state_up": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: false,
 				Computed: true,
 			},
 			"shared": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: false,
 				Computed: true,
@@ -141,21 +140,13 @@ func resourceNetworkingNetworkV2Create(d *schema.ResourceData, meta interface{})
 		MapValueSpecs(d),
 	}
 
-	asuRaw := d.Get("admin_state_up").(string)
-	if asuRaw != "" {
-		asu, err := strconv.ParseBool(asuRaw)
-		if err != nil {
-			return fmt.Errorf("admin_state_up, if provided, must be either 'true' or 'false'")
-		}
+	if v, ok := d.GetOkExists("admin_state_up"); ok {
+		asu := v.(bool)
 		createOpts.AdminStateUp = &asu
 	}
 
-	sharedRaw := d.Get("shared").(string)
-	if sharedRaw != "" {
-		shared, err := strconv.ParseBool(sharedRaw)
-		if err != nil {
-			return fmt.Errorf("shared, if provided, must be either 'true' or 'false': %v", err)
-		}
+	if v, ok := d.GetOkExists("shared"); ok {
+		shared := v.(bool)
 		createOpts.Shared = &shared
 	}
 
@@ -249,9 +240,9 @@ func resourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{}) e
 
 	d.Set("name", n.Name)
 	d.Set("description", n.Description)
-	d.Set("admin_state_up", strconv.FormatBool(n.AdminStateUp))
-	d.Set("shared", strconv.FormatBool(n.Shared))
-	d.Set("external", strconv.FormatBool(n.External))
+	d.Set("admin_state_up", n.AdminStateUp)
+	d.Set("shared", n.Shared)
+	d.Set("external", n.External)
 	d.Set("tenant_id", n.TenantID)
 	d.Set("region", GetRegion(d, config))
 	d.Set("tags", n.Tags)
@@ -286,24 +277,12 @@ func resourceNetworkingNetworkV2Update(d *schema.ResourceData, meta interface{})
 		updateOpts.Description = &description
 	}
 	if d.HasChange("admin_state_up") {
-		asuRaw := d.Get("admin_state_up").(string)
-		if asuRaw != "" {
-			asu, err := strconv.ParseBool(asuRaw)
-			if err != nil {
-				return fmt.Errorf("admin_state_up, if provided, must be either 'true' or 'false'")
-			}
-			updateOpts.AdminStateUp = &asu
-		}
+		asu := d.Get("admin_state_up").(bool)
+		updateOpts.AdminStateUp = &asu
 	}
 	if d.HasChange("shared") {
-		sharedRaw := d.Get("shared").(string)
-		if sharedRaw != "" {
-			shared, err := strconv.ParseBool(sharedRaw)
-			if err != nil {
-				return fmt.Errorf("shared, if provided, must be either 'true' or 'false': %v", err)
-			}
-			updateOpts.Shared = &shared
-		}
+		shared := d.Get("shared").(bool)
+		updateOpts.Shared = &shared
 	}
 
 	// Change tags if needed.

--- a/openstack/resource_openstack_networking_network_v2_test.go
+++ b/openstack/resource_openstack_networking_network_v2_test.go
@@ -210,6 +210,107 @@ func TestAccNetworkingV2Network_transparent_vlan_Create(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2Network_adminStateUp_omit(t *testing.T) {
+	var network networks.Network
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2NetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2Network_adminStateUp_omit,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_network_v2.network_1", "admin_state_up", "true"),
+					testAccCheckNetworkingV2NetworkAdminStateUp(&network, true),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2Network_adminStateUp_true(t *testing.T) {
+	var network networks.Network
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2NetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2Network_adminStateUp_true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_network_v2.network_1", "admin_state_up", "true"),
+					testAccCheckNetworkingV2NetworkAdminStateUp(&network, true),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2Network_adminStateUp_false(t *testing.T) {
+	var network networks.Network
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2NetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2Network_adminStateUp_false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_network_v2.network_1", "admin_state_up", "false"),
+					testAccCheckNetworkingV2NetworkAdminStateUp(&network, false),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2Network_adminStateUp_update(t *testing.T) {
+	var network networks.Network
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2NetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2Network_adminStateUp_omit,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_network_v2.network_1", "admin_state_up", "true"),
+					testAccCheckNetworkingV2NetworkAdminStateUp(&network, true),
+				),
+			},
+			{
+				Config: testAccNetworkingV2Network_adminStateUp_false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_network_v2.network_1", "admin_state_up", "false"),
+					testAccCheckNetworkingV2NetworkAdminStateUp(&network, false),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingV2NetworkDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
@@ -258,6 +359,18 @@ func testAccCheckNetworkingV2NetworkExists(n string, network *networks.Network) 
 		}
 
 		*network = *found
+
+		return nil
+	}
+}
+
+func testAccCheckNetworkingV2NetworkAdminStateUp(
+	network *networks.Network, expected bool) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		if network.AdminStateUp != expected {
+			return fmt.Errorf("Network has wrong admin_state_up. Expected %t, got %t", expected, network.AdminStateUp)
+		}
 
 		return nil
 	}
@@ -385,5 +498,25 @@ resource "openstack_networking_network_v2" "network_1" {
   name             = "network_1"
 	admin_state_up   = "true"
 	transparent_vlan = "true"
+}
+`
+
+const testAccNetworkingV2Network_adminStateUp_omit = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+}
+`
+
+const testAccNetworkingV2Network_adminStateUp_true = `
+resource "openstack_networking_network_v2" "network_1" {
+  name           = "network_1"
+  admin_state_up = "true"
+}
+`
+
+const testAccNetworkingV2Network_adminStateUp_false = `
+resource "openstack_networking_network_v2" "network_1" {
+  name           = "network_1"
+  admin_state_up = "false"
 }
 `


### PR DESCRIPTION
openstack_networking_network_v2 was originally created with the fields
"admin_state_up" and "shared" as TypeString. This was to work around
Terraform mistaking an omitted boolean argument as "false".

Now that `GetOkExists` is available, we can correctly account for this
case.

This commit changes these two fields to TypeBool while still retaining
the prior behavior that TypeString was working around.

For #548 