### PR TITLE
 Networking v2: Deprecate subnet allocation_pools for allocation_pool

### DIFF
--- a/openstack/networking_subnet_v2.go
+++ b/openstack/networking_subnet_v2.go
@@ -1,0 +1,31 @@
+package openstack
+
+func networkingSubnetV2AllocationPoolsMatch(oldPools, newPools []interface{}) bool {
+	if len(oldPools) != len(newPools) {
+		return false
+	}
+
+	for _, newPool := range newPools {
+		var found bool
+
+		newPoolPool := newPool.(map[string]interface{})
+		newStart := newPoolPool["start"].(string)
+		newEnd := newPoolPool["end"].(string)
+
+		for _, oldPool := range oldPools {
+			oldPoolPool := oldPool.(map[string]interface{})
+			oldStart := oldPoolPool["start"].(string)
+			oldEnd := oldPoolPool["end"].(string)
+
+			if oldStart == newStart && oldEnd == newEnd {
+				found = true
+			}
+		}
+
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}

--- a/openstack/networking_subnet_v2_test.go
+++ b/openstack/networking_subnet_v2_test.go
@@ -1,0 +1,108 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNetworkingSubnetV2AllocationPoolsMatch(t *testing.T) {
+	oldPools := []interface{}{
+		map[string]interface{}{
+			"start": "192.168.199.2",
+			"end":   "192.168.199.100",
+		},
+
+		map[string]interface{}{
+			"start": "10.3.0.1",
+			"end":   "10.3.0.100",
+		},
+	}
+
+	newPools := []interface{}{
+		map[string]interface{}{
+			"start": "192.168.199.2",
+			"end":   "192.168.199.100",
+		},
+
+		map[string]interface{}{
+			"start": "10.3.0.1",
+			"end":   "10.3.0.100",
+		},
+	}
+
+	same := networkingSubnetV2AllocationPoolsMatch(oldPools, newPools)
+	assert.Equal(t, same, true)
+
+	oldPools = []interface{}{
+		map[string]interface{}{
+			"start": "192.168.199.2",
+			"end":   "192.168.199.100",
+		},
+	}
+
+	newPools = []interface{}{
+		map[string]interface{}{
+			"start": "192.168.199.2",
+			"end":   "192.168.199.100",
+		},
+
+		map[string]interface{}{
+			"start": "10.3.0.1",
+			"end":   "10.3.0.100",
+		},
+	}
+
+	same = networkingSubnetV2AllocationPoolsMatch(oldPools, newPools)
+	assert.Equal(t, same, false)
+
+	oldPools = []interface{}{
+		map[string]interface{}{
+			"start": "192.168.199.2",
+			"end":   "192.168.199.100",
+		},
+
+		map[string]interface{}{
+			"start": "10.3.0.1",
+			"end":   "10.3.0.100",
+		},
+	}
+
+	newPools = []interface{}{
+		map[string]interface{}{
+			"start": "10.3.0.1",
+			"end":   "10.3.0.100",
+		},
+	}
+
+	same = networkingSubnetV2AllocationPoolsMatch(oldPools, newPools)
+	assert.Equal(t, same, false)
+
+	oldPools = []interface{}{
+		map[string]interface{}{
+			"start": "192.168.199.10",
+			"end":   "192.168.199.150",
+		},
+
+		map[string]interface{}{
+			"start": "10.3.0.1",
+			"end":   "10.3.0.100",
+		},
+	}
+
+	newPools = []interface{}{
+		map[string]interface{}{
+			"start": "192.168.199.2",
+			"end":   "192.168.199.100",
+		},
+
+		map[string]interface{}{
+			"start": "10.3.0.1",
+			"end":   "10.3.0.100",
+		},
+	}
+
+	same = networkingSubnetV2AllocationPoolsMatch(oldPools, newPools)
+	assert.Equal(t, same, false)
+
+}

--- a/openstack/resource_openstack_networking_subnet_v2.go
+++ b/openstack/resource_openstack_networking_subnet_v2.go
@@ -613,32 +613,10 @@ func waitForSubnetDelete(networkingClient *gophercloud.ServiceClient, subnetId s
 func resourceSubnetV2AllocationPoolsCustomizeDiff(diff *schema.ResourceDiff) error {
 	if diff.Id() != "" && diff.HasChange("allocation_pools") {
 		o, n := diff.GetChange("allocation_pools")
-		oRaw := o.([]interface{})
-		nRaw := n.([]interface{})
+		oldPools := o.([]interface{})
+		newPools := n.([]interface{})
 
-		samePools := true
-
-		for _, newRaw := range nRaw {
-			var found bool
-
-			newRawPool := newRaw.(map[string]interface{})
-			newStart := newRawPool["start"].(string)
-			newEnd := newRawPool["end"].(string)
-
-			for _, oldRaw := range oRaw {
-				oldRawPool := oldRaw.(map[string]interface{})
-				oldStart := oldRawPool["start"].(string)
-				oldEnd := oldRawPool["end"].(string)
-
-				if oldStart == newStart && oldEnd == newEnd {
-					found = true
-				}
-			}
-
-			if !found {
-				samePools = false
-			}
-		}
+		samePools := networkingSubnetV2AllocationPoolsMatch(oldPools, newPools)
 
 		if samePools {
 			log.Printf("[DEBUG] allocation_pools have not changed. clearing diff")

--- a/openstack/resource_openstack_networking_subnet_v2.go
+++ b/openstack/resource_openstack_networking_subnet_v2.go
@@ -71,10 +71,11 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 				Computed: true,
 			},
 			"allocation_pools": {
-				Type:       schema.TypeList,
-				Optional:   true,
-				Computed:   true,
-				Deprecated: "use allocation_pool instead",
+				Type:          schema.TypeList,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"allocation_pool"},
+				Deprecated:    "use allocation_pool instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"start": {
@@ -89,9 +90,10 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 				},
 			},
 			"allocation_pool": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"allocation_pools"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"start": {

--- a/openstack/resource_openstack_networking_subnet_v2.go
+++ b/openstack/resource_openstack_networking_subnet_v2.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/terraform/helper/customdiff"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
@@ -70,7 +71,25 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 				Computed: true,
 			},
 			"allocation_pools": {
-				Type:     schema.TypeList,
+				Type:       schema.TypeList,
+				Optional:   true,
+				Computed:   true,
+				Deprecated: "use allocation_pool instead",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"start": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"end": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"allocation_pool": {
+				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -171,6 +190,13 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
+
+		CustomizeDiff: customdiff.Sequence(
+			// Clear the diff if the old and new allocation_pools are the same.
+			func(diff *schema.ResourceDiff, v interface{}) error {
+				return resourceSubnetV2AllocationPoolsCustomizeDiff(diff)
+			},
+		),
 	}
 }
 
@@ -193,7 +219,7 @@ func resourceNetworkingSubnetV2Create(d *schema.ResourceData, meta interface{}) 
 			TenantID:        d.Get("tenant_id").(string),
 			IPv6AddressMode: d.Get("ipv6_address_mode").(string),
 			IPv6RAMode:      d.Get("ipv6_ra_mode").(string),
-			AllocationPools: resourceSubnetAllocationPoolsV2(d),
+			AllocationPools: resourceSubnetAllocationPoolsCreateV2(d),
 			DNSNameservers:  resourceSubnetDNSNameserversV2(d),
 			HostRoutes:      resourceSubnetHostRoutesV2(d),
 			SubnetPoolID:    d.Get("subnetpool_id").(string),
@@ -305,6 +331,7 @@ func resourceNetworkingSubnetV2Read(d *schema.ResourceData, meta interface{}) er
 		allocationPools = append(allocationPools, pool)
 	}
 	d.Set("allocation_pools", allocationPools)
+	d.Set("allocation_pool", allocationPools)
 
 	// Set the subnet's Gateway IP.
 	gatewayIP := s.GatewayIP
@@ -380,9 +407,12 @@ func resourceNetworkingSubnetV2Update(d *schema.ResourceData, meta interface{}) 
 		updateOpts.EnableDHCP = &v
 	}
 
