### PR TITLE
Networking v2: Deprecate openstack_networking_subnet_v2.host_routes

### DIFF
--- a/openstack/resource_openstack_networking_subnet_v2.go
+++ b/openstack/resource_openstack_networking_subnet_v2.go
@@ -112,9 +112,10 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"host_routes": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: false,
+				Type:       schema.TypeList,
+				Optional:   true,
+				ForceNew:   false,
+				Deprecated: "Use openstack_networking_subnet_route_v2 instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"destination_cidr": {
@@ -271,7 +272,6 @@ func resourceNetworkingSubnetV2Read(d *schema.ResourceData, meta interface{}) er
 	d.Set("description", s.Description)
 	d.Set("tenant_id", s.TenantID)
 	d.Set("dns_nameservers", s.DNSNameservers)
-	d.Set("host_routes", s.HostRoutes)
 	d.Set("enable_dhcp", s.EnableDHCP)
 	d.Set("network_id", s.NetworkID)
 	d.Set("ipv6_address_mode", s.IPv6AddressMode)

--- a/website/docs/r/networking_subnet_v2.html.markdown
+++ b/website/docs/r/networking_subnet_v2.html.markdown
@@ -78,7 +78,8 @@ The following arguments are supported:
     in this subnet. Changing this updates the DNS name servers for the existing
     subnet.
 
-* `host_routes` - (Optional) An array of routes that should be used by devices
+* `host_routes` - (**Deprecated** - use `openstack_networking_subnet_route_v2`
+    instead) An array of routes that should be used by devices
     with IPs from this subnet (not including local subnet route). The host_route
     object structure is documented below. Changing this updates the host routes
     for the existing subnet.


### PR DESCRIPTION
This commit deprecates the host_routes argument of the
openstack_networking_subnet_v2 resource. Given there is a schema issue
with setting the host_routes attribute and that using both this resource
and the openstack_networking_subnet_route_v2 resource will cause diffs
to occur, it's best to have the supported solution be to use the
dedicated resource.