### PR TITLE
Add new data source 'openstack_compute_availability_zones_v2'

### DIFF
--- a/openstack/data_source_openstack_compute_availability_zones_v2.go
+++ b/openstack/data_source_openstack_compute_availability_zones_v2.go
@@ -41,6 +41,7 @@ func dataSourceComputeAvailabilityZonesV2Read(d *schema.ResourceData, meta inter
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err.Error())
 	}
+
 	allPages, err := availabilityzones.List(computeClient).AllPages()
 	if err != nil {
 		return fmt.Errorf("Error retrieving openstack_compute_availability_zones_v2: %s", err.Error())
@@ -49,6 +50,7 @@ func dataSourceComputeAvailabilityZonesV2Read(d *schema.ResourceData, meta inter
 	if err != nil {
 		return fmt.Errorf("Error extracting openstack_compute_availability_zones_v2 from response: %s", err.Error())
 	}
+
 	state := d.Get("state").(string)
 	if state == "" {
 		state = "available"
@@ -60,7 +62,9 @@ func dataSourceComputeAvailabilityZonesV2Read(d *schema.ResourceData, meta inter
 			zones = append(zones, z.ZoneName)
 		}
 	}
+
 	d.SetId(time.Now().UTC().String())
 	d.Set("names", zones)
+
 	return nil
 }

--- a/openstack/data_source_openstack_compute_availability_zones_v2.go
+++ b/openstack/data_source_openstack_compute_availability_zones_v2.go
@@ -16,7 +16,9 @@ func dataSourceComputeAvailabilityZonesV2() *schema.Resource {
 			"names": {
 				Type:     schema.TypeList,
 				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 			"region": {
 				Type:     schema.TypeString,
@@ -33,22 +35,18 @@ func dataSourceComputeAvailabilityZonesV2() *schema.Resource {
 
 func dataSourceComputeAvailabilityZonesV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	region := d.Get("region").(string)
-	if region == "" {
-		region = GetRegion(d, config)
-	}
-	computeClient, err := config.computeV2Client(region)
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating OpenStack compute client: %s", err.Error())
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
 
 	allPages, err := availabilityzones.List(computeClient).AllPages()
 	if err != nil {
-		return fmt.Errorf("Error retrieving openstack_compute_availability_zones_v2: %s", err.Error())
+		return fmt.Errorf("Error retrieving openstack_compute_availability_zones_v2: %s", err)
 	}
 	zoneInfo, err := availabilityzones.ExtractAvailabilityZones(allPages)
 	if err != nil {
-		return fmt.Errorf("Error extracting openstack_compute_availability_zones_v2 from response: %s", err.Error())
+		return fmt.Errorf("Error extracting openstack_compute_availability_zones_v2 from response: %s", err)
 	}
 
 	state := d.Get("state").(string)

--- a/openstack/data_source_openstack_compute_availability_zones_v2.go
+++ b/openstack/data_source_openstack_compute_availability_zones_v2.go
@@ -18,6 +18,10 @@ func dataSourceComputeAvailabilityZonesV2() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"state": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -29,7 +33,11 @@ func dataSourceComputeAvailabilityZonesV2() *schema.Resource {
 
 func dataSourceComputeAvailabilityZonesV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d, config))
+	region := d.Get("region").(string)
+	if region == "" {
+		region = GetRegion(d, config)
+	}
+	computeClient, err := config.computeV2Client(region)
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err.Error())
 	}

--- a/openstack/data_source_openstack_compute_availability_zones_v2.go
+++ b/openstack/data_source_openstack_compute_availability_zones_v2.go
@@ -1,0 +1,58 @@
+package openstack
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func dataSourceComputeAvailabilityZonesV2() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceComputeAvailabilityZonesV2Read,
+		Schema: map[string]*schema.Schema{
+			"names": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"state": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"available", "unavailable"}, true),
+			},
+		},
+	}
+}
+
+func dataSourceComputeAvailabilityZonesV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	computeClient, err := config.computeV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err.Error())
+	}
+	allPages, err := availabilityzones.List(computeClient).AllPages()
+	if err != nil {
+		return fmt.Errorf("Unable to fetch availability zones: %s", err.Error())
+	}
+	zoneInfo, err := availabilityzones.ExtractAvailabilityZones(allPages)
+	if err != nil {
+		return fmt.Errorf("Unable to extract availability zones: %s", err.Error())
+	}
+	state := d.Get("state").(string)
+	if state == "" {
+		state = "available"
+	}
+	stateBool := state == "available"
+	zones := make([]string, 0, len(zoneInfo))
+	for _, z := range zoneInfo {
+		if z.ZoneState.Available == stateBool {
+			zones = append(zones, z.ZoneName)
+		}
+	}
+	d.SetId(time.Now().UTC().String())
+	d.Set("names", zones)
+	return nil
+}