-	if d.HasChange("allocation_pools") {
+	if d.HasChange("allocation_pool") {
 		hasChange = true
-		updateOpts.AllocationPools = resourceSubnetAllocationPoolsV2(d)
+		updateOpts.AllocationPools = resourceSubnetAllocationPoolUpdateV2(d)
+	} else if d.HasChange("allocation_pools") {
+		hasChange = true
+		updateOpts.AllocationPools = resourceSubnetAllocationPoolsUpdateV2(d)
 	}
 
 	if hasChange {
@@ -431,8 +461,53 @@ func resourceNetworkingSubnetV2Delete(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func resourceSubnetAllocationPoolsV2(d *schema.ResourceData) []subnets.AllocationPool {
+// resourceSubnetAllocationPoolsCreateV2 returns a slice of allocation pools
+// when creating a subnet. It takes into account both the old allocation_pools
+// argument as well as the new allocation_pool argument.
+//
+// This can be modified to only account for allocation_pool when
+// allocation_pools is removed.
+func resourceSubnetAllocationPoolsCreateV2(d *schema.ResourceData) []subnets.AllocationPool {
+	// First check allocation_pools since that is the original,
+	// but deprecated, argument.
 	rawAPs := d.Get("allocation_pools").([]interface{})
+	if len(rawAPs) == 0 {
+		// Then check allocation_pool which is the new argument.
+		rawAPs = d.Get("allocation_pool").(*schema.Set).List()
+	}
+
+	aps := make([]subnets.AllocationPool, len(rawAPs))
+	for i, raw := range rawAPs {
+		rawMap := raw.(map[string]interface{})
+		aps[i] = subnets.AllocationPool{
+			Start: rawMap["start"].(string),
+			End:   rawMap["end"].(string),
+		}
+	}
+	return aps
+}
+
+// resourceSubnetAllocationPoolsUpdateV2 returns a slice of allocation pools
+// when modifying a subnet using the old allocation_pools argument.
+//
+// This can be removed when allocation_pools is removed.
+func resourceSubnetAllocationPoolsUpdateV2(d *schema.ResourceData) []subnets.AllocationPool {
+	rawAPs := d.Get("allocation_pools").([]interface{})
+	aps := make([]subnets.AllocationPool, len(rawAPs))
+	for i, raw := range rawAPs {
+		rawMap := raw.(map[string]interface{})
+		aps[i] = subnets.AllocationPool{
+			Start: rawMap["start"].(string),
+			End:   rawMap["end"].(string),
+		}
+	}
+	return aps
+}
+
+// resourceSubnetAllocationPoolUpdateV2 returns a slice of allocation pools
+// when modifying a subnet using the new allocation_pool argument.
+func resourceSubnetAllocationPoolUpdateV2(d *schema.ResourceData) []subnets.AllocationPool {
+	rawAPs := d.Get("allocation_pool").(*schema.Set).List()
 	aps := make([]subnets.AllocationPool, len(rawAPs))
 	for i, raw := range rawAPs {
 		rawMap := raw.(map[string]interface{})
@@ -532,4 +607,44 @@ func waitForSubnetDelete(networkingClient *gophercloud.ServiceClient, subnetId s
 		log.Printf("[DEBUG] OpenStack Subnet %s still active.\n", subnetId)
 		return s, "ACTIVE", nil
 	}
+}
+
+func resourceSubnetV2AllocationPoolsCustomizeDiff(diff *schema.ResourceDiff) error {
+	if diff.Id() != "" && diff.HasChange("allocation_pools") {
+		o, n := diff.GetChange("allocation_pools")
+		oRaw := o.([]interface{})
+		nRaw := n.([]interface{})
+
+		samePools := true
+
+		for _, newRaw := range nRaw {
+			var found bool
+
+			newRawPool := newRaw.(map[string]interface{})
+			newStart := newRawPool["start"].(string)
+			newEnd := newRawPool["end"].(string)
+
+			for _, oldRaw := range oRaw {
+				oldRawPool := oldRaw.(map[string]interface{})
+				oldStart := oldRawPool["start"].(string)
+				oldEnd := oldRawPool["end"].(string)
+
+				if oldStart == newStart && oldEnd == newEnd {
+					found = true
+				}
+			}
+
+			if !found {
+				samePools = false
+			}
+		}
+
+		if samePools {
+			log.Printf("[DEBUG] allocation_pools have not changed. clearing diff")
+			return diff.Clear("allocation_pools")
+		}
+
+	}
+
+	return nil
 }

--- a/openstack/resource_openstack_networking_subnet_v2.go
+++ b/openstack/resource_openstack_networking_subnet_v2.go
@@ -468,12 +468,13 @@ func resourceNetworkingSubnetV2Delete(d *schema.ResourceData, meta interface{}) 
 // This can be modified to only account for allocation_pool when
 // allocation_pools is removed.
 func resourceSubnetAllocationPoolsCreateV2(d *schema.ResourceData) []subnets.AllocationPool {
-	// First check allocation_pools since that is the original,
-	// but deprecated, argument.
-	rawAPs := d.Get("allocation_pools").([]interface{})
+	// First check allocation_pool since that is the new argument.
+	rawAPs := d.Get("allocation_pool").(*schema.Set).List()
+
 	if len(rawAPs) == 0 {
-		// Then check allocation_pool which is the new argument.
-		rawAPs = d.Get("allocation_pool").(*schema.Set).List()
+		// If no allocation_pool was specified, check allocation_pools
+		// which is the older legacy argument.
+		rawAPs = d.Get("allocation_pools").([]interface{})
 	}
 
 	aps := make([]subnets.AllocationPool, len(rawAPs))

--- a/openstack/resource_openstack_networking_subnet_v2_test.go
+++ b/openstack/resource_openstack_networking_subnet_v2_test.go
@@ -205,6 +205,73 @@ func TestAccNetworkingV2Subnet_subnetPrefixLength(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2Subnet_multipleAllocationPools(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2SubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2Subnet_multipleAllocationPools_1,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"openstack_networking_subnet_v2.subnet_1", "allocation_pools.#", "2"),
+				),
+			},
+			{
+				Config: testAccNetworkingV2Subnet_multipleAllocationPools_2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"openstack_networking_subnet_v2.subnet_1", "allocation_pools.#", "2"),
+				),
+			},
+			{
+				Config: testAccNetworkingV2Subnet_multipleAllocationPools_3,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"openstack_networking_subnet_v2.subnet_1", "allocation_pools.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2Subnet_allocationPool(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2SubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2Subnet_allocationPool_1,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"openstack_networking_subnet_v2.subnet_1", "allocation_pool.1804036869.start", "10.3.0.2"),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_subnet_v2.subnet_1", "allocation_pool.1804036869.end", "10.3.0.255"),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_subnet_v2.subnet_1", "allocation_pool.1586215448.start", "10.3.255.0"),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_subnet_v2.subnet_1", "allocation_pool.1586215448.end", "10.3.255.254"),
+				),
+			},
+			{
+				Config: testAccNetworkingV2Subnet_allocationPool_2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"openstack_networking_subnet_v2.subnet_1", "allocation_pool.1804036869.start", "10.3.0.2"),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_subnet_v2.subnet_1", "allocation_pool.1804036869.end", "10.3.0.255"),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_subnet_v2.subnet_1", "allocation_pool.2876574713.start", "10.3.255.10"),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_subnet_v2.subnet_1", "allocation_pool.2876574713.end", "10.3.255.154"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingV2SubnetDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
@@ -461,5 +528,120 @@ resource "openstack_networking_subnet_v2" "subnet_2" {
   enable_dhcp   = false
   network_id    = "${openstack_networking_network_v2.network_1.id}"
   subnetpool_id = "${openstack_networking_subnetpool_v2.subnetpool_1.id}"
+}
+`
+
+const testAccNetworkingV2Subnet_multipleAllocationPools_1 = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name = "subnet_1"
+  cidr = "10.3.0.0/16"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+
+  allocation_pools {
+    start = "10.3.0.2"
+    end = "10.3.0.255"
+  }
+
+  allocation_pools {
+    start = "10.3.255.0"
+    end = "10.3.255.254"
+  }
+}
+`
+
+const testAccNetworkingV2Subnet_multipleAllocationPools_2 = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name = "subnet_1"
+  cidr = "10.3.0.0/16"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+
+  allocation_pools {
+    start = "10.3.255.0"
+    end = "10.3.255.254"
+  }
+
+  allocation_pools {
+    start = "10.3.0.2"
+    end = "10.3.0.255"
+  }
+}
+`
+
+const testAccNetworkingV2Subnet_multipleAllocationPools_3 = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name = "subnet_1"
+  cidr = "10.3.0.0/16"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+
+  allocation_pools {
+    start = "10.3.255.10"
+    end = "10.3.255.154"
+  }
+
+  allocation_pools {
+    start = "10.3.0.2"
+    end = "10.3.0.255"
+  }
+}
+`
+
+const testAccNetworkingV2Subnet_allocationPool_1 = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name = "subnet_1"
+  cidr = "10.3.0.0/16"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+
+  allocation_pool {
+    start = "10.3.0.2"
+    end = "10.3.0.255"
+  }
+
+  allocation_pool {
+    start = "10.3.255.0"
+    end = "10.3.255.254"
+  }
+}
+`
+
+const testAccNetworkingV2Subnet_allocationPool_2 = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name = "subnet_1"
+  cidr = "10.3.0.0/16"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+
+  allocation_pools {
+    start = "10.3.255.10"
+    end = "10.3.255.154"
+  }
+
+  allocation_pools {
+    start = "10.3.0.2"
+    end = "10.3.0.255"
+  }
 }
 `

