### PR TITLE
Manila: introduce manila messages for detailed share errors

### DIFF
--- a/openstack/resource_openstack_sharedfilesystem_share_access_v2.go
+++ b/openstack/resource_openstack_sharedfilesystem_share_access_v2.go
@@ -112,7 +112,7 @@ func resourceSharedFilesystemShareAccessV2Create(d *schema.ResourceData, meta in
 	// Wait for access to become active before continuing
 	err = waitForSFV2Access(sfsClient, shareID, access.ID, "active", pending, timeout)
 	if err != nil {
-		return fmt.Errorf("Error waiting for OpenStack share ACL on %s to be applied: %s", shareID, err)
+		return err
 	}
 
 	return resourceSharedFilesystemShareAccessV2Read(d, meta)
@@ -191,7 +191,7 @@ func resourceSharedFilesystemShareAccessV2Delete(d *schema.ResourceData, meta in
 	pending := []string{"active", "new", "queued_to_deny", "denying"}
 	err = waitForSFV2Access(sfsClient, shareID, d.Id(), "denied", pending, timeout)
 	if err != nil {
-		return fmt.Errorf("Error waiting for OpenStack share ACL on %s to be removed: %s", shareID, err)
+		return err
 	}
 
 	return nil

--- a/openstack/resource_openstack_sharedfilesystem_share_v2.go
+++ b/openstack/resource_openstack_sharedfilesystem_share_v2.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/errors"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/messages"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
 )
 
@@ -215,7 +216,7 @@ func resourceSharedFilesystemShareV2Create(d *schema.ResourceData, meta interfac
 	// Wait for share to become active before continuing
 	err = waitForSFV2Share(sfsClient, share.ID, "available", []string{"creating", "manage_starting"}, timeout)
 	if err != nil {
-		return fmt.Errorf("Error waiting for OpenStack share %s to become available: %s", share.ID, err)
+		return err
 	}
 
 	return resourceSharedFilesystemShareV2Read(d, meta)
@@ -306,7 +307,7 @@ func resourceSharedFilesystemShareV2Update(d *schema.ResourceData, meta interfac
 		// Wait for share to become active before continuing
 		err = waitForSFV2Share(sfsClient, d.Id(), "available", []string{"creating", "manage_starting", "extending", "shrinking"}, timeout)
 		if err != nil {
-			return fmt.Errorf("Error waiting for OpenStack share %s to become available: %s", d.Id(), err)
+			return err
 		}
 
 		log.Printf("[DEBUG] Attempting to update share")
@@ -332,7 +333,7 @@ func resourceSharedFilesystemShareV2Update(d *schema.ResourceData, meta interfac
 		// Wait for share to become active before continuing
 		err = waitForSFV2Share(sfsClient, d.Id(), "available", []string{"creating", "manage_starting", "extending", "shrinking"}, timeout)
 		if err != nil {
-			return fmt.Errorf("Error waiting for OpenStack share %s to become available: %s", d.Id(), err)
+			return err
 		}
 	}
 
@@ -380,7 +381,7 @@ func resourceSharedFilesystemShareV2Update(d *schema.ResourceData, meta interfac
 		// Wait for share to become active before continuing
 		err = waitForSFV2Share(sfsClient, d.Id(), "available", pending, timeout)
 		if err != nil {
-			return fmt.Errorf("Error waiting for OpenStack share %s to become available: %s", d.Id(), err)
+			return err
 		}
 	}
 
@@ -449,7 +450,12 @@ func waitForSFV2Share(sfsClient *gophercloud.ServiceClient, id string, target st
 				return fmt.Errorf("Error: share %s not found: %s", id, err)
 			}
 		}
-		return fmt.Errorf("Error waiting for share %s to become %s: %s", id, target, err)
+		errorMessage := fmt.Sprintf("Error waiting for share %s to become %s", id, target)
+		msg, mErr := resourceSFSV2ShareManilaMessage(sfsClient, id)
+		if mErr != nil {
+			return fmt.Errorf("%s (%s) and error getting detailed manila message: %s", errorMessage, err, mErr)
+		}
+		return fmt.Errorf("%s: %s: the latest manila message (%s): %s", errorMessage, err, msg.CreatedAt, msg.UserMessage)
 	}
 
 	return nil
@@ -463,4 +469,31 @@ func resourceSFV2ShareRefreshFunc(sfsClient *gophercloud.ServiceClient, id strin
 		}
 		return share, share.Status, nil
 	}
