### PR TITLE
LBaaS V2: Detect null LB statuses result

### DIFF
--- a/openstack/lb_v2_shared.go
+++ b/openstack/lb_v2_shared.go
@@ -327,7 +327,11 @@ func resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient *gophercloud.Serv
 			return nil, "", fmt.Errorf("Unable to get statuses from the Load Balancer %s statuses tree: %s", lbID, err)
 		}
 
-		if !strSliceContains(lbSkipLBStatuses, statuses.Loadbalancer.ProvisioningStatus) {
+		// Don't fail, when statuses returns "null"
+		if statuses == nil || statuses.Loadbalancer == nil {
+			statuses = new(loadbalancers.StatusTree)
+			statuses.Loadbalancer = new(loadbalancers.LoadBalancer)
+		} else if !strSliceContains(lbSkipLBStatuses, statuses.Loadbalancer.ProvisioningStatus) {
 			return statuses.Loadbalancer, statuses.Loadbalancer.ProvisioningStatus, nil
 		}
 


### PR DESCRIPTION
Resolves #687 

When `/statuses` responses with `null`, `Extract()` method doesn't fail, but returns `nil`. If it is nil, then a successful result is the best we can do.