### PR TITLE
Internal: fwaas resources cleanup

### DIFF
--- a/openstack/data_source_openstack_fw_policy_v1.go
+++ b/openstack/data_source_openstack_fw_policy_v1.go
@@ -19,32 +19,39 @@ func dataSourceFWPolicyV1() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+
 			"policy_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
 			"tenant_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
+
 			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
 			"audited": {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+
 			"shared": {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+
 			"rules": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -74,20 +81,20 @@ func dataSourceFWPolicyV1Read(d *schema.ResourceData, meta interface{}) error {
 
 	allFWPolicies, err := policies.ExtractPolicies(pages)
 	if err != nil {
-		return fmt.Errorf("Unable to retrieve firewall policies: %s", err)
+		return fmt.Errorf("Unable to retrieve openstack_fw_policy_v1: %s", err)
 	}
 
 	if len(allFWPolicies) < 1 {
-		return fmt.Errorf("No firewall policies found with name: %s", d.Get("name"))
+		return fmt.Errorf("No openstack_fw_policy_v1 found with name: %s", d.Get("name"))
 	}
 
 	if len(allFWPolicies) > 1 {
-		return fmt.Errorf("More than one firewall policies found with name: %s", d.Get("name"))
+		return fmt.Errorf("More than one openstack_fw_policy_v1 found with name: %s", d.Get("name"))
 	}
 
 	policy := allFWPolicies[0]
 
-	log.Printf("[DEBUG] Retrieved firewall policies %s: %+v", policy.ID, policy)
+	log.Printf("[DEBUG] Retrieved openstack_fw_policy_v1 %s: %#v", policy.ID, policy)
 	d.SetId(policy.ID)
 
 	d.Set("name", policy.Name)

--- a/openstack/fw_firewall_v1.go
+++ b/openstack/fw_firewall_v1.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/routerinsertion"
+
 	"github.com/hashicorp/terraform/helper/resource"
 )
 

--- a/openstack/fw_firewall_v1.go
+++ b/openstack/fw_firewall_v1.go
@@ -1,0 +1,65 @@
+package openstack
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/routerinsertion"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+// Firewall is an OpenStack firewall.
+type Firewall struct {
+	firewalls.Firewall
+	routerinsertion.FirewallExt
+}
+
+// FirewallCreateOpts represents the attributes used when creating a new firewall.
+type FirewallCreateOpts struct {
+	firewalls.CreateOpts
+	ValueSpecs map[string]string `json:"value_specs,omitempty"`
+}
+
+// ToFirewallCreateMap casts a CreateOptsExt struct to a map.
+// It overrides firewalls.ToFirewallCreateMap to add the ValueSpecs field.
+func (opts FirewallCreateOpts) ToFirewallCreateMap() (map[string]interface{}, error) {
+	return BuildRequest(opts, "firewall")
+}
+
+//FirewallUpdateOpts
+type FirewallUpdateOpts struct {
+	firewalls.UpdateOptsBuilder
+}
+
+func (opts FirewallUpdateOpts) ToFirewallUpdateMap() (map[string]interface{}, error) {
+	return BuildRequest(opts, "firewall")
+}
+
+func fwFirewallV1RefreshFunc(networkingClient *gophercloud.ServiceClient, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		var fw Firewall
+
+		err := firewalls.Get(networkingClient, id).ExtractInto(&fw)
+		if err != nil {
+			return nil, "", err
+		}
+
+		return fw, fw.Status, nil
+	}
+}
+
+func fwFirewallV1DeleteFunc(networkingClient *gophercloud.ServiceClient, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		fw, err := firewalls.Get(networkingClient, id).Extract()
+
+		if err != nil {
+			if _, ok := err.(gophercloud.ErrDefault404); ok {
+				return "", "DELETED", nil
+			}
+			return nil, "", fmt.Errorf("Unexpected error: %s", err)
+		}
+
+		return fw, "DELETING", nil
+	}
+}

