### PR TITLE
Add `prefix_length` to subnet create

### DIFF
--- a/openstack/resource_openstack_networking_subnet_v2.go
+++ b/openstack/resource_openstack_networking_subnet_v2.go
@@ -41,15 +41,17 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 				ForceNew: true,
 			},
 			"cidr": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				ConflictsWith: []string{"prefix_length"},
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
 			},
 			"prefix_length": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeInt,
+				ConflictsWith: []string{"cidr"},
+				Optional:      true,
+				ForceNew:      true,
 			},
 			"name": {
 				Type:     schema.TypeString,
@@ -206,6 +208,9 @@ func resourceNetworkingSubnetV2Create(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if v, ok := d.GetOk("prefix_length"); ok {
+		if d.Get("subnetpool_id").(string) == "" {
+			return fmt.Errorf("'prefix_length' is only valid if 'subnetpool_id' is set")
+		}
 		prefixLength := v.(int)
 		createOpts.Prefixlen = prefixLength
 	}

--- a/openstack/resource_openstack_networking_subnet_v2.go
+++ b/openstack/resource_openstack_networking_subnet_v2.go
@@ -46,6 +46,11 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"prefix_length": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -198,6 +203,11 @@ func resourceNetworkingSubnetV2Create(d *schema.ResourceData, meta interface{}) 
 	if v, ok := d.GetOk("cidr"); ok {
 		cidr := v.(string)
 		createOpts.CIDR = cidr
+	}
+
+	if v, ok := d.GetOk("prefix_length"); ok {
+		prefixLength := v.(int)
+		createOpts.Prefixlen = prefixLength
 	}
 
 	if v, ok := d.GetOk("gateway_ip"); ok {

--- a/openstack/resource_openstack_networking_subnet_v2_test.go
+++ b/openstack/resource_openstack_networking_subnet_v2_test.go
@@ -182,7 +182,7 @@ func TestAccNetworkingV2Subnet_subnetPoolNoCIDR(t *testing.T) {
 	})
 }
 
-func TestAccNetworkingV2Subnet_subnetPoolPrefixLength(t *testing.T) {
+func TestAccNetworkingV2Subnet_subnetPrefixLength(t *testing.T) {
 	var subnet [2]subnets.Subnet
 
 	resource.Test(t, resource.TestCase{
@@ -191,7 +191,7 @@ func TestAccNetworkingV2Subnet_subnetPoolPrefixLength(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkingV2SubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkingV2Subnet_subnetPoolPrefixLength,
+				Config: testAccNetworkingV2Subnet_subnetPrefixLength,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2SubnetExists("openstack_networking_subnet_v2.subnet_1", &subnet[0]),
 					testAccCheckNetworkingV2SubnetExists("openstack_networking_subnet_v2.subnet_2", &subnet[1]),
@@ -436,7 +436,7 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
 }
 `
 
-const testAccNetworkingV2Subnet_subnetPoolPrefixLength = `
+const testAccNetworkingV2Subnet_subnetPrefixLength = `
 resource "openstack_networking_network_v2" "network_1" {
   name           = "network_1"
   admin_state_up = "true"

--- a/openstack/resource_openstack_networking_subnet_v2_test.go
+++ b/openstack/resource_openstack_networking_subnet_v2_test.go
@@ -182,6 +182,29 @@ func TestAccNetworkingV2Subnet_subnetPoolNoCIDR(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2Subnet_subnetPoolPrefixLength(t *testing.T) {
+	var subnet [2]subnets.Subnet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2SubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2Subnet_subnetPoolPrefixLength,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2SubnetExists("openstack_networking_subnet_v2.subnet_1", &subnet[0]),
+					testAccCheckNetworkingV2SubnetExists("openstack_networking_subnet_v2.subnet_2", &subnet[1]),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_subnet_v2.subnet_1", "prefix_length", "27"),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_subnet_v2.subnet_2", "prefix_length", "32"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingV2SubnetDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
@@ -410,5 +433,33 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
   name = "subnet_1"
 	network_id = "${openstack_networking_network_v2.network_1.id}"
 	subnetpool_id = "${openstack_networking_subnetpool_v2.subnetpool_1.id}"
+}
+`
+
+const testAccNetworkingV2Subnet_subnetPoolPrefixLength = `
+resource "openstack_networking_network_v2" "network_1" {
+  name           = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnetpool_v2" "subnetpool_1" {
+  name     = "my_ipv4_pool"
+  prefixes = ["10.11.12.0/24"]
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name          = "subnet_1"
+  prefix_length = 27
+  enable_dhcp   = false
+  network_id    = "${openstack_networking_network_v2.network_1.id}"
+  subnetpool_id = "${openstack_networking_subnetpool_v2.subnetpool_1.id}"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_2" {
+  name          = "subnet_2"
+  prefix_length = 32
+  enable_dhcp   = false
+  network_id    = "${openstack_networking_network_v2.network_1.id}"
+  subnetpool_id = "${openstack_networking_subnetpool_v2.subnetpool_1.id}"
 }
 `

--- a/website/docs/r/networking_subnet_v2.html.markdown
+++ b/website/docs/r/networking_subnet_v2.html.markdown
@@ -40,6 +40,11 @@ The following arguments are supported:
     version. You can omit this option if you are creating a subnet from a
     subnet pool.
 
+* `prefix_length` - (Optional) The prefix length to use when creating a subnet
+    from a subnet pool. The default subnet pool prefix length that was defined
+    when creating the subnet pool will be used if not provided. Changing this 
+    creates a new subnet.
+
 * `ip_version` - (Optional) IP version, either 4 (default) or 6. Changing this creates a
     new subnet.
 


### PR DESCRIPTION
Added the ability to define the required `prefix_length` when creating a subnet from a subnet pool.

Fixes #333 and fixes #702 

I have run the `TestAccNetworkingV2Subnet_` tests against my local devstack instance and there ar eno failures:
```bash
$ make testacc TEST=./openstack TESTARGS="-run=TestAccNetworkingV2Subnet_ -count=1"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./openstack -v -run=TestAccNetworkingV2Subnet_ -count=1 -timeout 120m
=== RUN   TestAccNetworkingV2Subnet_importBasic
--- PASS: TestAccNetworkingV2Subnet_importBasic (30.29s)
=== RUN   TestAccNetworkingV2Subnet_basic
--- PASS: TestAccNetworkingV2Subnet_basic (32.04s)
=== RUN   TestAccNetworkingV2Subnet_enableDHCP
--- PASS: TestAccNetworkingV2Subnet_enableDHCP (29.33s)
=== RUN   TestAccNetworkingV2Subnet_disableDHCP
--- PASS: TestAccNetworkingV2Subnet_disableDHCP (28.56s)
=== RUN   TestAccNetworkingV2Subnet_noGateway
--- PASS: TestAccNetworkingV2Subnet_noGateway (29.74s)
=== RUN   TestAccNetworkingV2Subnet_impliedGateway
--- PASS: TestAccNetworkingV2Subnet_impliedGateway (29.85s)
=== RUN   TestAccNetworkingV2Subnet_timeout
--- PASS: TestAccNetworkingV2Subnet_timeout (29.98s)
=== RUN   TestAccNetworkingV2Subnet_subnetPool
--- PASS: TestAccNetworkingV2Subnet_subnetPool (29.61s)
=== RUN   TestAccNetworkingV2Subnet_subnetPoolNoCIDR
--- PASS: TestAccNetworkingV2Subnet_subnetPoolNoCIDR (30.50s)
=== RUN   TestAccNetworkingV2Subnet_subnetPrefixLength
--- PASS: TestAccNetworkingV2Subnet_subnetPrefixLength (29.56s)
PASS
ok      github.com/dev-rowbot/terraform-provider-openstack/openstack    299.470s
```