### PR TITLE
Compute/Block Storage: Fix issue with volume detachment

### DIFF
--- a/openstack/resource_openstack_blockstorage_volume_v2.go
+++ b/openstack/resource_openstack_blockstorage_volume_v2.go
@@ -265,8 +265,7 @@ func resourceBlockStorageVolumeV2Delete(d *schema.ResourceData, meta interface{}
 			serverID := volumeAttachment.ServerID
 			attachmentID := volumeAttachment.ID
 			if err := volumeattach.Delete(computeClient, serverID, attachmentID).ExtractErr(); err != nil {
-				return fmt.Errorf(
-					"Error detaching openstack_blockstorage_volume_v2 %s from %s: %s", d.Id(), serverID, err)
+				return CheckDeleted(d, err, "Error detaching openstack_blockstorage_volume_v2")
 			}
 		}
 

--- a/openstack/resource_openstack_compute_volume_attach_v2.go
+++ b/openstack/resource_openstack_compute_volume_attach_v2.go
@@ -162,7 +162,7 @@ func resourceComputeVolumeAttachV2Delete(d *schema.ResourceData, meta interface{
 	}
 
 	if _, err = stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("Error detaching openstack_compute_volume_attach_v2 %s: %s", d.Id(), err)
+		return CheckDeleted(d, err, "Error detaching openstack_compute_volume_attach_v2")
 	}
 
 	return nil


### PR DESCRIPTION
For #639 

There are times when both the volume resource and the volume attachment
resource are both trying to detach at the same time and one request
returns a 404. This should be considered acceptable and not error.