+}
+
+func resourceSFSV2ShareManilaMessage(sfsClient *gophercloud.ServiceClient, id string) (*messages.Message, error) {
+	// we can simply set this, because this function is called after the error occurred
+	sfsClient.Microversion = "2.37"
+
+	listOpts := messages.ListOpts{
+		ResourceID: id,
+		SortKey:    "created_at",
+		SortDir:    "desc",
+		Limit:      1,
+	}
+	allPages, err := messages.List(sfsClient, listOpts).AllPages()
+	if err != nil {
+		return nil, fmt.Errorf("Unable to retrieve messages: %v", err)
+	}
+
+	allMessages, err := messages.ExtractMessages(allPages)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to extract messages: %v", err)
+	}
+
+	if len(allMessages) == 0 {
+		return nil, fmt.Errorf("No messages found")
+	}
+
+	return &allMessages[0], nil
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/messages/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/messages/requests.go
@@ -1,0 +1,72 @@
+package messages
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Delete will delete the existing Message with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToMessageListQuery() (string, error)
+}
+
+// ListOpts holds options for listing Messages. It is passed to the
+// messages.List function.
+type ListOpts struct {
+	// The message ID
+	ID string `q:"id"`
+	// The ID of the action during which the message was created
+	ActionID string `q:"action_id"`
+	// The ID of the message detail
+	DetailID string `q:"detail_id"`
+	// The message level
+	MessageLevel string `q:"message_level"`
+	// The UUID of the request during which the message was created
+	RequestID string `q:"request_id"`
+	// The UUID of the resource for which the message was created
+	ResourceID string `q:"resource_id"`
+	// The type of the resource for which the message was created
+	ResourceType string `q:"resource_type"`
+	// The key to sort a list of messages
+	SortKey string `q:"sort_key"`
+	// The key to sort a list of messages
+	SortDir string `q:"sort_dir"`
+	// The maximum number of messages to return
+	Limit int `q:"limit"`
+}
+
+// ToMessageListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToMessageListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns Messages optionally limited by the conditions provided in ListOpts.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToMessageListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return MessagePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Get retrieves the Message with the provided ID. To extract the Message
+// object from the response, call the Extract method on the GetResult.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/messages/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/messages/results.go
@@ -1,0 +1,99 @@
+package messages
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Message contains all the information associated with an OpenStack
+// Message.
+type Message struct {
+	// The message ID
+	ID string `json:"id"`
+	// The UUID of the project where the message was created
+	ProjectID string `json:"project_id"`
+	// The ID of the action during which the message was created
+	ActionID string `json:"action_id"`
+	// The ID of the message detail
+	DetailID string `json:"detail_id"`
+	// The message level
+	MessageLevel string `json:"message_level"`
+	// The UUID of the request during which the message was created
+	RequestID string `json:"request_id"`
+	// The UUID of the resource for which the message was created
+	ResourceID string `json:"resource_id"`
+	// The type of the resource for which the message was created
+	ResourceType string `json:"resource_type"`
+	// The message text
+	UserMessage string `json:"user_message"`
+	// The date and time stamp when the message was created
+	CreatedAt time.Time `json:"-"`
+	// The date and time stamp when the message will expire
+	ExpiresAt time.Time `json:"-"`
+}
+
+func (r *Message) UnmarshalJSON(b []byte) error {
+	type tmp Message
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+		ExpiresAt gophercloud.JSONRFC3339MilliNoZ `json:"expires_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Message(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.ExpiresAt = time.Time(s.ExpiresAt)
+
+	return nil
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// MessagePage is a pagination.pager that is returned from a call to the List function.
+type MessagePage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if a ListResult contains no Messages.
+func (r MessagePage) IsEmpty() (bool, error) {
+	messages, err := ExtractMessages(r)
+	return len(messages) == 0, err
+}
+
+// ExtractMessages extracts and returns Messages. It is used while
+// iterating over a messages.List call.
+func ExtractMessages(r pagination.Page) ([]Message, error) {
+	var s struct {
+		Messages []Message `json:"messages"`
+	}
+	err := (r.(MessagePage)).ExtractInto(&s)
+	return s.Messages, err
+}
+
+// Extract will get the Message object out of the commonResult object.
+func (r commonResult) Extract() (*Message, error) {
+	var s struct {
+		Message *Message `json:"message"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Message, err
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/messages/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/messages/urls.go
@@ -1,0 +1,15 @@
+package messages
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("messages")
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("messages", id)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return getURL(c, id)
+}

