### PR TITLE
 Internal: Use ErrDefault409 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/fatih/color v1.6.0 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
-	github.com/gophercloud/gophercloud v0.0.0-20190215023200-9e57e2f8ff0c
+	github.com/gophercloud/gophercloud v0.0.0-20190318015731-ff9851476e98
 	github.com/gophercloud/utils v0.0.0-20190212203534-6f24f46ce3c9
 	github.com/hashicorp/go-getter v0.0.0-20180425224130-3f60ec5cfbb2 // indirect
 	github.com/hashicorp/go-hclog v0.0.0-20180402200405-69ff559dc25f // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/googleapis/gax-go v0.0.0-20161107002406-da06d194a00e h1:CYRpN206UTHUi
 github.com/googleapis/gax-go v0.0.0-20161107002406-da06d194a00e/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/gophercloud/gophercloud v0.0.0-20190208042652-bc37892e1968/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gophercloud/gophercloud v0.0.0-20190212181753-892256c46858/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
-github.com/gophercloud/gophercloud v0.0.0-20190215023200-9e57e2f8ff0c h1:n8bk/luCIxJX+0emWRexjWxuR4CRfMWQuAZYjzkq5Ck=
-github.com/gophercloud/gophercloud v0.0.0-20190215023200-9e57e2f8ff0c/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
+github.com/gophercloud/gophercloud v0.0.0-20190318015731-ff9851476e98 h1:yVCQl8LUAduuT+xe+Wo+kq1lXQtMSPo+4EoOD9AIY0k=
+github.com/gophercloud/gophercloud v0.0.0-20190318015731-ff9851476e98/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/utils v0.0.0-20190128072930-fbb6ab446f01/go.mod h1:wjDF8z83zTeg5eMLml5EBSlAhbF7G8DobyI1YsMuyzw=
 github.com/gophercloud/utils v0.0.0-20190212203534-6f24f46ce3c9 h1:frK+RgSyzotPwHzxlbGO9aeM+zoQ4LgUfQbbynAAavw=
 github.com/gophercloud/utils v0.0.0-20190212203534-6f24f46ce3c9/go.mod h1:95GkZLE4Nob0I9L4qW5dWmyiekLwK3HsVAOV13XY9CY=

--- a/openstack/fw_policy_v1.go
+++ b/openstack/fw_policy_v1.go
@@ -26,13 +26,11 @@ func fwPolicyV1DeleteFunc(networkingClient *gophercloud.ServiceClient, id string
 			return "", "DELETED", nil
 		}
 
-		if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
-			if errCode.Actual == 409 {
-				// This error usually means that the policy is attached
-				// to a firewall. At this point, the firewall is probably
-				// being delete. So, we retry a few times.
-				return nil, "ACTIVE", nil
-			}
+		if _, ok := err.(gophercloud.ErrDefault409); ok {
+			// This error usually means that the policy is attached
+			// to a firewall. At this point, the firewall is probably
+			// being delete. So, we retry a few times.
+			return nil, "ACTIVE", nil
 		}
 
 		return nil, "ACTIVE", err

--- a/openstack/networking_network_v2.go
+++ b/openstack/networking_network_v2.go
@@ -81,10 +81,8 @@ func resourceNetworkingNetworkV2StateRefreshFunc(client *gophercloud.ServiceClie
 			if _, ok := err.(gophercloud.ErrDefault404); ok {
 				return n, "DELETED", nil
 			}
-			if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					return n, "ACTIVE", nil
-				}
+			if _, ok := err.(gophercloud.ErrDefault409); ok {
+				return n, "ACTIVE", nil
 			}
 
 			return n, "", err

--- a/openstack/networking_router_interface_v2.go
+++ b/openstack/networking_router_interface_v2.go
@@ -52,11 +52,9 @@ func resourceNetworkingRouterInterfaceV2DeleteRefreshFunc(networkingClient *goph
 				log.Printf("[DEBUG] Successfully deleted openstack_networking_router_interface_v2 %s", routerInterfaceID)
 				return r, "DELETED", nil
 			}
-			if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					log.Printf("[DEBUG] openstack_networking_router_interface_v2 %s is still in use", routerInterfaceID)
-					return r, "ACTIVE", nil
-				}
+			if _, ok := err.(gophercloud.ErrDefault409); ok {
+				log.Printf("[DEBUG] openstack_networking_router_interface_v2 %s is still in use", routerInterfaceID)
+				return r, "ACTIVE", nil
 			}
 
 			return r, "ACTIVE", err

