### PR TITLE
Networking V2: Update port DHCP options in one API call

### DIFF
--- a/openstack/networking_port_v2.go
+++ b/openstack/networking_port_v2.go
@@ -28,60 +28,53 @@ func resourceNetworkingPortV2StateRefreshFunc(client *gophercloud.ServiceClient,
 }
 
 func expandNetworkingPortDHCPOptsV2Create(dhcpOpts *schema.Set) []extradhcpopts.CreateExtraDHCPOpt {
-	rawDHCPOpts := dhcpOpts.List()
+	var extraDHCPOpts []extradhcpopts.CreateExtraDHCPOpt
 
-	extraDHCPOpts := make([]extradhcpopts.CreateExtraDHCPOpt, len(rawDHCPOpts))
-	for i, raw := range rawDHCPOpts {
-		rawMap := raw.(map[string]interface{})
+	if dhcpOpts != nil {
+		for _, raw := range dhcpOpts.List() {
+			rawMap := raw.(map[string]interface{})
 
-		ipVersion := rawMap["ip_version"].(int)
-		optName := rawMap["name"].(string)
-		optValue := rawMap["value"].(string)
+			ipVersion := rawMap["ip_version"].(int)
+			optName := rawMap["name"].(string)
+			optValue := rawMap["value"].(string)
 
-		extraDHCPOpts[i] = extradhcpopts.CreateExtraDHCPOpt{
-			OptName:   optName,
-			OptValue:  optValue,
-			IPVersion: gophercloud.IPVersion(ipVersion),
+			extraDHCPOpts = append(extraDHCPOpts, extradhcpopts.CreateExtraDHCPOpt{
+				OptName:   optName,
+				OptValue:  optValue,
+				IPVersion: gophercloud.IPVersion(ipVersion),
+			})
 		}
 	}
 
 	return extraDHCPOpts
 }
 
-func expandNetworkingPortDHCPOptsV2Update(dhcpOpts *schema.Set) []extradhcpopts.UpdateExtraDHCPOpt {
-	rawDHCPOpts := dhcpOpts.List()
+func expandNetworkingPortDHCPOptsV2Update(oldDHCPopts, newDHCPopts *schema.Set) []extradhcpopts.UpdateExtraDHCPOpt {
+	var extraDHCPOpts []extradhcpopts.UpdateExtraDHCPOpt
 
-	extraDHCPOpts := make([]extradhcpopts.UpdateExtraDHCPOpt, len(rawDHCPOpts))
-	for i, raw := range rawDHCPOpts {
-		rawMap := raw.(map[string]interface{})
+	if newDHCPopts != nil {
+		for _, raw := range newDHCPopts.List() {
+			rawMap := raw.(map[string]interface{})
 
-		ipVersion := rawMap["ip_version"].(int)
-		optName := rawMap["name"].(string)
-		optValue := rawMap["value"].(string)
+			ipVersion := rawMap["ip_version"].(int)
+			optName := rawMap["name"].(string)
+			optValue := rawMap["value"].(string)
 
-		extraDHCPOpts[i] = extradhcpopts.UpdateExtraDHCPOpt{
-			OptName:   optName,
-			OptValue:  &optValue,
-			IPVersion: gophercloud.IPVersion(ipVersion),
+			extraDHCPOpts = append(extraDHCPOpts, extradhcpopts.UpdateExtraDHCPOpt{
+				OptName:   optName,
+				OptValue:  &optValue,
+				IPVersion: gophercloud.IPVersion(ipVersion),
+			})
 		}
 	}
 
-	return extraDHCPOpts
-}
-
-func expandNetworkingPortDHCPOptsV2Delete(dhcpOpts *schema.Set) []extradhcpopts.UpdateExtraDHCPOpt {
-	if dhcpOpts == nil {
-		return []extradhcpopts.UpdateExtraDHCPOpt{}
-	}
-
-	rawDHCPOpts := dhcpOpts.List()
-
-	extraDHCPOpts := make([]extradhcpopts.UpdateExtraDHCPOpt, len(rawDHCPOpts))
-	for i, raw := range rawDHCPOpts {
-		rawMap := raw.(map[string]interface{})
-		extraDHCPOpts[i] = extradhcpopts.UpdateExtraDHCPOpt{
-			OptName:  rawMap["name"].(string),
-			OptValue: nil,
+	if oldDHCPopts != nil {
+		for _, raw := range oldDHCPopts.List() {
+			rawMap := raw.(map[string]interface{})
+			extraDHCPOpts = append(extraDHCPOpts, extradhcpopts.UpdateExtraDHCPOpt{
+				OptName:  rawMap["name"].(string),
+				OptValue: nil,
+			})
 		}
 	}
 

--- a/openstack/networking_port_v2_test.go
+++ b/openstack/networking_port_v2_test.go
@@ -89,7 +89,7 @@ func TestExpandNetworkingPortDHCPOptsV2Update(t *testing.T) {
 		},
 	}
 
-	actualDHCPOptions := expandNetworkingPortDHCPOptsV2Update(d.Get("extra_dhcp_option").(*schema.Set))
+	actualDHCPOptions := expandNetworkingPortDHCPOptsV2Update(nil, d.Get("extra_dhcp_option").(*schema.Set))
 
 	assert.ElementsMatch(t, expectedDHCPOptions, actualDHCPOptions)
 }
@@ -99,9 +99,9 @@ func TestExpandNetworkingPortDHCPOptsEmptyV2Update(t *testing.T) {
 	d := r.TestResourceData()
 	d.SetId("1")
 
-	expectedDHCPOptions := []extradhcpopts.UpdateExtraDHCPOpt{}
+	var expectedDHCPOptions []extradhcpopts.UpdateExtraDHCPOpt
 
-	actualDHCPOptions := expandNetworkingPortDHCPOptsV2Update(d.Get("extra_dhcp_option").(*schema.Set))
+	actualDHCPOptions := expandNetworkingPortDHCPOptsV2Update(nil, d.Get("extra_dhcp_option").(*schema.Set))
 
 	assert.ElementsMatch(t, expectedDHCPOptions, actualDHCPOptions)
 }
@@ -132,7 +132,7 @@ func TestExpandNetworkingPortDHCPOptsV2Delete(t *testing.T) {
 		},
 	}
 
-	actualDHCPOptions := expandNetworkingPortDHCPOptsV2Delete(d.Get("extra_dhcp_option").(*schema.Set))
+	actualDHCPOptions := expandNetworkingPortDHCPOptsV2Update(d.Get("extra_dhcp_option").(*schema.Set), nil)
 
 	assert.ElementsMatch(t, expectedDHCPOptions, actualDHCPOptions)
 }

--- a/openstack/resource_openstack_networking_port_v2.go
+++ b/openstack/resource_openstack_networking_port_v2.go
@@ -430,50 +430,33 @@ func resourceNetworkingPortV2Update(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	// At this point, perform the update for all "standard" port changes.
-	if hasChange {
-		log.Printf("[DEBUG] openstack_networking_port_v2 %s update options: %#v", d.Id(), updateOpts)
-		_, err = ports.Update(networkingClient, d.Id(), updateOpts).Extract()
-		if err != nil {
-			return fmt.Errorf("Error updating OpenStack Neutron Port: %s", err)
-		}
-	}
+	var finalUpdateOpts ports.UpdateOptsBuilder
+	finalUpdateOpts = updateOpts
 
 	// Next, perform any dhcp option changes.
 	if d.HasChange("extra_dhcp_option") {
+		hasChange = true
+
 		o, n := d.GetChange("extra_dhcp_option")
 		oldDHCPOpts := o.(*schema.Set)
 		newDHCPOpts := n.(*schema.Set)
 
-		// Delete all old DHCP options, regardless of if they still exist.
-		// If they do still exist, they will be re-added below.
-		if oldDHCPOpts.Len() != 0 {
-			deleteExtraDHCPOpts := expandNetworkingPortDHCPOptsV2Delete(oldDHCPOpts)
-			dhcpUpdateOpts := extradhcpopts.UpdateOptsExt{
-				UpdateOptsBuilder: &ports.UpdateOpts{},
-				ExtraDHCPOpts:     deleteExtraDHCPOpts,
-			}
+		addDHCPOpts := newDHCPOpts.Difference(oldDHCPOpts)
+		deleteDHCPOpts := oldDHCPOpts.Difference(newDHCPOpts)
 
-			log.Printf("[DEBUG] Deleting old DHCP opts for openstack_networking_port_v2 %s", d.Id())
-			_, err = ports.Update(networkingClient, d.Id(), dhcpUpdateOpts).Extract()
-			if err != nil {
-				return fmt.Errorf("Error updating OpenStack Neutron Port: %s", err)
-			}
+		updateExtraDHCPOpts := expandNetworkingPortDHCPOptsV2Update(deleteDHCPOpts, addDHCPOpts)
+		finalUpdateOpts = extradhcpopts.UpdateOptsExt{
+			UpdateOptsBuilder: updateOpts,
+			ExtraDHCPOpts:     updateExtraDHCPOpts,
 		}
+	}
 
-		// Add any new DHCP options and re-add previously set DHCP options.
-		if newDHCPOpts.Len() != 0 {
-			updateExtraDHCPOpts := expandNetworkingPortDHCPOptsV2Update(newDHCPOpts)
-			dhcpUpdateOpts := extradhcpopts.UpdateOptsExt{
-				UpdateOptsBuilder: &ports.UpdateOpts{},
-				ExtraDHCPOpts:     updateExtraDHCPOpts,
-			}
-
-			log.Printf("[DEBUG] Updating openstack_networking_port_v2 %s with options: %#v", d.Id(), dhcpUpdateOpts)
-			_, err = ports.Update(networkingClient, d.Id(), dhcpUpdateOpts).Extract()
-			if err != nil {
-				return fmt.Errorf("Error updating openstack_networking_port_v2 %s: %s", d.Id(), err)
-			}
+	// At this point, perform the update for all "standard" port changes.
+	if hasChange {
+		log.Printf("[DEBUG] openstack_networking_port_v2 %s update options: %#v", d.Id(), updateOpts)
+		_, err = ports.Update(networkingClient, d.Id(), finalUpdateOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("Error updating OpenStack Neutron Port: %s", err)
 		}
 	}
 

--- a/openstack/resource_openstack_networking_port_v2.go
+++ b/openstack/resource_openstack_networking_port_v2.go
@@ -441,8 +441,8 @@ func resourceNetworkingPortV2Update(d *schema.ResourceData, meta interface{}) er
 		oldDHCPOpts := o.(*schema.Set)
 		newDHCPOpts := n.(*schema.Set)
 
-		addDHCPOpts := newDHCPOpts.Difference(oldDHCPOpts)
 		deleteDHCPOpts := oldDHCPOpts.Difference(newDHCPOpts)
+		addDHCPOpts := newDHCPOpts.Difference(oldDHCPOpts)
 
 		updateExtraDHCPOpts := expandNetworkingPortDHCPOptsV2Update(deleteDHCPOpts, addDHCPOpts)
 		finalUpdateOpts = extradhcpopts.UpdateOptsExt{

--- a/openstack/resource_openstack_networking_port_v2_test.go
+++ b/openstack/resource_openstack_networking_port_v2_test.go
@@ -526,6 +526,26 @@ func TestAccNetworkingV2Port_updateExtraDHCPOpts(t *testing.T) {
 					testAccCheckNetworkingV2SubnetExists("openstack_networking_subnet_v2.subnet_1", &subnet),
 					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
 					testAccCheckNetworkingV2PortExists("openstack_networking_port_v2.port_1", &port),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_port_v2.port_1", "extra_dhcp_option.#", "2"),
+				),
+			},
+			{
+				Config: testAccNetworkingV2Port_updateExtraDHCPOpts_5,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2SubnetExists("openstack_networking_subnet_v2.subnet_1", &subnet),
+					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
+					testAccCheckNetworkingV2PortExists("openstack_networking_port_v2.port_1", &port),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_port_v2.port_1", "extra_dhcp_option.#", "2"),
+				),
+			},
+			{
+				Config: testAccNetworkingV2Port_updateExtraDHCPOpts_6,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2SubnetExists("openstack_networking_subnet_v2.subnet_1", &subnet),
+					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
+					testAccCheckNetworkingV2PortExists("openstack_networking_port_v2.port_1", &port),
 					resource.TestCheckNoResourceAttr(
 						"openstack_networking_port_v2.port_1", "extra_dhcp_option"),
 				),
@@ -1862,6 +1882,70 @@ resource "openstack_networking_port_v2" "port_1" {
 `
 
 const testAccNetworkingV2Port_updateExtraDHCPOpts_4 = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name = "subnet_1"
+  cidr = "192.168.199.0/24"
+  ip_version = 4
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+}
+
+resource "openstack_networking_port_v2" "port_1" {
+  name = "port_1"
+  admin_state_up = "true"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+  fixed_ip {
+    subnet_id =  "${openstack_networking_subnet_v2.subnet_1.id}"
+    ip_address = "192.168.199.23"
+  }
+  extra_dhcp_option {
+    name = "optionD"
+    value = "valueD"
+  }
+  extra_dhcp_option {
+    name = "optionE"
+    value = "valueEE"
+  }
+}
+`
+
+const testAccNetworkingV2Port_updateExtraDHCPOpts_5 = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name = "subnet_1"
+  cidr = "192.168.199.0/24"
+  ip_version = 4
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+}
+
+resource "openstack_networking_port_v2" "port_1" {
+  name = "port_1"
+  admin_state_up = "true"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+  fixed_ip {
+    subnet_id =  "${openstack_networking_subnet_v2.subnet_1.id}"
+    ip_address = "192.168.199.23"
+  }
+  extra_dhcp_option {
+    name = "optionD"
+    value = "valueDD"
+  }
+  extra_dhcp_option {
+    name = "optionE"
+    value = "valueEE"
+  }
+}
+`
+
+const testAccNetworkingV2Port_updateExtraDHCPOpts_6 = `
 resource "openstack_networking_network_v2" "network_1" {
   name = "network_1"
   admin_state_up = "true"


### PR DESCRIPTION
This improvement will simplify further changes for newer port DNS (597) and port bindings extensions (665). Now port properties and DHCP options can be updated in one call.

I removed `expandNetworkingPortDHCPOptsV2Delete` func and embedded its logic into the `expandNetworkingPortDHCPOptsV2Update`. Using Sets, we can identify which options should be removed, and which options should be added, and combine this data into one `finalUpdateOpts`.

@ozerovandrei, @jtopjian please review.