### PR TITLE
Internal: Networking V2 Trunk resource cleanup

### DIFF
--- a/openstack/networking_trunk_v2.go
+++ b/openstack/networking_trunk_v2.go
@@ -1,0 +1,69 @@
+package openstack
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func networkingTrunkV2StateRefreshFunc(client *gophercloud.ServiceClient, trunkID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		trunk, err := trunks.Get(client, trunkID).Extract()
+		if err != nil {
+			if _, ok := err.(gophercloud.ErrDefault404); ok {
+				return trunk, "DELETED", nil
+			}
+
+			return nil, "", err
+		}
+
+		return trunk, trunk.Status, nil
+	}
+}
+
+func flattenNetworkingTrunkSubportsV2(subports []trunks.Subport) []map[string]interface{} {
+	trunkSubports := make([]map[string]interface{}, len(subports))
+
+	for i, subport := range subports {
+		trunkSubports[i] = map[string]interface{}{
+			"port_id":           subport.PortID,
+			"segmentation_type": subport.SegmentationType,
+			"segmentation_id":   subport.SegmentationID,
+		}
+	}
+
+	return trunkSubports
+}
+
+func expandNetworkingTrunkSubportsV2(subports *schema.Set) []trunks.Subport {
+	rawSubports := subports.List()
+
+	trunkSubports := make([]trunks.Subport, len(rawSubports))
+	for i, raw := range rawSubports {
+		rawMap := raw.(map[string]interface{})
+
+		trunkSubports[i] = trunks.Subport{
+			PortID:           rawMap["port_id"].(string),
+			SegmentationType: rawMap["segmentation_type"].(string),
+			SegmentationID:   rawMap["segmentation_id"].(int),
+		}
+	}
+
+	return trunkSubports
+}
+
+func expandNetworkingTrunkSubportsRemoveV2(subports *schema.Set) []trunks.RemoveSubport {
+	rawSubports := subports.List()
+
+	subportsToRemove := make([]trunks.RemoveSubport, len(rawSubports))
+	for i, raw := range rawSubports {
+		rawMap := raw.(map[string]interface{})
+
+		subportsToRemove[i] = trunks.RemoveSubport{
+			PortID: rawMap["port_id"].(string),
+		}
+	}
+
+	return subportsToRemove
+}

--- a/openstack/networking_trunk_v2.go
+++ b/openstack/networking_trunk_v2.go
@@ -22,7 +22,7 @@ func networkingTrunkV2StateRefreshFunc(client *gophercloud.ServiceClient, trunkI
 	}
 }
 