--- a/openstack/networking_subnetpool_v2.go
+++ b/openstack/networking_subnetpool_v2.go
@@ -13,10 +13,8 @@ func networkingSubnetpoolV2StateRefreshFunc(client *gophercloud.ServiceClient, i
 			if _, ok := err.(gophercloud.ErrDefault404); ok {
 				return subnetpool, "DELETED", nil
 			}
-			if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					return subnetpool, "ACTIVE", nil
-				}
+			if _, ok := err.(gophercloud.ErrDefault409); ok {
+				return subnetpool, "ACTIVE", nil
 			}
 
 			return nil, "", err

--- a/openstack/resource_openstack_blockstorage_volume_v1.go
+++ b/openstack/resource_openstack_blockstorage_volume_v1.go
@@ -262,10 +262,8 @@ func resourceBlockStorageVolumeV1Delete(d *schema.ResourceData, meta interface{}
 
 				// A 409 is also acceptable because there's another
 				// concurrent action happening.
-				if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
-					if errCode.Actual == 409 {
-						continue
-					}
+				if _, ok := err.(gophercloud.ErrDefault409); ok {
+					continue
 				}
 
 				return fmt.Errorf(

--- a/openstack/resource_openstack_blockstorage_volume_v2.go
+++ b/openstack/resource_openstack_blockstorage_volume_v2.go
@@ -275,10 +275,8 @@ func resourceBlockStorageVolumeV2Delete(d *schema.ResourceData, meta interface{}
 
 				// A 409 is also acceptable because there's another
 				// concurrent action happening.
-				if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
-					if errCode.Actual == 409 {
-						continue
-					}
+				if _, ok := err.(gophercloud.ErrDefault409); ok {
+					continue
 				}
 
 				return fmt.Errorf(

--- a/openstack/resource_openstack_blockstorage_volume_v3.go
+++ b/openstack/resource_openstack_blockstorage_volume_v3.go
@@ -330,10 +330,8 @@ func resourceBlockStorageVolumeV3Delete(d *schema.ResourceData, meta interface{}
 
 				// A 409 is also acceptable because there's another
 				// concurrent action happening.
-				if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
-					if errCode.Actual == 409 {
-						continue
-					}
+				if _, ok := err.(gophercloud.ErrDefault409); ok {
+					continue
 				}
 
 				return fmt.Errorf(

--- a/openstack/resource_openstack_lb_monitor_v1.go
+++ b/openstack/resource_openstack_lb_monitor_v1.go
@@ -275,11 +275,9 @@ func waitForLBMonitorDelete(networkingClient *gophercloud.ServiceClient, monitor
 				return m, "DELETED", nil
 			}
 
-			if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					log.Printf("[DEBUG] OpenStack LB Monitor (%s) is waiting for Pool to delete.", monitorId)
-					return m, "PENDING", nil
-				}
+			if _, ok := err.(gophercloud.ErrDefault409); ok {
+				log.Printf("[DEBUG] OpenStack LB Monitor (%s) is waiting for Pool to delete.", monitorId)
+				return m, "PENDING", nil
 			}
 
 			return m, "ACTIVE", err
@@ -293,11 +291,9 @@ func waitForLBMonitorDelete(networkingClient *gophercloud.ServiceClient, monitor
 				return m, "DELETED", nil
 			}
 
-			if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					log.Printf("[DEBUG] OpenStack LB Monitor (%s) is waiting for Pool to delete.", monitorId)
-					return m, "PENDING", nil
-				}
+			if _, ok := err.(gophercloud.ErrDefault409); ok {
+				log.Printf("[DEBUG] OpenStack LB Monitor (%s) is waiting for Pool to delete.", monitorId)
+				return m, "PENDING", nil
 			}
 
 			return m, "ACTIVE", err

--- a/openstack/resource_openstack_networking_secgroup_v2.go
+++ b/openstack/resource_openstack_networking_secgroup_v2.go
@@ -235,10 +235,8 @@ func waitForSecGroupDelete(networkingClient *gophercloud.ServiceClient, secGroup
 				log.Printf("[DEBUG] Successfully deleted OpenStack Neutron Security Group %s", secGroupId)
 				return r, "DELETED", nil
 			}
-			if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					return r, "ACTIVE", nil
-				}
+			if _, ok := err.(gophercloud.ErrDefault409); ok {
+				return r, "ACTIVE", nil
 			}
 			return r, "ACTIVE", err
 		}

--- a/openstack/resource_openstack_networking_subnet_v2.go
+++ b/openstack/resource_openstack_networking_subnet_v2.go
@@ -508,10 +508,8 @@ func waitForSubnetDelete(networkingClient *gophercloud.ServiceClient, subnetId s
 				log.Printf("[DEBUG] Successfully deleted OpenStack Subnet %s", subnetId)
 				return s, "DELETED", nil
 			}
-			if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					return s, "ACTIVE", nil
-				}
+			if _, ok := err.(gophercloud.ErrDefault409); ok {
+				return s, "ACTIVE", nil
 			}
 			return s, "ACTIVE", err
 		}