--- a/openstack/fw_policy_v1.go
+++ b/openstack/fw_policy_v1.go
@@ -1,0 +1,40 @@
+package openstack
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+// PolicyCreateOpts represents the attributes used when creating a new firewall policy.
+type PolicyCreateOpts struct {
+	policies.CreateOpts
+	ValueSpecs map[string]string `json:"value_specs,omitempty"`
+}
+
+// ToPolicyCreateMap casts a CreateOpts struct to a map.
+// It overrides policies.ToFirewallPolicyCreateMap to add the ValueSpecs field.
+func (opts PolicyCreateOpts) ToFirewallPolicyCreateMap() (map[string]interface{}, error) {
+	return BuildRequest(opts, "firewall_policy")
+}
+
+func fwPolicyV1DeleteFunc(networkingClient *gophercloud.ServiceClient, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		err := policies.Delete(networkingClient, id).Err
+		if err == nil {
+			return "", "DELETED", nil
+		}
+
+		if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
+			if errCode.Actual == 409 {
+				// This error usually means that the policy is attached
+				// to a firewall. At this point, the firewall is probably
+				// being delete. So, we retry a few times.
+				return nil, "ACTIVE", nil
+			}
+		}
+
+		return nil, "ACTIVE", err
+	}
+}

--- a/openstack/fw_rule_v1.go
+++ b/openstack/fw_rule_v1.go
@@ -1,0 +1,56 @@
+package openstack
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules"
+)
+
+// RuleCreateOpts represents the attributes used when creating a new firewall rule.
+type RuleCreateOpts struct {
+	rules.CreateOpts
+	ValueSpecs map[string]string `json:"value_specs,omitempty"`
+}
+
+// ToRuleCreateMap casts a CreateOpts struct to a map.
+// It overrides rules.ToRuleCreateMap to add the ValueSpecs field.
+func (opts RuleCreateOpts) ToRuleCreateMap() (map[string]interface{}, error) {
+	b, err := BuildRequest(opts, "firewall_rule")
+	if err != nil {
+		return nil, err
+	}
+
+	if m := b["firewall_rule"].(map[string]interface{}); m["protocol"] == "any" {
+		m["protocol"] = nil
+	}
+
+	return b, nil
+}
+
+func expandFWRuleV1IPVersion(ipv int) gophercloud.IPVersion {
+	// Determine the IP Version
+	var ipVersion gophercloud.IPVersion
+	switch ipv {
+	case 4:
+		ipVersion = gophercloud.IPv4
+	case 6:
+		ipVersion = gophercloud.IPv6
+	}
+
+	return ipVersion
+}
+
+func expandFWRuleV1Protocol(p string) rules.Protocol {
+	var protocol rules.Protocol
+	switch p {
+	case "any":
+		protocol = rules.ProtocolAny
+	case "icmp":
+		protocol = rules.ProtocolICMP
+	case "tcp":
+		protocol = rules.ProtocolTCP
+	case "udp":
+		protocol = rules.ProtocolUDP
+	}
+
+	return protocol
+}

--- a/openstack/fw_rule_v1_test.go
+++ b/openstack/fw_rule_v1_test.go
@@ -1,0 +1,25 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpandFWRuleV1IPVersion(t *testing.T) {
+	ipv := 4
+
+	expected := gophercloud.IPv4
+	actual := expandFWRuleV1IPVersion(ipv)
+	assert.Equal(t, expected, actual)
+}
+
+func TestExpandFWRuleV1Protocol(t *testing.T) {
+	proto := "tcp"
+
+	expected := rules.ProtocolTCP
+	actual := expandFWRuleV1Protocol(proto)
+	assert.Equal(t, expected, actual)
+}

--- a/openstack/resource_openstack_fw_firewall_v1.go
+++ b/openstack/resource_openstack_fw_firewall_v1.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/routerinsertion"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -35,29 +34,35 @@ func resourceFWFirewallV1() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
 			"policy_id": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+
 			"admin_state_up": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
 			},
+
 			"tenant_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