-func flattenNetworkingTrunkSubportsV2(subports []trunks.Subport) []map[string]interface{} {
+func flattenNetworkingTrunkV2Subports(subports []trunks.Subport) []map[string]interface{} {
 	trunkSubports := make([]map[string]interface{}, len(subports))
 
 	for i, subport := range subports {
@@ -36,7 +36,7 @@ func flattenNetworkingTrunkSubportsV2(subports []trunks.Subport) []map[string]in
 	return trunkSubports
 }
 
-func expandNetworkingTrunkSubportsV2(subports *schema.Set) []trunks.Subport {
+func expandNetworkingTrunkV2Subports(subports *schema.Set) []trunks.Subport {
 	rawSubports := subports.List()
 
 	trunkSubports := make([]trunks.Subport, len(rawSubports))
@@ -53,7 +53,7 @@ func expandNetworkingTrunkSubportsV2(subports *schema.Set) []trunks.Subport {
 	return trunkSubports
 }
 
-func expandNetworkingTrunkSubportsRemoveV2(subports *schema.Set) []trunks.RemoveSubport {
+func expandNetworkingTrunkV2SubportsRemove(subports *schema.Set) []trunks.RemoveSubport {
 	rawSubports := subports.List()
 
 	subportsToRemove := make([]trunks.RemoveSubport, len(rawSubports))

--- a/openstack/networking_trunk_v2_test.go
+++ b/openstack/networking_trunk_v2_test.go
@@ -36,7 +36,7 @@ func TestFlattenNetworkingTrunkSubportsV2(t *testing.T) {
 		},
 	}
 
-	actualSubports := flattenNetworkingTrunkSubportsV2(subports)
+	actualSubports := flattenNetworkingTrunkV2Subports(subports)
 
 	assert.ElementsMatch(t, expectedSubports, actualSubports)
 }
@@ -71,7 +71,7 @@ func TestExpandNetworkingTrunkSubportsV2(t *testing.T) {
 		},
 	}
 
-	actualSubports := expandNetworkingTrunkSubportsV2(d.Get("sub_port").(*schema.Set))
+	actualSubports := expandNetworkingTrunkV2Subports(d.Get("sub_port").(*schema.Set))
 
 	assert.ElementsMatch(t, expectedSubports, actualSubports)
 }
@@ -102,7 +102,7 @@ func TestExpandNetworkingTrunkSubportsRemoveV2(t *testing.T) {
 		},
 	}
 
-	actualRemoveSubports := expandNetworkingTrunkSubportsRemoveV2(d.Get("sub_port").(*schema.Set))
+	actualRemoveSubports := expandNetworkingTrunkV2SubportsRemove(d.Get("sub_port").(*schema.Set))
 
 	assert.ElementsMatch(t, expectedRemoveSubports, actualRemoveSubports)
 }

--- a/openstack/networking_trunk_v2_test.go
+++ b/openstack/networking_trunk_v2_test.go
@@ -1,0 +1,108 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks"
+)
+
+func TestFlattenNetworkingTrunkSubportsV2(t *testing.T) {
+	subports := []trunks.Subport{
+		{
+			PortID:           "port_id_1",
+			SegmentationType: "type_1",
+			SegmentationID:   111,
+		},
+		{
+			PortID:           "port_id_2",
+			SegmentationType: "type_2",
+			SegmentationID:   222,
+		},
+	}
+
+	expectedSubports := []map[string]interface{}{
+		{
+			"port_id":           "port_id_1",
+			"segmentation_id":   111,
+			"segmentation_type": "type_1",
+		},
+		{
+			"port_id":           "port_id_2",
+			"segmentation_id":   222,
+			"segmentation_type": "type_2",
+		},
+	}
+
+	actualSubports := flattenNetworkingTrunkSubportsV2(subports)
+
+	assert.ElementsMatch(t, expectedSubports, actualSubports)
+}
+
+func TestExpandNetworkingTrunkSubportsV2(t *testing.T) {
+	r := resourceNetworkingTrunkV2()
+	d := r.TestResourceData()
+	d.SetId("1")
+	subport1 := map[string]interface{}{
+		"port_id":           "port_id_1",
+		"segmentation_id":   111,
+		"segmentation_type": "type_1",
+	}
+	subport2 := map[string]interface{}{
+		"port_id":           "port_id_2",
+		"segmentation_id":   222,
+		"segmentation_type": "type_2",
+	}
+	subports := []map[string]interface{}{subport1, subport2}
+	d.Set("sub_port", subports)
+
+	expectedSubports := []trunks.Subport{
+		{
+			PortID:           "port_id_1",
+			SegmentationType: "type_1",
+			SegmentationID:   111,
+		},
+		{
+			PortID:           "port_id_2",
+			SegmentationType: "type_2",
+			SegmentationID:   222,
+		},
+	}
+
+	actualSubports := expandNetworkingTrunkSubportsV2(d.Get("sub_port").(*schema.Set))
+
+	assert.ElementsMatch(t, expectedSubports, actualSubports)
+}
+
+func TestExpandNetworkingTrunkSubportsRemoveV2(t *testing.T) {
+	r := resourceNetworkingTrunkV2()
+	d := r.TestResourceData()
+	d.SetId("1")
+	subport1 := map[string]interface{}{
+		"port_id":           "port_id_3",
+		"segmentation_id":   333,
+		"segmentation_type": "type_3",
+	}
+	subport2 := map[string]interface{}{
+		"port_id":           "port_id_4",
+		"segmentation_id":   444,
+		"segmentation_type": "type_4",
+	}
+	subports := []map[string]interface{}{subport1, subport2}
+	d.Set("sub_port", subports)
+
+	expectedRemoveSubports := []trunks.RemoveSubport{
+		{
+			PortID: "port_id_3",
+		},
+		{
+			PortID: "port_id_4",
+		},
+	}
+
+	actualRemoveSubports := expandNetworkingTrunkSubportsRemoveV2(d.Get("sub_port").(*schema.Set))
+
+	assert.ElementsMatch(t, expectedRemoveSubports, actualRemoveSubports)
+}