--- a/openstack/resource_openstack_objectstorage_container_v1.go
+++ b/openstack/resource_openstack_objectstorage_container_v1.go
@@ -211,8 +211,8 @@ func resourceObjectStorageContainerV1Delete(d *schema.ResourceData, meta interfa
 
 	_, err = containers.Delete(objectStorageClient, d.Id()).Extract()
 	if err != nil {
-		gopherErr, ok := err.(gophercloud.ErrUnexpectedResponseCode)
-		if ok && gopherErr.Actual == 409 && d.Get("force_destroy").(bool) {
+		_, ok := err.(gophercloud.ErrDefault409)
+		if ok && d.Get("force_destroy").(bool) {
 			// Container may have things. Delete them.
 			log.Printf("[DEBUG] Attempting to forceDestroy Openstack container %+v", err)
 

--- a/openstack/resource_openstack_vpnaas_ipsec_policy_v2.go
+++ b/openstack/resource_openstack_vpnaas_ipsec_policy_v2.go
@@ -301,10 +301,8 @@ func waitForIPSecPolicyDeletion(networkingClient *gophercloud.ServiceClient, id 
 			return "", "DELETED", nil
 		}
 
-		if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
-			if errCode.Actual == 409 {
-				return nil, "ACTIVE", nil
-			}
+		if _, ok := err.(gophercloud.ErrDefault409); ok {
+			return nil, "ACTIVE", nil
 		}
 
 		return nil, "ACTIVE", err

--- a/openstack/util.go
+++ b/openstack/util.go
@@ -103,16 +103,13 @@ func FormatHeaders(headers http.Header, seperator string) string {
 }
 
 func checkForRetryableError(err error) *resource.RetryError {
-	switch errCode := err.(type) {
+	switch err.(type) {
 	case gophercloud.ErrDefault500:
 		return resource.RetryableError(err)
-	case gophercloud.ErrUnexpectedResponseCode:
-		switch errCode.Actual {
-		case 409, 503:
-			return resource.RetryableError(err)
-		default:
-			return resource.NonRetryableError(err)
-		}
+	case gophercloud.ErrDefault409:
+		return resource.RetryableError(err)
+	case gophercloud.ErrDefault503:
+		return resource.RetryableError(err)
 	default:
 		return resource.NonRetryableError(err)
 	}

--- a/vendor/github.com/gophercloud/gophercloud/.travis.yml
+++ b/vendor/github.com/gophercloud/gophercloud/.travis.yml
@@ -9,6 +9,7 @@ install:
 go:
 - "1.10"
 - "1.11"
+- "1.12"
 - "tip"
 env:
   global:

--- a/vendor/github.com/gophercloud/gophercloud/.zuul.yaml
+++ b/vendor/github.com/gophercloud/gophercloud/.zuul.yaml
@@ -14,6 +14,13 @@
     run: .zuul/playbooks/gophercloud-acceptance-test/run.yaml
 
 - job:
+    name: gophercloud-acceptance-test-ironic
+    parent: golang-test
+    description: |
+      Run gophercloud ironic acceptance test on master branch
+    run: .zuul/playbooks/gophercloud-acceptance-test-ironic/run.yaml
+
+- job:
     name: gophercloud-acceptance-test-queens
     parent: gophercloud-acceptance-test
     description: |
@@ -74,6 +81,7 @@
       jobs:
         - gophercloud-unittest
         - gophercloud-acceptance-test
+        - gophercloud-acceptance-test-ironic
     recheck-mitaka:
       jobs:
         - gophercloud-acceptance-test-mitaka

--- a/vendor/github.com/gophercloud/gophercloud/errors.go
+++ b/vendor/github.com/gophercloud/gophercloud/errors.go
@@ -122,6 +122,11 @@ type ErrDefault408 struct {
 	ErrUnexpectedResponseCode
 }
 
+// ErrDefault409 is the default error type returned on a 409 HTTP response code.
+type ErrDefault409 struct {
+	ErrUnexpectedResponseCode
+}
+
 // ErrDefault429 is the default error type returned on a 429 HTTP response code.
 type ErrDefault429 struct {
 	ErrUnexpectedResponseCode
@@ -209,6 +214,12 @@ type Err405er interface {
 // from a 408 error.
 type Err408er interface {
 	Error408(ErrUnexpectedResponseCode) error
+}
+
+// Err409er is the interface resource error types implement to override the error message
+// from a 409 error.
+type Err409er interface {
+	Error409(ErrUnexpectedResponseCode) error
 }
 
 // Err429er is the interface resource error types implement to override the error message

--- a/vendor/github.com/gophercloud/gophercloud/openstack/auth_env.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/auth_env.go
@@ -13,15 +13,19 @@ AuthOptionsFromEnv fills out an identity.AuthOptions structure with the
 settings found on the various OpenStack OS_* environment variables.
 
 The following variables provide sources of truth: OS_AUTH_URL, OS_USERNAME,
-OS_PASSWORD, OS_TENANT_ID, and OS_TENANT_NAME.
+OS_PASSWORD and OS_PROJECT_ID.
 
 Of these, OS_USERNAME, OS_PASSWORD, and OS_AUTH_URL must have settings,
-or an error will result.  OS_TENANT_ID, OS_TENANT_NAME, OS_PROJECT_ID, and
-OS_PROJECT_NAME are optional.
+or an error will result.  OS_PROJECT_ID, is optional.
 
-OS_TENANT_ID and OS_TENANT_NAME are mutually exclusive to OS_PROJECT_ID and
-OS_PROJECT_NAME. If OS_PROJECT_ID and OS_PROJECT_NAME are set, they will
-still be referred as "tenant" in Gophercloud.
+OS_TENANT_ID and OS_TENANT_NAME are deprecated forms of OS_PROJECT_ID and
+OS_PROJECT_NAME and the latter are expected against a v3 auth api.
+
+If OS_PROJECT_ID and OS_PROJECT_NAME are set, they will still be referred
+as "tenant" in Gophercloud.
+
+If OS_PROJECT_NAME is set, it requires OS_PROJECT_ID to be set as well to
+handle projects not on the default domain.
 
 To use this function, first set the OS_* environment variables (for example,
 by sourcing an `openrc` file), then:
@@ -79,6 +83,13 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 	if (applicationCredentialID != "" || applicationCredentialName != "") && applicationCredentialSecret == "" {
 		err := gophercloud.ErrMissingEnvironmentVariable{
 			EnvironmentVariable: "OS_APPLICATION_CREDENTIAL_SECRET",
+		}
+		return nilOptions, err
+	}
+
+	if domainID == "" && domainName == "" && tenantID == "" && tenantName != "" {
+		err := gophercloud.ErrMissingEnvironmentVariable{
+			EnvironmentVariable: "OS_PROJECT_ID",
 		}
 		return nilOptions, err
 	}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/results.go
@@ -77,6 +77,8 @@ type Volume struct {
 	ConsistencyGroupID string `json:"consistencygroup_id"`
 	// Multiattach denotes if the volume is multi-attach capable.
 	Multiattach bool `json:"multiattach"`
+	// Image metadata entries, only included for volumes that were created from an image, or from a snapshot of a volume originally created from an image.
+	VolumeImageMetadata map[string]string `json:"volume_image_metadata"`
 }
 
 // UnmarshalJSON another unmarshalling function

--- a/vendor/github.com/gophercloud/gophercloud/openstack/client.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/client.go
@@ -310,6 +310,12 @@ func NewBareMetalV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointO
 	return initClientOpts(client, eo, "baremetal")
 }
 
+// NewBareMetalIntrospectionV1 creates a ServiceClient that may be used with the v1
+// bare metal introspection package.
+func NewBareMetalIntrospectionV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "baremetal-inspector")
+}
+
 // NewObjectStorageV1 creates a ServiceClient that may be used with the v1
 // object storage package.
 func NewObjectStorageV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/flavors/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/flavors/requests.go
@@ -148,7 +148,7 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	return
 }
 
-// Get retrieves details of a single flavor. Use ExtractFlavor to convert its
+// Get retrieves details of a single flavor. Use Extract to convert its
 // result into a Flavor.
 func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/requests.go
@@ -183,8 +183,14 @@ type CreateOpts struct {
 	// AccessIPv4 specifies an IPv4 address for the instance.
 	AccessIPv4 string `json:"accessIPv4,omitempty"`
 
-	// AccessIPv6 pecifies an IPv6 address for the instance.
+	// AccessIPv6 specifies an IPv6 address for the instance.
 	AccessIPv6 string `json:"accessIPv6,omitempty"`
+
+	// Min specifies Minimum number of servers to launch.
+	Min int `json:"min_count,omitempty"`
+
+	// Max specifies Maximum number of servers to launch.
+	Max int `json:"max_count,omitempty"`
 
 	// ServiceClient will allow calls to be made to retrieve an image or
 	// flavor ID by name.
@@ -274,6 +280,14 @@ func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
 			return nil, err
 		}
 		b["flavorRef"] = flavorID
+	}
+
+	if opts.Min != 0 {
+		b["min_count"] = opts.Min
+	}
+
+	if opts.Max != 0 {
+		b["max_count"] = opts.Max
 	}
 
 	return map[string]interface{}{"server": b}, nil

--- a/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters/requests.go
@@ -136,9 +136,9 @@ const (
 )
 
 type UpdateOpts struct {
-	Op    UpdateOp `json:"op" required:"true"`
-	Path  string   `json:"path" required:"true"`
-	Value string   `json:"value,omitempty"`
+	Op    UpdateOp    `json:"op" required:"true"`
+	Path  string      `json:"path" required:"true"`
+	Value interface{} `json:"value,omitempty"`
 }
 
 // UpdateOptsBuilder allows extensions to add additional parameters to the

--- a/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates/requests.go
@@ -133,9 +133,9 @@ const (
 )
 
 type UpdateOpts struct {
-	Op    UpdateOp `json:"op" required:"true"`
-	Path  string   `json:"path" required:"true"`
-	Value string   `json:"value,omitempty"`
+	Op    UpdateOp    `json:"op" required:"true"`
+	Path  string      `json:"path" required:"true"`
+	Value interface{} `json:"value,omitempty"`
 }
 
 // UpdateOptsBuilder allows extensions to add additional parameters to the

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/applicationcredentials/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/applicationcredentials/requests.go
@@ -14,7 +14,7 @@ type ListOptsBuilder interface {
 // ListOpts provides options to filter the List results.
 type ListOpts struct {
 	// Name filters the response by an application credential name
-	Name string `json:"name"`
+	Name string `q:"name"`
 }
 
 // ToApplicationCredentialListQuery formats a ListOpts into a query string.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/requests.go
@@ -5,6 +5,12 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToFloatingIPListQuery() (string, error)
+}
+
 // ListOpts allows the filtering and sorting of paginated collections through
 // the API. Filtering is achieved by passing in struct field values that map to
 // the floating IP attributes you want to see returned. SortKey allows you to
@@ -31,16 +37,25 @@ type ListOpts struct {
 	NotTagsAny        string `q:"not-tags-any"`
 }
 
+// ToNetworkListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToFloatingIPListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
 // List returns a Pager which allows you to iterate over a collection of
 // floating IP resources. It accepts a ListOpts struct, which allows you to
 // filter and sort the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
-	q, err := gophercloud.BuildQueryString(&opts)
-	if err != nil {
-		return pagination.Pager{Err: err}
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(c)
+	if opts != nil {
+		query, err := opts.ToFloatingIPListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
 	}
-	u := rootURL(c) + q.String()
-	return pagination.NewPager(c, u, func(r pagination.PageResult) pagination.Page {
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
 		return FloatingIPPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/results.go
@@ -56,11 +56,13 @@ type commonResult struct {
 
 // Extract will extract a FloatingIP resource from a result.
 func (r commonResult) Extract() (*FloatingIP, error) {
-	var s struct {
-		FloatingIP *FloatingIP `json:"floatingip"`
-	}
+	var s FloatingIP
 	err := r.ExtractInto(&s)
-	return s.FloatingIP, err
+	return &s, err
+}
+
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "floatingip")
 }
 
 // CreateResult represents the result of a create operation. Call its Extract
@@ -122,4 +124,8 @@ func ExtractFloatingIPs(r pagination.Page) ([]FloatingIP, error) {
 	}
 	err := (r.(FloatingIPPage)).ExtractInto(&s)
 	return s.FloatingIPs, err
+}
+
+func ExtractFloatingIPsInto(r pagination.Page, v interface{}) error {
+	return r.(FloatingIPPage).Result.ExtractIntoSlicePtr(v, "floatingips")
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/results.go
@@ -8,7 +8,7 @@ import (
 // GatewayInfo represents the information of an external gateway for any
 // particular network router.
 type GatewayInfo struct {
-	NetworkID        string            `json:"network_id"`
+	NetworkID        string            `json:"network_id,omitempty"`
 	EnableSNAT       *bool             `json:"enable_snat,omitempty"`
 	ExternalFixedIPs []ExternalFixedIP `json:"external_fixed_ips,omitempty"`
 }

--- a/vendor/github.com/gophercloud/gophercloud/provider_client.go
+++ b/vendor/github.com/gophercloud/gophercloud/provider_client.go
@@ -2,6 +2,7 @@ package gophercloud
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -76,13 +77,21 @@ type ProviderClient struct {
 	// with the token and reauth func zeroed. Such client can be used to perform reauthorization.
 	Throwaway bool
 
+	// Context is the context passed to the HTTP request.
+	Context context.Context
+
+	// mut is a mutex for the client. It protects read and write access to client attributes such as getting
+	// and setting the TokenID.
 	mut *sync.RWMutex
 
+	// reauthmut is a mutex for reauthentication it attempts to ensure that only one reauthentication
+	// attempt happens at one time.
 	reauthmut *reauthlock
 
 	authResult AuthResult
 }
 
+// reauthlock represents a set of attributes used to help in the reauthentication process.
 type reauthlock struct {
 	sync.RWMutex
 	reauthing    bool
@@ -219,7 +228,7 @@ func (client *ProviderClient) Reauthenticate(previousToken string) (err error) {
 		return nil
 	}
 
-	if client.mut == nil {
+	if client.reauthmut == nil {
 		return client.ReauthFunc()
 	}
 
@@ -233,9 +242,6 @@ func (client *ProviderClient) Reauthenticate(previousToken string) (err error) {
 		return err
 	}
 	client.reauthmut.Unlock()
-
-	client.mut.Lock()
-	defer client.mut.Unlock()
 
 	client.reauthmut.Lock()
 	client.reauthmut.reauthing = true
@@ -311,6 +317,9 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return nil, err
+	}
+	if client.Context != nil {
+		req = req.WithContext(client.Context)
 	}
 
 	// Populate the request headers. Apply options.MoreHeaders last, to give the caller the chance to
@@ -433,6 +442,11 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 			err = ErrDefault408{respErr}
 			if error408er, ok := errType.(Err408er); ok {
 				err = error408er.Error408(respErr)
+			}
+		case http.StatusConflict:
+			err = ErrDefault409{respErr}
+			if error409er, ok := errType.(Err409er); ok {
+				err = error409er.Error409(respErr)
 			}
 		case 429:
 			err = ErrDefault429{respErr}

--- a/vendor/github.com/gophercloud/gophercloud/service_client.go
+++ b/vendor/github.com/gophercloud/gophercloud/service_client.go
@@ -131,6 +131,8 @@ func (client *ServiceClient) setMicroversionHeader(opts *RequestOpts) {
 		opts.MoreHeaders["X-OpenStack-Volume-API-Version"] = client.Microversion
 	case "baremetal":
 		opts.MoreHeaders["X-OpenStack-Ironic-API-Version"] = client.Microversion
+	case "baremetal-introspection":
+		opts.MoreHeaders["X-OpenStack-Ironic-Inspector-API-Version"] = client.Microversion
 	}
 
 	if client.Type != "" {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ github.com/golang/protobuf/ptypes
 github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
-# github.com/gophercloud/gophercloud v0.0.0-20190215023200-9e57e2f8ff0c
+# github.com/gophercloud/gophercloud v0.0.0-20190318015731-ff9851476e98
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/openstack
 github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions


### PR DESCRIPTION
This commit changes all 409 checks to use the new dedicated
gophercloud.ErrDefault409 type.