### PR TITLE
Networking v2: Fix Allowed Address Pairs validation

### DIFF
--- a/openstack/resource_openstack_networking_port_v2.go
+++ b/openstack/resource_openstack_networking_port_v2.go
@@ -137,9 +137,8 @@ func resourceNetworkingPortV2() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ip_address": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.SingleIP(),
+							Type:     schema.TypeString,
+							Required: true,
 						},
 						"mac_address": {
 							Type:     schema.TypeString,


### PR DESCRIPTION
This change reverts a previous modification which restricted an allowed
address pair's IP address to be a single IP address rather than a CIDR.

For #659 