--- a/openstack/resource_openstack_networking_trunk_v2.go
+++ b/openstack/resource_openstack_networking_trunk_v2.go
@@ -106,7 +106,7 @@ func resourceNetworkingTrunkV2Create(d *schema.ResourceData, meta interface{}) e
 		Description: d.Get("description").(string),
 		PortID:      d.Get("port_id").(string),
 		TenantID:    d.Get("tenant_id").(string),
-		Subports:    expandNetworkingTrunkSubportsV2(d.Get("sub_port").(*schema.Set)),
+		Subports:    expandNetworkingTrunkV2Subports(d.Get("sub_port").(*schema.Set)),
 	}
 
 	if v, ok := d.GetOkExists("admin_state_up"); ok {
@@ -173,7 +173,7 @@ func resourceNetworkingTrunkV2Read(d *schema.ResourceData, meta interface{}) err
 	d.Set("tenant_id", trunk.TenantID)
 	d.Set("tags", trunk.Tags)
 
-	err = d.Set("sub_port", flattenNetworkingTrunkSubportsV2(trunk.Subports))
+	err = d.Set("sub_port", flattenNetworkingTrunkV2Subports(trunk.Subports))
 	if err != nil {
 		log.Printf("[DEBUG] Unable to set openstack_networking_trunk_v2 %s sub_port: %s", d.Id(), err)
 	}
@@ -229,7 +229,7 @@ func resourceNetworkingTrunkV2Update(d *schema.ResourceData, meta interface{}) e
 		// Delete all old subports, regardless of if they still exist.
 		// If they do still exist, they will be re-added below.
 		if oldSubport.Len() != 0 {
-			removeSubports := expandNetworkingTrunkSubportsRemoveV2(oldSubport)
+			removeSubports := expandNetworkingTrunkV2SubportsRemove(oldSubport)
 			removeSubportsOpts := trunks.RemoveSubportsOpts{
 				Subports: removeSubports,
 			}
@@ -243,7 +243,7 @@ func resourceNetworkingTrunkV2Update(d *schema.ResourceData, meta interface{}) e
 
 		// Add any new sub_port and re-add previously set subports.
 		if newSubport.Len() != 0 {
-			addSubports := expandNetworkingTrunkSubportsV2(oldSubport)
+			addSubports := expandNetworkingTrunkV2Subports(newSubport)
 			addSubportsOpts := trunks.AddSubportsOpts{
 				Subports: addSubports,
 			}

--- a/openstack/resource_openstack_networking_trunk_v2.go
+++ b/openstack/resource_openstack_networking_trunk_v2.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks"
 )
@@ -32,31 +31,37 @@ func resourceNetworkingTrunkV2() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
 			},
+
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
 			},
+
 			"port_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
+
 			"admin_state_up": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+
 			"tenant_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
+
 			"sub_port": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -78,6 +83,7 @@ func resourceNetworkingTrunkV2() *schema.Resource {
 					},
 				},
 			},
