### PR TITLE
Support acceptance test against OpenStack Stein release in OpenLab

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -22,6 +22,9 @@
     recheck-rocky:
       jobs:
         - terraform-provider-openstack-acceptance-test-rocky
+    recheck-stein:
+      jobs:
+        - terraform-provider-openstack-acceptance-test-stein
     recheck-trove:
       jobs:
         - terraform-provider-openstack-acceptance-test-trove


### PR DESCRIPTION
Input comment "recheck stable/stein" in pull request comments, that
will trigger acceptance tests against OpenStack Stein release. OpenLab
will report test result in followint comments automatically.

Related: theopenlab/openlab#231