--- a/vendor/github.com/hashicorp/terraform/helper/customdiff/compose.go
+++ b/vendor/github.com/hashicorp/terraform/helper/customdiff/compose.go
@@ -1,0 +1,72 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// All returns a CustomizeDiffFunc that runs all of the given
+// CustomizeDiffFuncs and returns all of the errors produced.
+//
+// If one function produces an error, functions after it are still run.
+// If this is not desirable, use function Sequence instead.
+//
+// If multiple functions returns errors, the result is a multierror.
+//
+// For example:
+//
+//     &schema.Resource{
+//         // ...
+//         CustomizeDiff: customdiff.All(
+//             customdiff.ValidateChange("size", func (old, new, meta interface{}) error {
+//                 // If we are increasing "size" then the new value must be
+//                 // a multiple of the old value.
+//                 if new.(int) <= old.(int) {
+//                     return nil
+//                 }
+//                 if (new.(int) % old.(int)) != 0 {
+//                     return fmt.Errorf("new size value must be an integer multiple of old value %d", old.(int))
+//                 }
+//                 return nil
+//             }),
+//             customdiff.ForceNewIfChange("size", func (old, new, meta interface{}) bool {
+//                 // "size" can only increase in-place, so we must create a new resource
+//                 // if it is decreased.
+//                 return new.(int) < old.(int)
+//             }),
+//             customdiff.ComputedIf("version_id", func (d *schema.ResourceDiff, meta interface{}) bool {
+//                 // Any change to "content" causes a new "version_id" to be allocated.
+//                 return d.HasChange("content")
+//             }),
+//         ),
+//     }
+//
+func All(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		var err error
+		for _, f := range funcs {
+			thisErr := f(d, meta)
+			if thisErr != nil {
+				err = multierror.Append(err, thisErr)
+			}
+		}
+		return err
+	}
+}
+
+// Sequence returns a CustomizeDiffFunc that runs all of the given
+// CustomizeDiffFuncs in sequence, stopping at the first one that returns
+// an error and returning that error.
+//
+// If all functions succeed, the combined function also succeeds.
+func Sequence(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		for _, f := range funcs {
+			err := f(d, meta)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform/helper/customdiff/computed.go
+++ b/vendor/github.com/hashicorp/terraform/helper/customdiff/computed.go
@@ -1,0 +1,16 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// ComputedIf returns a CustomizeDiffFunc that sets the given key's new value
+// as computed if the given condition function returns true.
+func ComputedIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if f(d, meta) {
+			d.SetNewComputed(key)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform/helper/customdiff/condition.go
+++ b/vendor/github.com/hashicorp/terraform/helper/customdiff/condition.go
@@ -1,0 +1,60 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// ResourceConditionFunc is a function type that makes a boolean decision based
+// on an entire resource diff.
+type ResourceConditionFunc func(d *schema.ResourceDiff, meta interface{}) bool
+
+// ValueChangeConditionFunc is a function type that makes a boolean decision
+// by comparing two values.
+type ValueChangeConditionFunc func(old, new, meta interface{}) bool
+
+// ValueConditionFunc is a function type that makes a boolean decision based
+// on a given value.
+type ValueConditionFunc func(value, meta interface{}) bool
+
+// If returns a CustomizeDiffFunc that calls the given condition
+// function and then calls the given CustomizeDiffFunc only if the condition
+// function returns true.
+//
+// This can be used to include conditional customizations when composing
+// customizations using All and Sequence, but should generally be used only in
+// simple scenarios. Prefer directly writing a CustomizeDiffFunc containing
+// a conditional branch if the given CustomizeDiffFunc is already a
+// locally-defined function, since this avoids obscuring the control flow.
+func If(cond ResourceConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if cond(d, meta) {
+			return f(d, meta)
+		}
+		return nil
+	}
+}
+
+// IfValueChange returns a CustomizeDiffFunc that calls the given condition
+// function with the old and new values of the given key and then calls the
+// given CustomizeDiffFunc only if the condition function returns true.
+func IfValueChange(key string, cond ValueChangeConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		if cond(old, new, meta) {
+			return f(d, meta)
+		}
+		return nil
+	}
+}
+
+// IfValue returns a CustomizeDiffFunc that calls the given condition
+// function with the new values of the given key and then calls the
+// given CustomizeDiffFunc only if the condition function returns true.
+func IfValue(key string, cond ValueConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if cond(d.Get(key), meta) {
+			return f(d, meta)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform/helper/customdiff/doc.go
+++ b/vendor/github.com/hashicorp/terraform/helper/customdiff/doc.go
@@ -1,0 +1,11 @@
+// Package customdiff provides a set of reusable and composable functions
+// to enable more "declarative" use of the CustomizeDiff mechanism available
+// for resources in package helper/schema.
+//
+// The intent of these helpers is to make the intent of a set of diff
+// customizations easier to see, rather than lost in a sea of Go function
+// boilerplate. They should _not_ be used in situations where they _obscure_
+// intent, e.g. by over-using the composition functions where a single
+// function containing normal Go control flow statements would be more
+// straightforward.
+package customdiff

--- a/vendor/github.com/hashicorp/terraform/helper/customdiff/force_new.go
+++ b/vendor/github.com/hashicorp/terraform/helper/customdiff/force_new.go
@@ -1,0 +1,40 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// ForceNewIf returns a CustomizeDiffFunc that flags the given key as
+// requiring a new resource if the given condition function returns true.
+//
+// The return value of the condition function is ignored if the old and new
+// values of the field compare equal, since no attribute diff is generated in
+// that case.
+func ForceNewIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if f(d, meta) {
+			d.ForceNew(key)
+		}
+		return nil
+	}
+}
+
+// ForceNewIfChange returns a CustomizeDiffFunc that flags the given key as
+// requiring a new resource if the given condition function returns true.
+//
+// The return value of the condition function is ignored if the old and new
+// values compare equal, since no attribute diff is generated in that case.
+//
+// This function is similar to ForceNewIf but provides the condition function
+// only the old and new values of the given key, which leads to more compact
+// and explicit code in the common case where the decision can be made with
+// only the specific field value.
+func ForceNewIfChange(key string, f ValueChangeConditionFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		if f(old, new, meta) {
+			d.ForceNew(key)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform/helper/customdiff/validate.go
+++ b/vendor/github.com/hashicorp/terraform/helper/customdiff/validate.go
@@ -1,0 +1,38 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// ValueChangeValidationFunc is a function type that validates the difference
+// (or lack thereof) between two values, returning an error if the change
+// is invalid.
+type ValueChangeValidationFunc func(old, new, meta interface{}) error
+
+// ValueValidationFunc is a function type that validates a particular value,
+// returning an error if the value is invalid.
+type ValueValidationFunc func(value, meta interface{}) error
+
+// ValidateChange returns a CustomizeDiffFunc that applies the given validation
+// function to the change for the given key, returning any error produced.
+func ValidateChange(key string, f ValueChangeValidationFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		return f(old, new, meta)
+	}
+}
+
+// ValidateValue returns a CustomizeDiffFunc that applies the given validation
+// function to value of the given key, returning any error produced.
+//
+// This should generally not be used since it is functionally equivalent to
+// a validation function applied directly to the schema attribute in question,
+// but is provided for situations where composing multiple CustomizeDiffFuncs
+// together makes intent clearer than spreading that validation across the
+// schema.
+func ValidateValue(key string, f ValueValidationFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		val := d.Get(key)
+		return f(val, meta)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -204,6 +204,7 @@ github.com/hashicorp/logutils
 # github.com/hashicorp/terraform v0.11.12-beta1.0.20190212191339-ee1f8f9362f3
 github.com/hashicorp/terraform/plugin
 github.com/hashicorp/terraform/flatmap
+github.com/hashicorp/terraform/helper/customdiff
 github.com/hashicorp/terraform/helper/hashcode
 github.com/hashicorp/terraform/helper/mutexkv
 github.com/hashicorp/terraform/helper/pathorcontents

--- a/website/docs/r/networking_subnet_v2.html.markdown
+++ b/website/docs/r/networking_subnet_v2.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `prefix_length` - (Optional) The prefix length to use when creating a subnet
     from a subnet pool. The default subnet pool prefix length that was defined
-    when creating the subnet pool will be used if not provided. Changing this 
+    when creating the subnet pool will be used if not provided. Changing this
     creates a new subnet.
 
 * `ip_version` - (Optional) IP version, either 4 (default) or 6. Changing this creates a
@@ -63,9 +63,13 @@ The following arguments are supported:
 * `tenant_id` - (Optional) The owner of the subnet. Required if admin wants to
     create a subnet for another tenant. Changing this creates a new subnet.
 
-* `allocation_pools` - (Optional) An array of sub-ranges of CIDR available for
+* `allocation_pools` - (**Deprecated** - use `allocation_pool` instead)
+    An array of sub-ranges of CIDR available for dynamic allocation to ports.
+    The allocation_pools object structure is documented below.
+
+* `allocation_pool` - (Optional) An array of sub-ranges of CIDR available for
     dynamic allocation to ports. The allocation_pool object structure is
-    documented below. Changing this creates a new subnet.
+    documented below.
 
 * `gateway_ip` - (Optional)  Default gateway used by devices in this subnet.
     Leaving this blank and not setting `no_gateway` will cause a default
@@ -95,7 +99,13 @@ The following arguments are supported:
 
 * `tags` - (Optional) A set of string tags for the subnet.
 
-The `allocation_pools` block supports:
+The deprecated `allocation_pools` block supports:
+
+* `start` - (Required) The starting address.
+
+* `end` - (Required) The ending address.
+
+The `allocation_pool` block supports:
 
 * `start` - (Required) The starting address.
 


### PR DESCRIPTION
This commit deprecates the openstack_networking_subnet_v2
allocation_pools argument in favor of allocation_pool.

allocation_pool is a singular word which makes more sense to use
declaratively.

In addition, allocation_pools was originally a TypeList, but the
OpenStack API will not respect the ordering defined by the user for
multiple pools, which triggered unneeded diffs.

allocation_pool is now a TypeSet which accounts for an unordered
response.

For #729 

/cc @kayrus 