+
 			"tags": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -96,25 +102,29 @@ func resourceNetworkingTrunkV2Create(d *schema.ResourceData, meta interface{}) e
 	}
 
 	createOpts := trunks.CreateOpts{
-		Name:         d.Get("name").(string),
-		Description:  d.Get("description").(string),
-		AdminStateUp: resourceNetworkingTrunkV2AdminStateUp(d),
-		PortID:       d.Get("port_id").(string),
-		TenantID:     d.Get("tenant_id").(string),
-		Subports:     resourceNetworkingTrunkV2Subports(d.Get("sub_port").(*schema.Set)),
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		PortID:      d.Get("port_id").(string),
+		TenantID:    d.Get("tenant_id").(string),
+		Subports:    expandNetworkingTrunkSubportsV2(d.Get("sub_port").(*schema.Set)),
 	}
 
-	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	if v, ok := d.GetOkExists("admin_state_up"); ok {
+		asu := v.(bool)
+		createOpts.AdminStateUp = &asu
+	}
+
+	log.Printf("[DEBUG] openstack_networking_trunk_v2 create options: %#v", createOpts)
 	trunk, err := trunks.Create(client, createOpts).Extract()
 	if err != nil {
-		return fmt.Errorf("Error creating OpenStack Neutron trunk: %s", err)
+		return fmt.Errorf("Error creating openstack_networking_trunk_v2: %s", err)
 	}
 
-	log.Printf("[DEBUG] Waiting for OpenStack Neutron trunk (%s) to become available.", trunk.ID)
+	log.Printf("[DEBUG] Waiting for openstack_networking_trunk_v2 %s to become available.", trunk.ID)
 
 	stateConf := &resource.StateChangeConf{
-		Target:     []string{"ACTIVE"},
-		Refresh:    waitForNetworkTrunkActive(client, trunk.ID),
+		Target:     []string{"ACTIVE", "DOWN"},
+		Refresh:    networkingTrunkV2StateRefreshFunc(client, trunk.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      5 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -122,20 +132,22 @@ func resourceNetworkingTrunkV2Create(d *schema.ResourceData, meta interface{}) e
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error waiting for trunk to become active: %s", err)
+		return fmt.Errorf("Error waiting for openstack_networking_trunk_v2 %s to become available: %s", trunk.ID, err)
 	}
+
+	d.SetId(trunk.ID)
 
 	tags := networkV2AttributesTags(d)
 	if len(tags) > 0 {
 		tagOpts := attributestags.ReplaceAllOpts{Tags: tags}
 		tags, err := attributestags.ReplaceAll(client, "trunks", trunk.ID, tagOpts).Extract()
 		if err != nil {
-			return fmt.Errorf("Unable to set trunk tags: %v", err)
+			return fmt.Errorf("Error setting tags on openstack_networking_trunk_v2 %s: %s", trunk.ID, err)
 		}
-		log.Printf("[DEBUG] Set Tags = %+v on trunk %s", tags, trunk.ID)
+		log.Printf("[DEBUG] Set tags %s on openstack_networking_trunk_v2 %s", tags, trunk.ID)
 	}
 
-	d.SetId(trunk.ID)
+	log.Printf("[DEBUG] Created openstack_networking_trunk_v2 %s: %#v", trunk.ID, trunk)
 	return resourceNetworkingTrunkV2Read(d, meta)
 }
 
@@ -148,9 +160,10 @@ func resourceNetworkingTrunkV2Read(d *schema.ResourceData, meta interface{}) err
 
 	trunk, err := trunks.Get(client, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "trunk")
+		return CheckDeleted(d, err, "Error getting openstack_networking_trunk_v2")
 	}
-	log.Printf("[DEBUG] Retrieved trunk %s: %+v", d.Id(), trunk)
+
+	log.Printf("[DEBUG] Retrieved openstack_networking_trunk_v2 %s: %#v", d.Id(), trunk)
 
 	d.Set("region", GetRegion(d, config))
 	d.Set("name", trunk.Name)
