### PR TITLE
DNS v2: Fix recordset diffs

### DIFF
--- a/openstack/dns_recordset_v2.go
+++ b/openstack/dns_recordset_v2.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets"
@@ -79,17 +78,14 @@ func expandDNSRecordSetV2Records(v []interface{}) []string {
 	return records
 }
 
-// dnsRecordSetV2SuppressRecordDiffs will suppress diffs when the format
-// of a record is different yet still a valid DNS record. For example, if a
-// user specifies an IPv6 address using [bracket] notation, but the record is
-// returned without brackets, it is still a valid record.
-func dnsRecordSetV2SuppressRecordDiffs(k, old, new string, d *schema.ResourceData) bool {
-	re := regexp.MustCompile("[][]")
-	new = re.ReplaceAllString(new, "")
+// dnsRecordSetV2RecordsStateFunc will strip brackets from IPv6 addresses.
+func dnsRecordSetV2RecordsStateFunc(v interface{}) string {
+	if addr, ok := v.(string); ok {
+		re := regexp.MustCompile("[][]")
+		addr = re.ReplaceAllString(addr, "")
 
-	if old == new {
-		return true
+		return addr
 	}
 
-	return false
+	return ""
 }

--- a/openstack/dns_recordset_v2_test.go
+++ b/openstack/dns_recordset_v2_test.go
@@ -17,10 +17,12 @@ func TestDNSRecordSetV2ParseID(t *testing.T) {
 	assert.Equal(t, expectedRecordSetID, actualRecordSetID)
 }
 
-func TestExpandDNSRecordSetV2Records(t *testing.T) {
+func TestDNSRecordSetV2RecordsStateFunc(t *testing.T) {
 	data := []interface{}{"foo", "[bar]", "baz"}
 	expected := []string{"foo", "bar", "baz"}
 
-	actual := expandDNSRecordSetV2Records(data)
-	assert.Equal(t, expected, actual)
+	for i, record := range data {
+		actual := dnsRecordSetV2RecordsStateFunc(record)
+		assert.Equal(t, expected[i], actual)
+	}
 }

--- a/website/docs/r/dns_recordset_v2.html.markdown
+++ b/website/docs/r/dns_recordset_v2.html.markdown
@@ -54,7 +54,9 @@ The following arguments are supported:
 
 * `description` - (Optional) A description of the  record set.
 
-* `records` - (Optional) An array of DNS records.
+* `records` - (Optional) An array of DNS records. _Note:_ if an IPv6 address
+  contains brackets (`[ ]`), the brackets will be stripped and the modified
+  address will be recorded in the state.
 
 * `value_specs` - (Optional) Map of additional options. Changing this creates a
   new record set.


### PR DESCRIPTION
For #627 

This commit fixes an issue where the records attribute in the
`openstack_dns_recordset_v2` resource would sometimes be returned in a
different order than what the user specified.

The hardest part about implementing this fix is managing the internal
feature of removing brackets from IPv6 addresses.

In order to successfully continue removing the brackets as well as
retain backwards compatibility, the following changes were made:

1. The `records` field is no longer being set in the Read function. This
is because the `records` field is not computed, so it does not need to
be set during Read.

2. An import function has been created so `records` is set when a user
imports a recordset.

3. `DiffSuppressFunc` has been replaced with a `StateFunc`. Because
`records` is no longer being set in Read, a diff will never occur, but
the modified IPv6 records still need to have records stripped.

4. `records` is being re-set in state during the Create function with
the IPv6 brackets stripped out.

I've tested this pretty extensively, including running this patch against an existing state file to confirm that no diffs will occur.  Importing also works, but I did not include an IPv6 import test because the records might be set out of order (this is an acceptable situation for this to happen).