### PR TITLE
Manila: fix doc captions

### DIFF
--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -358,16 +358,16 @@
           <a href="#">Shared File System</a>
           <ul class="nav nav-visible">
             <li<%= sidebar_current("docs-openstack-resource-sharedfilesystem-securityservice-v2") %>>
-              <a href="/docs/providers/openstack/r/sharedfilesystem_securityservice_v2.html">sharedfilesystem_securityservice_v2</a>
+              <a href="/docs/providers/openstack/r/sharedfilesystem_securityservice_v2.html">openstack_sharedfilesystem_securityservice_v2</a>
             </li>
             <li<%= sidebar_current("docs-openstack-resource-sharedfilesystem-sharenetwork-v2") %>>
-              <a href="/docs/providers/openstack/r/sharedfilesystem_sharenetwork_v2.html">sharedfilesystem_sharenetwork_v2</a>
+              <a href="/docs/providers/openstack/r/sharedfilesystem_sharenetwork_v2.html">openstack_sharedfilesystem_sharenetwork_v2</a>
             </li>
             <li<%= sidebar_current("docs-openstack-resource-sharedfilesystem-share-v2") %>>
-              <a href="/docs/providers/openstack/r/sharedfilesystem_share_v2.html">sharedfilesystem_share_v2</a>
+              <a href="/docs/providers/openstack/r/sharedfilesystem_share_v2.html">openstack_sharedfilesystem_share_v2</a>
             </li>
             <li<%= sidebar_current("docs-openstack-resource-sharedfilesystem-share_access-v2") %>>
-              <a href="/docs/providers/openstack/r/sharedfilesystem_share_access_v2.html">sharedfilesystem_share_access_v2</a>
+              <a href="/docs/providers/openstack/r/sharedfilesystem_share_access_v2.html">openstack_sharedfilesystem_share_access_v2</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
`openstack_` caption prefix was forgotten. Fortunately the links are ok.