--- a/openstack/data_source_openstack_compute_availability_zones_v2.go
+++ b/openstack/data_source_openstack_compute_availability_zones_v2.go
@@ -28,6 +28,7 @@ func dataSourceComputeAvailabilityZonesV2() *schema.Resource {
 
 			"state": {
 				Type:         schema.TypeString,
+				Default:      "available",
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"available", "unavailable"}, true),
 			},
@@ -51,11 +52,7 @@ func dataSourceComputeAvailabilityZonesV2Read(d *schema.ResourceData, meta inter
 		return fmt.Errorf("Error extracting openstack_compute_availability_zones_v2 from response: %s", err)
 	}
 
-	state := d.Get("state").(string)
-	if state == "" {
-		state = "available"
-	}
-	stateBool := state == "available"
+	stateBool := d.Get("state").(string) == "available"
 	zones := make([]string, 0, len(zoneInfo))
 	for _, z := range zoneInfo {
 		if z.ZoneState.Available == stateBool {

--- a/openstack/data_source_openstack_compute_availability_zones_v2.go
+++ b/openstack/data_source_openstack_compute_availability_zones_v2.go
@@ -20,10 +20,12 @@ func dataSourceComputeAvailabilityZonesV2() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+
 			"region": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
 			"state": {
 				Type:         schema.TypeString,
 				Optional:     true,

--- a/openstack/data_source_openstack_compute_availability_zones_v2.go
+++ b/openstack/data_source_openstack_compute_availability_zones_v2.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
@@ -61,6 +62,9 @@ func dataSourceComputeAvailabilityZonesV2Read(d *schema.ResourceData, meta inter
 			zones = append(zones, z.ZoneName)
 		}
 	}
+
+	// sort.Strings sorts in place, returns nothing
+	sort.Strings(zones)
 
 	d.SetId(time.Now().UTC().String())
 	d.Set("names", zones)

--- a/openstack/data_source_openstack_compute_availability_zones_v2.go
+++ b/openstack/data_source_openstack_compute_availability_zones_v2.go
@@ -43,11 +43,11 @@ func dataSourceComputeAvailabilityZonesV2Read(d *schema.ResourceData, meta inter
 	}
 	allPages, err := availabilityzones.List(computeClient).AllPages()
 	if err != nil {
-		return fmt.Errorf("Unable to fetch availability zones: %s", err.Error())
+		return fmt.Errorf("Error retrieving openstack_compute_availability_zones_v2: %s", err.Error())
 	}
 	zoneInfo, err := availabilityzones.ExtractAvailabilityZones(allPages)
 	if err != nil {
-		return fmt.Errorf("Unable to extract availability zones: %s", err.Error())
+		return fmt.Errorf("Error extracting openstack_compute_availability_zones_v2 from response: %s", err.Error())
 	}
 	state := d.Get("state").(string)
 	if state == "" {

--- a/openstack/data_source_openstack_compute_availability_zones_v2.go
+++ b/openstack/data_source_openstack_compute_availability_zones_v2.go
@@ -23,6 +23,7 @@ func dataSourceComputeAvailabilityZonesV2() *schema.Resource {
 
 			"region": {
 				Type:     schema.TypeString,
+				Computed: true,
 				Optional: true,
 			},
 
@@ -38,7 +39,8 @@ func dataSourceComputeAvailabilityZonesV2() *schema.Resource {
 
 func dataSourceComputeAvailabilityZonesV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	computeClient, err := config.computeV2Client(GetRegion(d, config))
+	region := GetRegion(d, config)
+	computeClient, err := config.computeV2Client(region)
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
@@ -62,6 +64,7 @@ func dataSourceComputeAvailabilityZonesV2Read(d *schema.ResourceData, meta inter
 
 	d.SetId(time.Now().UTC().String())
 	d.Set("names", zones)
+	d.Set("region", region)
 
 	return nil
 }

--- a/openstack/data_source_openstack_compute_availability_zones_v2.go
+++ b/openstack/data_source_openstack_compute_availability_zones_v2.go
@@ -3,9 +3,9 @@ package openstack
 import (
 	"fmt"
 	"sort"
-	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
+	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )
@@ -66,7 +66,7 @@ func dataSourceComputeAvailabilityZonesV2Read(d *schema.ResourceData, meta inter
 	// sort.Strings sorts in place, returns nothing
 	sort.Strings(zones)
 
-	d.SetId(time.Now().UTC().String())
+	d.SetId(hashcode.Strings(zones))
 	d.Set("names", zones)
 	d.Set("region", region)
 

--- a/openstack/data_source_openstack_compute_availability_zones_v2_test.go
+++ b/openstack/data_source_openstack_compute_availability_zones_v2_test.go
@@ -1,12 +1,10 @@
 package openstack
 
 import (
-	"fmt"
-	"strconv"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccOpenStackAvailabilityZonesV2_basic(t *testing.T) {
@@ -17,36 +15,11 @@ func TestAccOpenStackAvailabilityZonesV2_basic(t *testing.T) {
 			{
 				Config: testAccOpenStackAvailabilityZonesConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2AvailabilityZones("data.openstack_compute_availability_zones_v2.zones"),
+					resource.TestMatchResourceAttr("data.openstack_compute_availability_zones_v2.zones", "names.#", regexp.MustCompile("[1-9]\\d*")),
 				),
 			},
 		},
 	})
-}
-
-func testAccCheckComputeV2AvailabilityZones(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Can't find AZ resource: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("AZ resource ID not set")
-		}
-		v, ok := rs.Primary.Attributes["names.#"]
-		if !ok {
-			return fmt.Errorf("AZ name list missing")
-		}
-		qty, err := strconv.Atoi(v)
-		if err != nil {
-			return err
-		}
-		if qty < 1 {
-			return fmt.Errorf("No AZs found, something is broken")
-		}
-		return nil
-	}
 }
 
 const testAccOpenStackAvailabilityZonesConfig = `

--- a/openstack/data_source_openstack_compute_availability_zones_v2_test.go
+++ b/openstack/data_source_openstack_compute_availability_zones_v2_test.go
@@ -1,0 +1,54 @@
+package openstack
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccOpenStackAvailabilityZonesV2_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenStackAvailabilityZonesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2AvailabilityZones("data.openstack_compute_availability_zones_v2.zones"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckComputeV2AvailabilityZones(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find AZ resource: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("AZ resource ID not set")
+		}
+		v, ok := rs.Primary.Attributes["names.#"]
+		if !ok {
+			return fmt.Errorf("AZ name list missing")
+		}
+		qty, err := strconv.Atoi(v)
+		if err != nil {
+			return err
+		}
+		if qty < 1 {
+			return fmt.Errorf("No AZs found, something is broken")
+		}
+		return nil
+	}
+}
+
+const testAccOpenStackAvailabilityZonesConfig = `
+data "openstack_compute_availability_zones_v2" "zones" {}
+`

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -221,6 +221,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"openstack_blockstorage_snapshot_v2":          dataSourceBlockStorageSnapshotV2(),
 			"openstack_blockstorage_snapshot_v3":          dataSourceBlockStorageSnapshotV3(),
+			"openstack_compute_availability_zones_v2":     dataSourceComputeAvailabilityZonesV2(),
 			"openstack_compute_flavor_v2":                 dataSourceComputeFlavorV2(),
 			"openstack_compute_keypair_v2":                dataSourceComputeKeypairV2(),
 			"openstack_containerinfra_clustertemplate_v1": dataSourceContainerInfraClusterTemplateV1(),

--- a/website/docs/d/compute_availability_zones_v2.html.markdown
+++ b/website/docs/d/compute_availability_zones_v2.html.markdown
@@ -18,12 +18,13 @@ data "openstack_compute_availability_zones_v2" "zones" {}
 
 ## Argument Reference
 
+* `region` - (Optional) The `region` to fetch availability zones from, defaults to the provider's `region`
 * `state` - (Optional) The `state` of the availability zones to match, default ("available").
 
 
 ## Attributes Reference
 
-`id` is set to the time in UTC in which the information was retreived. In addition, the following attributes
+`id` is set to hash of the returned zone list. In addition, the following attributes
 are exported:
 
-* `names` - The names of the availability zones that match the queried `state`
+* `names` - The names of the availability zones, ordered alphanumerically, that match the queried `state`

--- a/website/docs/d/compute_availability_zones_v2.html.markdown
+++ b/website/docs/d/compute_availability_zones_v2.html.markdown
@@ -1,0 +1,29 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_compute_availability_zones_v2"
+sidebar_current: "docs-openstack-datasource-compute-availability-zones-v2"
+description: |-
+  Get a list of availability zones from OpenStack
+---
+
+# openstack\_compute\_availability\_zones\_v2
+
+Use this data source to get a list of availability zones from OpenStack
+
+## Example Usage
+
+```hcl
+data "openstack_compute_availability_zones_v2" "zones" {}
+```
+
+## Argument Reference
+
+* `state` - (Optional) The `state` of the availability zones to match, default ("available").
+
+
+## Attributes Reference
+
+`id` is set to the time in UTC in which the information was retreived. In addition, the following attributes
+are exported:
+
+* `names` - The names of the availability zones that match the queried `state`

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -19,6 +19,9 @@
             <li<%= sidebar_current("docs-openstack-datasource-blockstorage-snapshot-v3") %>>
               <a href="/docs/providers/openstack/d/blockstorage_snapshot_v3.html">openstack_blockstorage_snapshot_v3</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-datasource-compute-availability-zones-v2") %>>
+              <a href="/docs/providers/openstack/d/compute_availability_zones_v2.html">openstack_compute_availability_zones_v2</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-datasource-compute-flavor-v2") %>>
               <a href="/docs/providers/openstack/d/compute_flavor_v2.html">openstack_compute_flavor_v2</a>
             </li>


### PR DESCRIPTION
In working with this provider, I found myself missing the ability to query OpenStack for availability zones like you can in other providers (such as `terraform-provider-aws`).

This PR adds that functionality.

If anything is missing, please let me know! This is my first PR adding a resource/datasource to a provider