+
 			"associated_routers": {
 				Type:          schema.TypeSet,
 				Optional:      true,
@@ -66,11 +71,13 @@ func resourceFWFirewallV1() *schema.Resource {
 				ConflictsWith: []string{"no_routers"},
 				Computed:      true,
 			},
+
 			"no_routers": {
 				Type:          schema.TypeBool,
 				Optional:      true,
 				ConflictsWith: []string{"associated_routers"},
 			},
+
 			"value_specs": {
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -81,7 +88,6 @@ func resourceFWFirewallV1() *schema.Resource {
 }
 
 func resourceFWFirewallV1Create(d *schema.ResourceData, meta interface{}) error {
-
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
@@ -104,8 +110,6 @@ func resourceFWFirewallV1Create(d *schema.ResourceData, meta interface{}) error 
 
 	associatedRoutersRaw := d.Get("associated_routers").(*schema.Set).List()
 	if len(associatedRoutersRaw) > 0 {
-		log.Printf("[DEBUG] Will attempt to associate Firewall with router(s): %+v", associatedRoutersRaw)
-
 		var routerIds []string
 		for _, v := range associatedRoutersRaw {
 			routerIds = append(routerIds, v.(string))
@@ -119,33 +123,34 @@ func resourceFWFirewallV1Create(d *schema.ResourceData, meta interface{}) error 
 
 	if d.Get("no_routers").(bool) {
 		routerIds := make([]string, 0)
-		log.Println("[DEBUG] No routers specified. Setting to empty slice")
 		createOpts = &routerinsertion.CreateOptsExt{
 			CreateOptsBuilder: createOpts,
 			RouterIDs:         routerIds,
 		}
 	}
 
-	log.Printf("[DEBUG] Create firewall: %#v", createOpts)
+	log.Printf("[DEBUG] openstack_fw_firewall_v1 create options: %#v", createOpts)
 
 	firewall, err := firewalls.Create(networkingClient, createOpts).Extract()
 	if err != nil {
 		return err
 	}
 
-	log.Printf("[DEBUG] Firewall created: %#v", firewall)
+	log.Printf("[DEBUG] openstack_fw_firewall_v1 created: %#v", firewall)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"PENDING_CREATE"},
-		Target:     []string{"ACTIVE"},
-		Refresh:    waitForFirewallActive(networkingClient, firewall.ID),
+		Target:     []string{"ACTIVE", "INACTIVE"},
+		Refresh:    fwFirewallV1RefreshFunc(networkingClient, firewall.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      0,
 		MinTimeout: 2 * time.Second,
 	}
 
 	_, err = stateConf.WaitForState()
-	log.Printf("[DEBUG] Firewall (%s) is active.", firewall.ID)
+	if err != nil {
+		return fmt.Errorf("Error waiting for openstack_fw_firewall_v1 to become active: %s", err)
+	}
 
 	d.SetId(firewall.ID)
 
@@ -153,8 +158,6 @@ func resourceFWFirewallV1Create(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceFWFirewallV1Read(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] Retrieve information about firewall: %s", d.Id())
-
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
@@ -164,10 +167,10 @@ func resourceFWFirewallV1Read(d *schema.ResourceData, meta interface{}) error {
 	var firewall Firewall
 	err = firewalls.Get(networkingClient, d.Id()).ExtractInto(&firewall)
 	if err != nil {
-		return CheckDeleted(d, err, "firewall")
+		return CheckDeleted(d, err, "Error retrieving openstack_fw_firewall_v1")
 	}
 
-	log.Printf("[DEBUG] Read OpenStack Firewall %s: %#v", d.Id(), firewall)
+	log.Printf("[DEBUG] Retrieved openstack_fw_firewall_v1 %s: %#v", d.Id(), firewall)
 
 	d.Set("name", firewall.Name)
 	d.Set("description", firewall.Description)
@@ -181,7 +184,6 @@ func resourceFWFirewallV1Read(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceFWFirewallV1Update(d *schema.ResourceData, meta interface{}) error {
-
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
@@ -213,7 +215,6 @@ func resourceFWFirewallV1Update(d *schema.ResourceData, meta interface{}) error 
 	if d.HasChange("associated_routers") || d.HasChange("no_routers") {
 		// 'no_routers' = true means 'associated_routers' will be empty...
 		if d.Get("no_routers").(bool) {
-			log.Printf("[DEBUG] 'no_routers' is true.")
 			routerIds = make([]string, 0)
 		} else {
 			associatedRoutersRaw := d.Get("associated_routers").(*schema.Set).List()
@@ -230,7 +231,7 @@ func resourceFWFirewallV1Update(d *schema.ResourceData, meta interface{}) error 
 		updateOpts = opts
 	}
 
-	log.Printf("[DEBUG] Updating firewall with id %s: %#v", d.Id(), updateOpts)
+	log.Printf("[DEBUG] openstack_fw_firewall_v1 %s update options: %#v", d.Id(), updateOpts)
 
 	err = firewalls.Update(networkingClient, d.Id(), updateOpts).Err
 	if err != nil {
@@ -239,87 +240,66 @@ func resourceFWFirewallV1Update(d *schema.ResourceData, meta interface{}) error 
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"PENDING_CREATE", "PENDING_UPDATE"},
-		Target:     []string{"ACTIVE"},
-		Refresh:    waitForFirewallActive(networkingClient, d.Id()),
+		Target:     []string{"ACTIVE", "INACTIVE"},
+		Refresh:    fwFirewallV1RefreshFunc(networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutUpdate),
 		Delay:      0,
 		MinTimeout: 2 * time.Second,
 	}
 
 	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for openstack_fw_firewall_v1 %s to become active: %s", d.Id(), err)
+	}
 
 	return resourceFWFirewallV1Read(d, meta)
 }
 
 func resourceFWFirewallV1Delete(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] Destroy firewall: %s", d.Id())
-
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
+	_, err = firewalls.Get(networkingClient, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "Error retrieving openstack_fw_firewall_v1")
+	}
+
 	// Ensure the firewall was fully created/updated before being deleted.
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"PENDING_CREATE", "PENDING_UPDATE"},
-		Target:     []string{"ACTIVE"},
-		Refresh:    waitForFirewallActive(networkingClient, d.Id()),
+		Target:     []string{"ACTIVE", "INACTIVE"},
+		Refresh:    fwFirewallV1RefreshFunc(networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutUpdate),
 		Delay:      0,
 		MinTimeout: 2 * time.Second,
 	}
 
 	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for openstack_fw_firewall_v1 %s to become active: %s", d.Id(), err)
+	}
 
 	err = firewalls.Delete(networkingClient, d.Id()).Err
-
 	if err != nil {
-		return err
+		return fmt.Errorf("Error deleting openstack_fw_firewall_v1 %s: %s", d.Id(), err)
 	}
 
 	stateConf = &resource.StateChangeConf{
 		Pending:    []string{"DELETING"},
 		Target:     []string{"DELETED"},
-		Refresh:    waitForFirewallDeletion(networkingClient, d.Id()),
+		Refresh:    fwFirewallV1DeleteFunc(networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      0,
 		MinTimeout: 2 * time.Second,
 	}
 
 	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for openstack_fw_firewall_v1 %s to delete: %s", d.Id(), err)
+	}
 
 	return err
-}
-
-func waitForFirewallActive(networkingClient *gophercloud.ServiceClient, id string) resource.StateRefreshFunc {
-
-	return func() (interface{}, string, error) {
-		var fw Firewall
-
-		err := firewalls.Get(networkingClient, id).ExtractInto(&fw)
-		if err != nil {
-			return nil, "", err
-		}
-		return fw, fw.Status, nil
-	}
-}
-
-func waitForFirewallDeletion(networkingClient *gophercloud.ServiceClient, id string) resource.StateRefreshFunc {
-
-	return func() (interface{}, string, error) {
-		fw, err := firewalls.Get(networkingClient, id).Extract()
-		log.Printf("[DEBUG] Got firewall %s => %#v", id, fw)
-
-		if err != nil {
-			if _, ok := err.(gophercloud.ErrDefault404); ok {
-				log.Printf("[DEBUG] Firewall %s is actually deleted", id)
-				return "", "DELETED", nil
-			}
-			return nil, "", fmt.Errorf("Unexpected error: %s", err)
-		}
-
-		log.Printf("[DEBUG] Firewall %s deletion is pending", id)
-		return fw, "DELETING", nil
-	}
 }

--- a/openstack/resource_openstack_fw_policy_v1.go
+++ b/openstack/resource_openstack_fw_policy_v1.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -23,6 +22,7 @@ func resourceFWPolicyV1() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -32,34 +32,41 @@ func resourceFWPolicyV1() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
 			"audited": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
 			},
