### PR TITLE
Compute V2: Don't fail on delete, when compute instance doesn't exist

### DIFF
--- a/openstack/identity_user_v3_test.go
+++ b/openstack/identity_user_v3_test.go
@@ -32,10 +32,10 @@ func TestFlattenIdentityUserV3MFARules(t *testing.T) {
 	mfaRules := []interface{}{mfaRule_1, mfaRule_2}
 
 	expected := []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"rule": mfaRule_1,
 		},
-		map[string]interface{}{
+		{
 			"rule": mfaRule_2,
 		},
 	}

--- a/openstack/import_openstack_compute_interface_attach_v2_test.go
+++ b/openstack/import_openstack_compute_interface_attach_v2_test.go
@@ -21,6 +21,9 @@ func TestAccComputeV2InterfaceAttachImport_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"admin_pass",
+				},
 			},
 		},
 	})

--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -178,9 +178,10 @@ func resourceComputeInstanceV2() *schema.Resource {
 				ForceNew: true,
 			},
 			"admin_pass": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: false,
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+				ForceNew:  false,
 			},
 			"access_ip_v4": {
 				Type:     schema.TypeString,
@@ -890,7 +891,7 @@ func resourceComputeInstanceV2Delete(d *schema.ResourceData, meta interface{}) e
 	if d.Get("stop_before_destroy").(bool) {
 		err = startstop.Stop(computeClient, d.Id()).ExtractErr()
 		if err != nil {
-			log.Printf("[WARN] Error stopping OpenStack instance: %s", err)
+			log.Printf("[WARN] Error stopping openstack_compute_instance_v2: %s", err)
 		} else {
 			stopStateConf := &resource.StateChangeConf{
 				Pending:    []string{"ACTIVE"},
@@ -912,13 +913,13 @@ func resourceComputeInstanceV2Delete(d *schema.ResourceData, meta interface{}) e
 		log.Printf("[DEBUG] Force deleting OpenStack Instance %s", d.Id())
 		err = servers.ForceDelete(computeClient, d.Id()).ExtractErr()
 		if err != nil {
-			return fmt.Errorf("Error deleting OpenStack server: %s", err)
+			return CheckDeleted(d, err, "Error force deleting openstack_compute_instance_v2")
 		}
 	} else {
 		log.Printf("[DEBUG] Deleting OpenStack Instance %s", d.Id())
 		err = servers.Delete(computeClient, d.Id()).ExtractErr()
 		if err != nil {
-			return fmt.Errorf("Error deleting OpenStack server: %s", err)
+			return CheckDeleted(d, err, "Error deleting openstack_compute_instance_v2")
 		}
 	}
 
@@ -941,7 +942,6 @@ func resourceComputeInstanceV2Delete(d *schema.ResourceData, meta interface{}) e
 			d.Id(), err)
 	}
 
-	d.SetId("")
 	return nil
 }
 


### PR DESCRIPTION
For #456