### PR TITLE
Vet: fix unkeyed fields for importers

### DIFF
--- a/openstack/resource_openstack_lb_l7policy_v2.go
+++ b/openstack/resource_openstack_lb_l7policy_v2.go
@@ -22,7 +22,7 @@ func resourceL7PolicyV2() *schema.Resource {
 		Update: resourceL7PolicyV2Update,
 		Delete: resourceL7PolicyV2Delete,
 		Importer: &schema.ResourceImporter{
-			resourceL7PolicyV2Import,
+			State: resourceL7PolicyV2Import,
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/openstack/resource_openstack_lb_l7rule_v2.go
+++ b/openstack/resource_openstack_lb_l7rule_v2.go
@@ -21,7 +21,7 @@ func resourceL7RuleV2() *schema.Resource {
 		Update: resourceL7RuleV2Update,
 		Delete: resourceL7RuleV2Delete,
 		Importer: &schema.ResourceImporter{
-			resourceL7RuleV2Import,
+			State: resourceL7RuleV2Import,
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/openstack/resource_openstack_lb_member_v2.go
+++ b/openstack/resource_openstack_lb_member_v2.go
@@ -20,7 +20,7 @@ func resourceMemberV2() *schema.Resource {
 		Update: resourceMemberV2Update,
 		Delete: resourceMemberV2Delete,
 		Importer: &schema.ResourceImporter{
-			resourceMemberV2Import,
+			State: resourceMemberV2Import,
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/openstack/resource_openstack_lb_pool_v2.go
+++ b/openstack/resource_openstack_lb_pool_v2.go
@@ -19,7 +19,7 @@ func resourcePoolV2() *schema.Resource {
 		Update: resourcePoolV2Update,
 		Delete: resourcePoolV2Delete,
 		Importer: &schema.ResourceImporter{
-			resourcePoolV2Import,
+			State: resourcePoolV2Import,
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/openstack/resource_openstack_sharedfilesystem_share_access_v2.go
+++ b/openstack/resource_openstack_sharedfilesystem_share_access_v2.go
@@ -21,7 +21,7 @@ func resourceSharedFilesystemShareAccessV2() *schema.Resource {
 		Read:   resourceSharedFilesystemShareAccessV2Read,
 		Delete: resourceSharedFilesystemShareAccessV2Delete,
 		Importer: &schema.ResourceImporter{
-			resourceSharedFilesystemShareAccessV2Import,
+			State: resourceSharedFilesystemShareAccessV2Import,
 		},
 
 		Timeouts: &schema.ResourceTimeout{


### PR DESCRIPTION
Fix unkeyed fields for schema.ResourceImporter of the OpenStack LB and
Shared filesystem resources.