@@ -160,15 +173,9 @@ func resourceNetworkingTrunkV2Read(d *schema.ResourceData, meta interface{}) err
 	d.Set("tenant_id", trunk.TenantID)
 	d.Set("tags", trunk.Tags)
 
-	subports := make([]map[string]interface{}, len(trunk.Subports))
-	for i, trunkSubport := range trunk.Subports {
-		subports[i] = make(map[string]interface{})
-		subports[i]["port_id"] = trunkSubport.PortID
-		subports[i]["segmentation_type"] = trunkSubport.SegmentationType
-		subports[i]["segmentation_id"] = trunkSubport.SegmentationID
-	}
-	if err = d.Set("sub_port", subports); err != nil {
-		return fmt.Errorf("Unable to set sub_port for trunk %s: %s", d.Id(), err)
+	err = d.Set("sub_port", flattenNetworkingTrunkSubportsV2(trunk.Subports))
+	if err != nil {
+		log.Printf("[DEBUG] Unable to set openstack_networking_trunk_v2 %s sub_port: %s", d.Id(), err)
 	}
 
 	return nil
@@ -181,62 +188,70 @@ func resourceNetworkingTrunkV2Update(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
-	var updateTrunk bool
-	var updateOpts trunks.UpdateOpts
+	// Work with basic trunk update options.
+	var (
+		updateTrunk bool
+		updateOpts  trunks.UpdateOpts
+	)
 
 	if d.HasChange("name") {
 		updateTrunk = true
 		name := d.Get("name").(string)
 		updateOpts.Name = &name
 	}
+
 	if d.HasChange("description") {
 		updateTrunk = true
 		description := d.Get("description").(string)
 		updateOpts.Description = &description
 	}
+
 	if d.HasChange("admin_state_up") {
 		updateTrunk = true
-		updateOpts.AdminStateUp = resourceNetworkingTrunkV2AdminStateUp(d)
+		asu := d.Get("admin_state_up").(bool)
+		updateOpts.AdminStateUp = &asu
 	}
 
 	if updateTrunk {
-		log.Printf("[DEBUG] Updating trunk %s with options: %+v", d.Id(), updateOpts)
+		log.Printf("[DEBUG] openstack_networking_trunk_v2 %s update options: %#v", d.Id(), updateOpts)
 		_, err = trunks.Update(client, d.Id(), updateOpts).Extract()
 		if err != nil {
-			return fmt.Errorf("Error updating OpenStack Neutron trunk: %s", err)
+			return fmt.Errorf("Error updating openstack_networking_trunk_v2 %s: %s", d.Id(), err)
 		}
 	}
 
+	// Update subports  if needed.
 	if d.HasChange("sub_port") {
-		old, new := d.GetChange("sub_port")
+		o, n := d.GetChange("sub_port")
+		oldSubport := o.(*schema.Set)
+		newSubport := n.(*schema.Set)
 
-		toRemove := old.(*schema.Set).Difference(new.(*schema.Set))
-		toAdd := new.(*schema.Set).Difference(old.(*schema.Set))
-
-		if len(toRemove.List()) > 0 {
-			var subportsToRemove trunks.RemoveSubportsOpts
-
-			subports := resourceNetworkingTrunkV2Subports(toRemove)
-			log.Printf("[DEBUG] Removing subports from trunk %s: %#v", d.Id(), subports)
-			for _, subport := range subports {
-				v := trunks.RemoveSubport{PortID: subport.PortID}
-				subportsToRemove.Subports = append(subportsToRemove.Subports, v)
+		// Delete all old subports, regardless of if they still exist.
+		// If they do still exist, they will be re-added below.
+		if oldSubport.Len() != 0 {
+			removeSubports := expandNetworkingTrunkSubportsRemoveV2(oldSubport)
+			removeSubportsOpts := trunks.RemoveSubportsOpts{
+				Subports: removeSubports,
 			}
-			_, err := trunks.RemoveSubports(client, d.Id(), subportsToRemove).Extract()
+
+			log.Printf("[DEBUG] Deleting old subports for openstack_networking_trunk_v2 %s: %#v", d.Id(), removeSubportsOpts)
+			_, err := trunks.RemoveSubports(client, d.Id(), removeSubportsOpts).Extract()
 			if err != nil {
-				return fmt.Errorf("Error removing subports when updating OpenStack Neutron trunk: %s", err)
+				return fmt.Errorf("Error removing subports for openstack_networking_trunk_v2 %s: %s", d.Id(), err)
 			}
 		}
 
-		if len(toAdd.List()) > 0 {
-			var subportsToAdd trunks.AddSubportsOpts
-			subportsToAdd.Subports = resourceNetworkingTrunkV2Subports(toAdd)
+		// Add any new sub_port and re-add previously set subports.
+		if newSubport.Len() != 0 {
+			addSubports := expandNetworkingTrunkSubportsV2(oldSubport)
+			addSubportsOpts := trunks.AddSubportsOpts{
+				Subports: addSubports,
+			}
 
-			log.Printf("[DEBUG] Adding subports to trunk %s: %#v", d.Id(), subportsToAdd.Subports)
-
-			_, err := trunks.AddSubports(client, d.Id(), subportsToAdd).Extract()
+			log.Printf("[DEBUG] openstack_networking_trunk_v2 %s subports update options: %#v", d.Id(), addSubports)
+			_, err := trunks.AddSubports(client, d.Id(), addSubportsOpts).Extract()
 			if err != nil {
-				return fmt.Errorf("Error adding subports when updating OpenStack Neutron trunk: %s", err)
+				return fmt.Errorf("Error updating openstack_networking_trunk_v2 %s subports: %s", d.Id(), err)
 			}
 		}
 	}
@@ -246,9 +261,9 @@ func resourceNetworkingTrunkV2Update(d *schema.ResourceData, meta interface{}) e
 		tagOpts := attributestags.ReplaceAllOpts{Tags: tags}
 		tags, err := attributestags.ReplaceAll(client, "trunks", d.Id(), tagOpts).Extract()
 		if err != nil {
-			return fmt.Errorf("Error updating tags on trunk: %s", err)
+			return fmt.Errorf("Error setting tags on openstack_networking_trunk_v2 %s: %s", d.Id(), err)
 		}
-		log.Printf("[DEBUG] Updated tags = %+v on trunk %s", tags, d.Id())
+		log.Printf("[DEBUG] Set tags %s on openstack_networking_trunk_v2 %s", tags, d.Id())
 	}
 
 	return resourceNetworkingTrunkV2Read(d, meta)
@@ -261,10 +276,14 @@ func resourceNetworkingTrunkV2Delete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
+	if err := trunks.Delete(client, d.Id()).ExtractErr(); err != nil {
+		return CheckDeleted(d, err, "Error deleting openstack_networking_trunk_v2")
+	}
+
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"ACTIVE"},
+		Pending:    []string{"ACTIVE", "DOWN"},
 		Target:     []string{"DELETED"},
-		Refresh:    waitForNetworkTrunkDelete(client, d.Id()),
+		Refresh:    networkingTrunkV2StateRefreshFunc(client, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      5 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -272,76 +291,8 @@ func resourceNetworkingTrunkV2Delete(d *schema.ResourceData, meta interface{}) e
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error deleting OpenStack Neutron trunk: %s", err)
+		return fmt.Errorf("Error waiting for openstack_networking_trunk_v2 %s to delete: %s", d.Id(), err)
 	}
 
 	return nil
-}
-
-func resourceNetworkingTrunkV2Subports(d *schema.Set) (subports []trunks.Subport) {
-	rawSubports := d.List()
-	subports = make([]trunks.Subport, len(rawSubports))
-
-	for i, raw := range rawSubports {
-		rawMap := raw.(map[string]interface{})
-		subports[i] = trunks.Subport{
-			PortID:           rawMap["port_id"].(string),
-			SegmentationType: rawMap["segmentation_type"].(string),
-			SegmentationID:   rawMap["segmentation_id"].(int),
-		}
-	}
-	return
-}
-
-func resourceNetworkingTrunkV2AdminStateUp(d *schema.ResourceData) *bool {
-	value := false
-
-	if v, ok := d.GetOkExists("admin_state_up"); ok {
-		value = v.(bool)
-	}
-
-	return &value
-}
-
-func waitForNetworkTrunkActive(client *gophercloud.ServiceClient, trunkID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		trunk, err := trunks.Get(client, trunkID).Extract()
-		if err != nil {
-			return nil, "", err
-		}
-
-		log.Printf("[DEBUG] OpenStack Neutron trunk: %+v", trunk)
-		if trunk.Status == "DOWN" || trunk.Status == "ACTIVE" {
-			return trunk, "ACTIVE", nil
-		}
-
-		return trunk, trunk.Status, nil
-	}
-}
-
-func waitForNetworkTrunkDelete(client *gophercloud.ServiceClient, trunkID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		log.Printf("[DEBUG] Attempting to delete OpenStack Neutron trunk %s", trunkID)
-
-		trunk, err := trunks.Get(client, trunkID).Extract()
-		if err != nil {
-			if _, ok := err.(gophercloud.ErrDefault404); ok {
-				log.Printf("[DEBUG] Successfully deleted OpenStack trunk %s", trunkID)
-				return trunk, "DELETED", nil
-			}
-			return trunk, "ACTIVE", err
-		}
-
-		err = trunks.Delete(client, trunkID).ExtractErr()
-		if err != nil {
-			if _, ok := err.(gophercloud.ErrDefault404); ok {
-				log.Printf("[DEBUG] Successfully deleted OpenStack trunk %s", trunkID)
-				return trunk, "DELETED", nil
-			}
-			return trunk, "ACTIVE", err
-		}
-
-		log.Printf("[DEBUG] OpenStack trunk %s still active.\n", trunkID)
-		return trunk, "ACTIVE", nil
-	}
 }