--- a/vendor/github.com/gophercloud/gophercloud/provider_client.go
+++ b/vendor/github.com/gophercloud/gophercloud/provider_client.go
@@ -3,6 +3,7 @@ package gophercloud
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -192,7 +193,7 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 	// io.ReadSeeker as-is. Default the content-type to application/json.
 	if options.JSONBody != nil {
 		if options.RawBody != nil {
-			panic("Please provide only one of JSONBody or RawBody to gophercloud.Request().")
+			return nil, errors.New("please provide only one of JSONBody or RawBody to gophercloud.Request()")
 		}
 
 		rendered, err := json.Marshal(options.JSONBody)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -313,412 +313,412 @@
 			"revisionTime": "2018-03-28T16:31:53Z"
 		},
 		{
-			"checksumSHA1": "mxnleftS/IKLireRFde56VPFc8U=",
+			"checksumSHA1": "ohHY8vjAo8PNGtiIEof/qCwrueM=",
 			"path": "github.com/gophercloud/gophercloud",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "b7g9TcU1OmW7e2UySYeOAmcfHpY=",
 			"path": "github.com/gophercloud/gophercloud/internal",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "zDja+rJdiRPG4YeVdt21YX1J8bk=",
 			"path": "github.com/gophercloud/gophercloud/openstack",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "8YtBD+Um7I8ee1Xf1ZAWu74eP7w=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "MzOt8P1f2e0vX58I0l02+5AZ7rc=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v1/volumes",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "SDNVeLqHv7OhjKCAU0/McJUeWgo=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "lP4ajY5LWcqx5qFMCZ56FOTdJxo=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "vw46Q7Z5GKbrutRNXVqobqQcLdA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "buHPuL/qGZ2AlDdB/1KOjVISmsM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "VVSFrp4kBIDK62D+uCgV8IScwD0=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "tHW4ajx6KpesbhMfizNicJ6g9Ks=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces/testing",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "nQlviweyWynvpsXf1Ms0AecMzO8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "La8c0H0Eds4MmAKJ9lPdDgJDjSk=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "vFS5BwnCdQIfKm1nNWrR+ijsAZA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "lAQuKIqTuQ9JuMgN0pPkNtRH2RM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "+hlElX7o8ULWTc0r7oGyDlOnwWM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "jeRy+dt5B0E3ba5u/lzV+/lJn4c=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "PWbrce9A6LMWIGr0fK04AEEuQec=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "qfVZltu1fYTYXS97WbjeLuLPgUc=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/startstop",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "+Gif+WFd0WVjefjvmlR7jyTrdzQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/tenantnetworks",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "TMkBTIrYeL78yJ6wZNJQqG0tHR4=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "tRY1hWvCAjOtcouMKA9V6Aq9Afo=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/flavors",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "CSnfH01hSas0bdc/3m/f5Rt6SFY=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/images",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "gxNCsaZKNT2SUIUtirxfEcLn9jw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/servers",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "j2li+asUKunCgz691sa92VOjAvg=",
 			"path": "github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "VxqXejG0O0WC7oYiC1V4Hx2OKTU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "2RFHGbTIBvTz5oIuFc5DtVFiQYE=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/configurations",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "jdKwC7fxB11ACuo8CUH2VoleJao=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/databases",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "sQjGBGkPPevEYcyWz/7BN7inFbo=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/datastores",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "OufByUxj+IvLN5K7XcVVziy28Pw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/instances",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "62KZtZ4VoCLsOrXxcFTpp0qJEgw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/db/v1/users",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "nulZDXleFwq5Kk4Fm3xEXI5+SWw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "Cl13L7gpdQvfVTpQL4K0GkoSpiA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/dns/v2/zones",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "n7u1Hvuzxzhfghka+7JpqoNtRhI=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v2/tenants",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "z5NsqMZX3TLMzpmwzOOXE4M5D9w=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "Qzlv/69tlr+1r6W28WrOEEqT9EU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "y+w9UFsEgYvgQ5EaClNor1D95tw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/groups",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "46oS/lG/aAhCLVafeiJPNMv2DiQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/projects",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "ZG+k94WuW6QA8ttJMRvNT5kqI9g=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/roles",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "qOc+KYPka86DtcDnpvBuKdCb8jk=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/services",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "HNLKHXv7aYtKnRMo3msTbdGE5H8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "uGWuvrL9DW4CjMubbXSM6rVlm3Q=",
 			"path": "github.com/gophercloud/gophercloud/openstack/identity/v3/users",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "4Ci0F5SJgiJCXyDuxTQZYvwA00s=",
 			"path": "github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "ysiv+OUUPt6HfAKlWbR9w0QP4YU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/imageservice/v2/images",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "2KyigRom9gcqgGSRPm5pJFtmrdY=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "x6lD4wQOZc1rtm6kMaUBMwLxAlA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "ITDrcTALUPkyNYR3DB/xnrquSpc=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/extradhcpopts",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "iEycbTwNfi2VM+8KCJX2rkWoN1g=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "ROBaakcMIVCb0405H8/UuttEZtA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "FDgt1WaVGbp8w6vyCJbtkbsbWBc=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/routerinsertion",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "uZ5/gCROQHaiHpXfoLrfisRzbAU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "6CAupuagxLITVHlIraEiS9gc9i4=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "5nK6eV4Qr+XpVN+U0GsrW6vq+yA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "HiGzZXGIxrItijPCH+L7EbbCb9w=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/members",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "KZJLk70d5SX8TQO1q0MLAxGEBCU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/monitors",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "WYktmBouYI04KbKqDqHpgyMzZtQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/pools",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "3QfwJnsJHohoYV16/BOtDXpNEYI=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/vips",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "cnxAG0MRNpeg2Fqc1f2M40N2sc0=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/l7policies",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "//oZPYIT/hd1Y1YKzTUOiCpjO6o=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "DSn8Qz8UTQvehEoAIfi49tl3c4w=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "4JRkgqSuMmKmWmQvQpCTnKjDoVU=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/monitors",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "+Em48dU1PW4UMeGoaK7lkDoVqGM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "eUvwdXvz/Zkckr/isvP+2nXY2J8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/provider",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "3D3gnim5Al9npZZe+N6UyJfW1Dc=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "KI8KPllJwaS8Fzf5T5XcbbsHr1U=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "83WYX5SPirCgxPgjUsiihw6W3C8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "8BfPHfYcCbdSoLj/LJEjZx+MDTM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "TH4LSJLhZlq0fW36UVWltFlM3KA=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vlantransparent",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "TH4LSJLhZlq0fW36UVWltFlM3KA=",
@@ -735,134 +735,140 @@
 		{
 			"checksumSHA1": "grviOYvybawC80v7Fmw0XOBwr0A=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/endpointgroups",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "HhRP7Hw7cS7RM4cxGmQYk/vI8uM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/ikepolicies",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "NRvuezUVg0gU4CIZkWHnMhIYXx8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/ipsecpolicies",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "RnSw4UFgNNxmOuobe7c0GxGWwKM=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/services",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "4H6GsYh9zKxk8Z/Gs8NdMtMCVvQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/siteconnections",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "Mb510qurNKkP9f6cjZqK66ag4Ns=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/networks",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "KHyErSX8Lz8O4ipt/ZApFeqvCiQ=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/ports",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "K9Oh4kNh0iOQ5ICmp3PClTCQ0yY=",
 			"path": "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "v0EdYYIyrzR6j8tAiVkl2AQzmao=",
 			"path": "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "yD33+7iNdUykXt9qunPntb63Oqk=",
 			"path": "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "RswTYBtPwd1KE8EpLpHhsvO1Jtw=",
 			"path": "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "aODoF15ZwA4XJOWciguaAJRq/6o=",
 			"path": "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/swauth",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "cGyXqdYGrNLd3zAbwCmxbeVtPMk=",
 			"path": "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/apiversions",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "OMzZoYywPZnUjcWVUPmOHI2fNdo=",
 			"path": "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/errors",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
+		},
+		{
+			"checksumSHA1": "1JuJsj5gAd7d0e+dWnCJ0CJQgyw=",
+			"path": "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/messages",
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "eglgBdlffyYTo1SDz3Wb7IEE25o=",
 			"path": "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/securityservices",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "6ImzhiIe7n87OGSV9YskZRIsdg4=",
 			"path": "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharenetworks",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "uc07DD3fIKsFvWYtAEAm5djUV04=",
 			"path": "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "XtFWUuODVKpHHhiAPyi7VTD0YDE=",
 			"path": "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/snapshots",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "nkRXTSQyEk7yy+4u4/yC1kdvpaE=",
 			"path": "github.com/gophercloud/gophercloud/openstack/utils",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "/Wkc4WKxF/P87dOmUh5XUXcfmz8=",
 			"path": "github.com/gophercloud/gophercloud/pagination",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "b8tetZflGv6Pg22zYyodQGce7nc=",
 			"path": "github.com/gophercloud/gophercloud/testhelper",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "XHWKJUGCvXQNDmRrev0ZOVcISSM=",
 			"path": "github.com/gophercloud/gophercloud/testhelper/client",
-			"revision": "80c596f406a38975149db30d9ceddb774f3bfdb7",
-			"revisionTime": "2019-01-12T02:32:49Z"
+			"revision": "b8a40d168295758ab3dbb63759c8476a02750551",
+			"revisionTime": "2019-01-12T20:16:48Z"
 		},
 		{
 			"checksumSHA1": "JvMurZXDftdGc7f8PzE7EjXbuOw=",


### PR DESCRIPTION
Depends on https://github.com/gophercloud/gophercloud/issues/1400
Resolves #565
@jtopjian please review

an example message returned by `terraform apply`:

> Error: Error applying plan:
> 1 error(s) occurred:
> openstack_sharedfilesystem_share_v2.cifs: 1 error(s) occurred:
> openstack_sharedfilesystem_share_v2.cifs: Error waiting for share 37f7ab0d-6831-4538-ba8a-4ba5ca220e45 to become available: unexpected state 'error', wanted target 'available'. last error: %!s(<nil>): the latest manila message (2019-01-12 14:26:55.608715 +0000 UTC): create: Could not find an existing share server or allocate one on the share network provided. You may use a different share network, or verify the network details in the share network and retry your request. If this doesn't work, contact your administrator to troubleshoot issues with your network.