### PR TITLE
Block Storage v2: Fix volume detachment 404s

### DIFF
--- a/openstack/resource_openstack_blockstorage_volume_v1.go
+++ b/openstack/resource_openstack_blockstorage_volume_v1.go
@@ -260,6 +260,14 @@ func resourceBlockStorageVolumeV1Delete(d *schema.ResourceData, meta interface{}
 					continue
 				}
 
+				// A 409 is also acceptable because there's another
+				// concurrent action happening.
+				if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
+					if errCode.Actual == 409 {
+						continue
+					}
+				}
+
 				return fmt.Errorf(
 					"Error detaching openstack_blockstorage_volume_v1 %s from %s: %s", d.Id(), serverID, err)
 			}
@@ -267,7 +275,7 @@ func resourceBlockStorageVolumeV1Delete(d *schema.ResourceData, meta interface{}
 
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"in-use", "attaching", "detaching"},
-			Target:     []string{"available"},
+			Target:     []string{"available", "deleted"},
 			Refresh:    blockStorageVolumeV1StateRefreshFunc(blockStorageClient, d.Id()),
 			Timeout:    10 * time.Minute,
 			Delay:      10 * time.Second,

--- a/openstack/resource_openstack_blockstorage_volume_v3.go
+++ b/openstack/resource_openstack_blockstorage_volume_v3.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach"
@@ -320,6 +321,13 @@ func resourceBlockStorageVolumeV3Delete(d *schema.ResourceData, meta interface{}
 			serverID := volumeAttachment.ServerID
 			attachmentID := volumeAttachment.ID
 			if err := volumeattach.Delete(computeClient, serverID, attachmentID).ExtractErr(); err != nil {
+				// It's possible the volume was already detached by
+				// openstack_compute_volume_attach_v2, so consider
+				// a 404 acceptable and continue.
+				if _, ok := err.(gophercloud.ErrDefault404); ok {
+					continue
+				}
+
 				return fmt.Errorf(
 					"Error detaching openstack_blockstorage_volume_v3 %s from %s: %s", d.Id(), serverID, err)
 			}


### PR DESCRIPTION
For #639 

Amending #640, we shouldn't use CheckDeleted for the volume detach
portion since CheckDeleted will remove the resource from state. Instead,
we should just consider a 404 an acceptable error and continue.

Too many Deletes and CheckDelete on my mind.