+
 			"shared": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+
 			"tenant_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
+
 			"rules": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+
 			"value_specs": {
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -76,25 +83,14 @@ func resourceFWPolicyV1Create(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
-	v := d.Get("rules").([]interface{})
-
-	log.Printf("[DEBUG] Rules found : %#v", v)
-	log.Printf("[DEBUG] Rules count : %d", len(v))
-
-	rules := make([]string, len(v))
-	for i, v := range v {
-		rules[i] = v.(string)
-	}
-
 	audited := d.Get("audited").(bool)
-
 	opts := PolicyCreateOpts{
 		policies.CreateOpts{
 			Name:        d.Get("name").(string),
 			Description: d.Get("description").(string),
 			Audited:     &audited,
 			TenantID:    d.Get("tenant_id").(string),
-			Rules:       rules,
+			Rules:       expandToStringSlice(d.Get("rules").([]interface{})),
 		},
 		MapValueSpecs(d),
 	}
@@ -104,14 +100,14 @@ func resourceFWPolicyV1Create(d *schema.ResourceData, meta interface{}) error {
 		opts.Shared = &shared
 	}
 
-	log.Printf("[DEBUG] Create firewall policy: %#v", opts)
+	log.Printf("[DEBUG] openstack_fw_policy_v1 create options: %#v", opts)
 
 	policy, err := policies.Create(networkingClient, opts).Extract()
 	if err != nil {
-		return err
+		return fmt.Errorf("Error creating openstack_fw_policy_v1: %s", err)
 	}
 
-	log.Printf("[DEBUG] Firewall policy created: %#v", policy)
+	log.Printf("[DEBUG] openstack_fw_policy_v1 %s created: %#v", policy.ID, policy)
 
 	d.SetId(policy.ID)
 
@@ -119,8 +115,6 @@ func resourceFWPolicyV1Create(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceFWPolicyV1Read(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] Retrieve information about firewall policy: %s", d.Id())
-
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
@@ -129,10 +123,10 @@ func resourceFWPolicyV1Read(d *schema.ResourceData, meta interface{}) error {
 
 	policy, err := policies.Get(networkingClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "FW policy")
+		return CheckDeleted(d, err, "Error retrieving openstack_fw_policy_v1")
 	}
 
-	log.Printf("[DEBUG] Read OpenStack Firewall Policy %s: %#v", d.Id(), policy)
+	log.Printf("[DEBUG] Retrieved openstack_fw_policy_v1 %s: %#v", d.Id(), policy)
 
 	d.Set("name", policy.Name)
 	d.Set("description", policy.Description)
@@ -165,69 +159,43 @@ func resourceFWPolicyV1Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("rules") {
-		v := d.Get("rules").([]interface{})
-
-		log.Printf("[DEBUG] Rules found : %#v", v)
-		log.Printf("[DEBUG] Rules count : %d", len(v))
-
-		rules := make([]string, len(v))
-		for i, v := range v {
-			rules[i] = v.(string)
-		}
-		opts.Rules = rules
+		opts.Rules = expandToStringSlice(d.Get("rules").([]interface{}))
 	}
 
-	log.Printf("[DEBUG] Updating firewall policy with id %s: %#v", d.Id(), opts)
+	log.Printf("[DEBUG] openstack_fw_policy_v1 %s update options: %#v", d.Id(), opts)
 
 	err = policies.Update(networkingClient, d.Id(), opts).Err
 	if err != nil {
-		return err
+		return fmt.Errorf("Error updating openstack_fw_policy_v1 %s: %s", d.Id(), err)
 	}
 
 	return resourceFWPolicyV1Read(d, meta)
 }
 
 func resourceFWPolicyV1Delete(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] Destroy firewall policy: %s", d.Id())
-
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
+	_, err = policies.Get(networkingClient, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "Error retrieving openstack_fw_policy_v1")
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE"},
 		Target:     []string{"DELETED"},
-		Refresh:    waitForFirewallPolicyDeletion(networkingClient, d.Id()),
-		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Refresh:    fwPolicyV1DeleteFunc(networkingClient, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      0,
 		MinTimeout: 2 * time.Second,
 	}
 
 	if _, err = stateConf.WaitForState(); err != nil {
-		return err
+		return fmt.Errorf("Error waiting for openstack_fw_policy_v1 %s to be deleted: %s", d.Id(), err)
 	}
 
 	return nil
-}
-
-func waitForFirewallPolicyDeletion(networkingClient *gophercloud.ServiceClient, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		err := policies.Delete(networkingClient, id).Err
-		if err == nil {
-			return "", "DELETED", nil
-		}
-
-		if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
-			if errCode.Actual == 409 {
-				// This error usually means that the policy is attached
-				// to a firewall. At this point, the firewall is probably
-				// being delete. So, we retry a few times.
-				return nil, "ACTIVE", nil
-			}
-		}
-
-		return nil, "ACTIVE", err
-	}
 }

