### PR TITLE
Subnet recreating bug fix

### DIFF
--- a/openstack/resource_openstack_networking_port_v2.go
+++ b/openstack/resource_openstack_networking_port_v2.go
@@ -111,6 +111,7 @@ func resourceNetworkingPortV2() *schema.Resource {
 						"subnet_id": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 						"ip_address": {
 							Type:     schema.TypeString,


### PR DESCRIPTION
In my case Openstack provider (selectel.ru) doesn't automatically destroy 
subnet's ports. So I can't change any subnet parameters that forces subnet 
re-creation.

Steps to reproduce bug:

**1. Create configuration.***
```
resource "openstack_networking_network_v2" "lan" {
  region          = "${var.region}"
  name            = "${var.name}"
  admin_state_up  = true
}

resource "openstack_networking_subnet_v2" "lan" {
  region          = "${var.region}"
  name            = "${var.name}"
  cidr            = "192.168.0.0/24"
  network_id      = "${openstack_networking_network_v2.net.id}"
}

resource "openstack_networking_port_v2" "router" {
  network_id      = "${openstack_networking_network_v2.lan.network_id}"

  fixed_ip {
    subnet_id   = "${openstack_networking_subnet_v2.lan.subnet_id}"
  }
}
```

**2. Change configuration**
```
resource "openstack_networking_network_v2" "lan" {
  region          = "${var.region}"
  name            = "${var.name}"
  admin_state_up  = true
}

resource "openstack_networking_subnet_v2" "lan" {
  region          = "${var.region}"
  name            = "${var.name}"
  cidr            = "192.168.1.0/24" # <----- forces new recources
  network_id      = "${openstack_networking_network_v2.net.id}"
}

resource "openstack_networking_port_v2" "router" {
  network_id      = "${openstack_networking_network_v2.lan.network_id}"

  fixed_ip {
    subnet_id   = "${openstack_networking_subnet_v2.lan.subnet_id}"
  }
}
```
