### PR TITLE
SharedFilesystem v2: Fix access validation rules

### DIFF
--- a/openstack/resource_openstack_sharedfilesystem_share_access_v2.go
+++ b/openstack/resource_openstack_sharedfilesystem_share_access_v2.go
@@ -51,7 +51,7 @@ func resourceSharedFilesystemShareAccessV2() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"ip", "user", "cert", "cephx",
-				}, true),
+				}, false),
 			},
 
 			"access_to": {
@@ -66,7 +66,7 @@ func resourceSharedFilesystemShareAccessV2() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"rw", "ro",
-				}, true),
+				}, false),
 			},
 
 			"access_key": {


### PR DESCRIPTION
This commit enforces case sensitivity on access_type and access_level.

Per discussion in #715 

/cc @kayrus 