--- a/openstack/resource_openstack_fw_policy_v1_test.go
+++ b/openstack/resource_openstack_fw_policy_v1_test.go
@@ -62,23 +62,6 @@ func TestAccFWPolicyV1_deleteRules(t *testing.T) {
 	})
 }
 
-func TestAccFWPolicyV1_timeout(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckFW(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckFWPolicyV1Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFWPolicyV1_timeout,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckFWPolicyV1Exists(
-						"openstack_fw_policy_v1.policy_1", "", "", 0),
-				),
-			},
-		},
-	})
-}
-
 func testAccCheckFWPolicyV1Destroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
@@ -187,13 +170,5 @@ resource "openstack_fw_policy_v1" "policy_1" {
 resource "openstack_fw_rule_v1" "udp_deny" {
   protocol = "udp"
   action = "deny"
-}
-`
-
-const testAccFWPolicyV1_timeout = `
-resource "openstack_fw_policy_v1" "policy_1" {
-  timeouts {
-    create = "5m"
-  }
 }
 `

--- a/openstack/resource_openstack_fw_rule_v1.go
+++ b/openstack/resource_openstack_fw_rule_v1.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -27,53 +26,65 @@ func resourceFWRuleV1() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
 			"protocol": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+
 			"action": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+
 			"ip_version": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  4,
 			},
+
 			"source_ip_address": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
 			"destination_ip_address": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
 			"source_port": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
 			"destination_port": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
 			},
+
 			"tenant_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
+
 			"value_specs": {
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -84,7 +95,6 @@ func resourceFWRuleV1() *schema.Resource {
 }
 
 func resourceFWRuleV1Create(d *schema.ResourceData, meta interface{}) error {
-
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
@@ -92,16 +102,13 @@ func resourceFWRuleV1Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	enabled := d.Get("enabled").(bool)
-	ipVersion := resourceFWRuleV1DetermineIPVersion(d.Get("ip_version").(int))
-	protocol := resourceFWRuleV1DetermineProtocol(d.Get("protocol").(string))
-
 	ruleConfiguration := RuleCreateOpts{
 		rules.CreateOpts{
 			Name:                 d.Get("name").(string),
 			Description:          d.Get("description").(string),
-			Protocol:             protocol,
+			Protocol:             expandFWRuleV1Protocol(d.Get("protocol").(string)),
 			Action:               d.Get("action").(string),
-			IPVersion:            ipVersion,
+			IPVersion:            expandFWRuleV1IPVersion(d.Get("ip_version").(int)),
 			SourceIPAddress:      d.Get("source_ip_address").(string),
 			DestinationIPAddress: d.Get("destination_ip_address").(string),
 			SourcePort:           d.Get("source_port").(string),
@@ -112,15 +119,14 @@ func resourceFWRuleV1Create(d *schema.ResourceData, meta interface{}) error {
 		MapValueSpecs(d),
 	}
 
-	log.Printf("[DEBUG] Create firewall rule: %#v", ruleConfiguration)
+	log.Printf("[DEBUG] openstack_fw_rule_v1 create options: %#v", ruleConfiguration)
 
 	rule, err := rules.Create(networkingClient, ruleConfiguration).Extract()
-
 	if err != nil {
-		return err
+		return fmt.Errorf("Error creating openstack_fw_rule_v1: %s", err)
 	}
 
-	log.Printf("[DEBUG] Firewall rule with id %s : %#v", rule.ID, rule)
+	log.Printf("[DEBUG] Created openstack_fw_rule_v1 %s: %#v", rule.ID, rule)
 
 	d.SetId(rule.ID)
 
@@ -128,8 +134,6 @@ func resourceFWRuleV1Create(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceFWRuleV1Read(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] Retrieve information about firewall rule: %s", d.Id())
-
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
@@ -138,10 +142,10 @@ func resourceFWRuleV1Read(d *schema.ResourceData, meta interface{}) error {
 
 	rule, err := rules.Get(networkingClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "FW rule")
+		return CheckDeleted(d, err, "Error retrieving openstack_fw_rule_v1")
 	}
 
-	log.Printf("[DEBUG] Read OpenStack Firewall Rule %s: %#v", d.Id(), rule)
+	log.Printf("[DEBUG] Retrieved openstack_fw_rule_v1 %s: %#v", d.Id(), rule)
 
 	d.Set("action", rule.Action)
 	d.Set("name", rule.Name)
@@ -193,7 +197,7 @@ func resourceFWRuleV1Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("ip_version") {
-		ipVersion := resourceFWRuleV1DetermineIPVersion(d.Get("ip_version").(int))
+		ipVersion := expandFWRuleV1IPVersion(d.Get("ip_version").(int))
 		updateOpts.IPVersion = &ipVersion
 	}
 
@@ -202,7 +206,7 @@ func resourceFWRuleV1Update(d *schema.ResourceData, meta interface{}) error {
 		updateOpts.SourceIPAddress = &sourceIPAddress
 
 		// Also include the ip_version.
-		ipVersion := resourceFWRuleV1DetermineIPVersion(d.Get("ip_version").(int))
+		ipVersion := expandFWRuleV1IPVersion(d.Get("ip_version").(int))
 		updateOpts.IPVersion = &ipVersion
 	}
 
@@ -223,7 +227,7 @@ func resourceFWRuleV1Update(d *schema.ResourceData, meta interface{}) error {
 		updateOpts.DestinationIPAddress = &destinationIPAddress
 
 		// Also include the ip_version.
-		ipVersion := resourceFWRuleV1DetermineIPVersion(d.Get("ip_version").(int))
+		ipVersion := expandFWRuleV1IPVersion(d.Get("ip_version").(int))
 		updateOpts.IPVersion = &ipVersion
 	}
 
@@ -245,18 +249,16 @@ func resourceFWRuleV1Update(d *schema.ResourceData, meta interface{}) error {
 		updateOpts.Enabled = &enabled
 	}
 
-	log.Printf("[DEBUG] Updating firewall rules: %#v", updateOpts)
+	log.Printf("[DEBUG] openstack_fw_rule_v1 %s update options: %#v", d.Id(), updateOpts)
 	err = rules.Update(networkingClient, d.Id(), updateOpts).Err
 	if err != nil {
-		return err
+		return fmt.Errorf("Error updating openstack_fw_rule_v1 %s: %s", d.Id(), err)
 	}
 
 	return resourceFWRuleV1Read(d, meta)
 }
 
 func resourceFWRuleV1Delete(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] Destroy firewall rule: %s", d.Id())
-
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
@@ -265,44 +267,20 @@ func resourceFWRuleV1Delete(d *schema.ResourceData, meta interface{}) error {
 
 	rule, err := rules.Get(networkingClient, d.Id()).Extract()
 	if err != nil {
-		return err
+		return CheckDeleted(d, err, "Error retrieving openstack_fw_rule_v1")
 	}
 
 	if rule.PolicyID != "" {
 		_, err := policies.RemoveRule(networkingClient, rule.PolicyID, rule.ID).Extract()
 		if err != nil {
-			return err
+			return fmt.Errorf("Error removing openstack_fw_rule_v1 %s from policy %s: %s", d.Id(), rule.PolicyID, err)
 		}
 	}
 
-	return rules.Delete(networkingClient, d.Id()).Err
-}
-
-func resourceFWRuleV1DetermineIPVersion(ipv int) gophercloud.IPVersion {
-	// Determine the IP Version
-	var ipVersion gophercloud.IPVersion
-	switch ipv {
-	case 4:
-		ipVersion = gophercloud.IPv4
-	case 6:
-		ipVersion = gophercloud.IPv6
+	err = rules.Delete(networkingClient, d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("Error deleting openstack_fw_rule_v1 %s: %s", d.Id(), err)
 	}
 
-	return ipVersion
-}
-
-func resourceFWRuleV1DetermineProtocol(p string) rules.Protocol {
-	var protocol rules.Protocol
-	switch p {
-	case "any":
-		protocol = rules.ProtocolAny
-	case "icmp":
-		protocol = rules.ProtocolICMP
-	case "tcp":
-		protocol = rules.ProtocolTCP
-	case "udp":
-		protocol = rules.ProtocolUDP
-	}
-
-	return protocol
+	return nil
 }

--- a/openstack/types.go
+++ b/openstack/types.go
@@ -10,10 +10,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/routerinsertion"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools"
@@ -175,33 +171,6 @@ func (lrt *LogRoundTripper) formatJSON(raw []byte) string {
 	return string(pretty)
 }
 
-// Firewall is an OpenStack firewall.
-type Firewall struct {
-	firewalls.Firewall
-	routerinsertion.FirewallExt
-}
-
-// FirewallCreateOpts represents the attributes used when creating a new firewall.
-type FirewallCreateOpts struct {
-	firewalls.CreateOpts
-	ValueSpecs map[string]string `json:"value_specs,omitempty"`
-}
-
-// ToFirewallCreateMap casts a CreateOptsExt struct to a map.
-// It overrides firewalls.ToFirewallCreateMap to add the ValueSpecs field.
-func (opts FirewallCreateOpts) ToFirewallCreateMap() (map[string]interface{}, error) {
-	return BuildRequest(opts, "firewall")
-}
-
-//FirewallUpdateOpts
-type FirewallUpdateOpts struct {
-	firewalls.UpdateOptsBuilder
-}
-
-func (opts FirewallUpdateOpts) ToFirewallUpdateMap() (map[string]interface{}, error) {
-	return BuildRequest(opts, "firewall")
-}
-
 // FloatingIPCreateOpts represents the attributes used when creating a new floating ip.
 type FloatingIPCreateOpts struct {
 	floatingips.CreateOpts
@@ -226,12 +195,6 @@ func (opts NetworkCreateOpts) ToNetworkCreateMap() (map[string]interface{}, erro
 	return BuildRequest(opts, "network")
 }
 
-// PolicyCreateOpts represents the attributes used when creating a new firewall policy.
-type PolicyCreateOpts struct {
-	policies.CreateOpts
-	ValueSpecs map[string]string `json:"value_specs,omitempty"`
-}
-
 // IKEPolicyCreateOpts represents the attributes used when creating a new IKE policy.
 type IKEPolicyCreateOpts struct {
 	ikepolicies.CreateOpts
@@ -242,12 +205,6 @@ type IKEPolicyCreateOpts struct {
 type IKEPolicyLifetimeCreateOpts struct {
 	ikepolicies.LifetimeCreateOpts
 	ValueSpecs map[string]string `json:"value_specs,omitempty"`
-}
-
-// ToPolicyCreateMap casts a CreateOpts struct to a map.
-// It overrides policies.ToFirewallPolicyCreateMap to add the ValueSpecs field.
-func (opts PolicyCreateOpts) ToFirewallPolicyCreateMap() (map[string]interface{}, error) {
-	return BuildRequest(opts, "firewall_policy")
 }
 
 // PortCreateOpts represents the attributes used when creating a new port.
@@ -272,27 +229,6 @@ type RouterCreateOpts struct {
 // It overrides routers.ToRouterCreateMap to add the ValueSpecs field.
 func (opts RouterCreateOpts) ToRouterCreateMap() (map[string]interface{}, error) {
 	return BuildRequest(opts, "router")
-}
-
-// RuleCreateOpts represents the attributes used when creating a new firewall rule.
-type RuleCreateOpts struct {
-	rules.CreateOpts
-	ValueSpecs map[string]string `json:"value_specs,omitempty"`
-}
-
-// ToRuleCreateMap casts a CreateOpts struct to a map.
-// It overrides rules.ToRuleCreateMap to add the ValueSpecs field.
-func (opts RuleCreateOpts) ToRuleCreateMap() (map[string]interface{}, error) {
-	b, err := BuildRequest(opts, "firewall_rule")
-	if err != nil {
-		return nil, err
-	}
-
-	if m := b["firewall_rule"].(map[string]interface{}); m["protocol"] == "any" {
-		m["protocol"] = nil
-	}
-
-	return b, nil
 }
 
 // SubnetCreateOpts represents the attributes used when creating a new subnet.


### PR DESCRIPTION
For #456 

The FWaaS v1 API code is flaky since there were some breaking changes introduced in v1. It's also quite difficult to get a working FWaaS v1 service running in newer versions of Neutron. I've run the acceptance tests in two different environments, running two different versions of OpenStack, and tests pass in the version they were targeted for.

It's totally possible to use these resources in production, but I'm sure those who are have workarounds they are doing. This is not a fault of the resources, but of the API code.

FWaaS v1 is not tested in OpenLab.