### PR TITLE
Remove fixed_ip_v6 from the network block

### DIFF
--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -376,9 +376,6 @@ The `network` block supports:
 * `fixed_ip_v4` - (Optional) Specifies a fixed IPv4 address to be used on this
     network. Changing this creates a new server.
 
-* `fixed_ip_v6` - (Optional) Specifies a fixed IPv6 address to be used on this
-    network. Changing this creates a new server.
-
 * `access_network` - (Optional) Specifies if this network should be used for
     provisioning access. Accepts true or false. Defaults to false.
 


### PR DESCRIPTION
Remove fixed_ip_v6 from the network block in 

As described in #732 `fixed_ip_v6` can't be specified. Is 'read-only'.

Resolves #732 