--- a/website/docs/r/networking_trunk_v2.html.markdown
+++ b/website/docs/r/networking_trunk_v2.html.markdown
@@ -78,11 +78,11 @@ The following arguments are supported:
     `region` argument of the provider is used. Changing this creates a new
     trunk.
 
-* `name` - (Optional) A unique name for the port. Changing this
-    updates the `name` of an existing port.
+* `name` - (Optional) A unique name for the trunk. Changing this
+    updates the `name` of an existing trunk.
 
-* `description` - (Optional) Human-readable description of the port. Changing this
-    updates the name of the existing port.
+* `description` - (Optional) Human-readable description of the trunk. Changing this
+    updates the name of the existing trunk.
 
 * `port_id` - (Required) The ID of the port to be used as the parent port of the
     trunk. This is the port that should be used as the compute instance network
@@ -104,7 +104,7 @@ The `sub_port` block supports:
 
 * `port_id` - (Required) The ID of the port to be made a subport of the trunk.
 
-* `segmentation_type` - (Required) The segmenation tecnology to use, e.g., "vlan".
+* `segmentation_type` - (Required) The segmentation technology to use, e.g., "vlan".
 
 * `segmentation_id` - (Required) The numeric id of the subport segment.
 


### PR DESCRIPTION
Use extend and flatten functions for work with the trunk "sub_port"
argument/attribute.

Provide a single resource.StateRefreshFunc for the trunk resource.

Update debug messages for the trunk resource.

Fix "openstack_networking_trunk_v2" website documentation.