### PR TITLE
Networking V2: Omit empty ExternalFixedIP IPAddress for the router

### DIFF
--- a/openstack/resource_openstack_networking_router_v2.go
+++ b/openstack/resource_openstack_networking_router_v2.go
@@ -92,6 +92,7 @@ func resourceNetworkingRouterV2() *schema.Resource {
 						"ip_address": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 					},
 				},

--- a/openstack/resource_openstack_networking_router_v2_test.go
+++ b/openstack/resource_openstack_networking_router_v2_test.go
@@ -107,6 +107,30 @@ func TestAccNetworkingV2Router_vendor_opts_no_snat(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2Router_extFixedIPs(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2RouterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2Router_extFixedIPs,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"openstack_networking_router_v2.router_2", "name", "router_2"),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_router_v2.router_2", "external_fixed_ip.#", "2"),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_router_v2.router_2", "enable_snat", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingV2RouterDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
@@ -187,39 +211,71 @@ resource "openstack_networking_router_v2" "router_1" {
 
 var testAccNetworkingV2Router_vendor_opts = fmt.Sprintf(`
 resource "openstack_networking_router_v2" "router_1" {
-	name = "router_1"
-	admin_state_up = "true"
-	external_network_id = "%s"
-	vendor_options {
-		set_router_gateway_after_create = true
-	}
+  name = "router_1"
+  admin_state_up = "true"
+  external_network_id = "%s"
+  vendor_options {
+    set_router_gateway_after_create = true
+  }
 }
 `, OS_EXTGW_ID)
 
 var testAccNetworkingV2Router_vendor_opts_no_snat = fmt.Sprintf(`
 resource "openstack_networking_router_v2" "router_1" {
-        name = "router_1"
-        admin_state_up = "true"
-        distributed = "false"
-        external_network_id = "%s"
-        enable_snat = "false"
-        vendor_options {
-                set_router_gateway_after_create = true
-        }
+  name = "router_1"
+  admin_state_up = "true"
+  distributed = "false"
+  external_network_id = "%s"
+  enable_snat = "false"
+  vendor_options {
+    set_router_gateway_after_create = true
+  }
 }
 `, OS_EXTGW_ID)
 
 const testAccNetworkingV2Router_updateExternalGateway1 = `
 resource "openstack_networking_router_v2" "router_1" {
-	name = "router"
-	admin_state_up = "true"
+  name = "router"
+  admin_state_up = "true"
 }
 `
 
 var testAccNetworkingV2Router_updateExternalGateway2 = fmt.Sprintf(`
 resource "openstack_networking_router_v2" "router_1" {
-	name = "router"
-	admin_state_up = "true"
-	external_network_id = "%s"
+  name = "router"
+  admin_state_up = "true"
+  external_network_id = "%s"
 }
 `, OS_EXTGW_ID)
+
+var testAccNetworkingV2Router_extFixedIPs = fmt.Sprintf(`
+resource "openstack_networking_router_v2" "router_1" {
+  name = "router_1"
+  admin_state_up = "true"
+  external_network_id = "%s"
+
+  timeouts {
+    create = "5m"
+    delete = "5m"
+  }
+}
+
+resource "openstack_networking_router_v2" "router_2" {
+  name = "router_2"
+  admin_state_up = "true"
+  external_network_id = "%s"
+
+  external_fixed_ip {
+    subnet_id = "${openstack_networking_router_v2.router_1.external_fixed_ip.0.subnet_id}"
+  }
+
+  external_fixed_ip {
+    subnet_id = "${openstack_networking_router_v2.router_1.external_fixed_ip.0.subnet_id}"
+  }
+
+  timeouts {
+    create = "5m"
+    delete = "5m"
+  }
+}
+`, OS_EXTGW_ID, OS_EXTGW_ID)

--- a/website/docs/r/networking_router_v2.html.markdown
+++ b/website/docs/r/networking_router_v2.html.markdown
@@ -56,6 +56,8 @@ The following arguments are supported:
 * `enable_snat` - (Optional) Enable Source NAT for the router. Valid values are
     "true" or "false". An `external_network_id` has to be set in order to
     set this property. Changing this updates the `enable_snat` of the router.
+    Setting this value **requires** an **ext-gw-mode** extension to be enabled
+    in OpenStack Neutron.
 
 * `external_fixed_ip` - (Optional) An external fixed IP for the router. This
     can be repeated. The structure is described below. An `external_network_id`


### PR DESCRIPTION
Resolves #449
Requires https://github.com/gophercloud/gophercloud/issues/1414 to be fixed