### PR TITLE
Internal: Networking V2 Secgroup Rule cleanup

### DIFF
--- a/openstack/networking_secgroup_rule_v2.go
+++ b/openstack/networking_secgroup_rule_v2.go
@@ -1,0 +1,102 @@
+package openstack
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func resourceNetworkingSecGroupRuleV2StateRefreshFunc(client *gophercloud.ServiceClient, sgRuleID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		sgRule, err := rules.Get(client, sgRuleID).Extract()
+		if err != nil {
+			if _, ok := err.(gophercloud.ErrDefault404); ok {
+				return sgRule, "DELETED", nil
+			}
+
+			return sgRule, "", err
+		}
+
+		return sgRule, "ACTIVE", nil
+	}
+}
+
+func resourceNetworkingSecGroupRuleV2Direction(direction string) (rules.RuleDirection, error) {
+	switch direction {
+	case string(rules.DirIngress):
+		return rules.DirIngress, nil
+	case string(rules.DirEgress):
+		return rules.DirEgress, nil
+	}
+
+	return "", fmt.Errorf("unknown direction for openstack_networking_secgroup_rule_v2: %s", direction)
+}
+
+func resourceNetworkingSecGroupRuleV2EtherType(etherType string) (rules.RuleEtherType, error) {
+	switch etherType {
+	case string(rules.EtherType4):
+		return rules.EtherType4, nil
+	case string(rules.EtherType6):
+		return rules.EtherType6, nil
+	}
+
+	return "", fmt.Errorf("unknown ether type for openstack_networking_secgroup_rule_v2: %s", etherType)
+}
+
+func resourceNetworkingSecGroupRuleV2Protocol(protocol string) (rules.RuleProtocol, error) {
+	switch protocol {
+	case string(rules.ProtocolAH):
+		return rules.ProtocolAH, nil
+	case string(rules.ProtocolDCCP):
+		return rules.ProtocolDCCP, nil
+	case string(rules.ProtocolEGP):
+		return rules.ProtocolEGP, nil
+	case string(rules.ProtocolESP):
+		return rules.ProtocolESP, nil
+	case string(rules.ProtocolGRE):
+		return rules.ProtocolGRE, nil
+	case string(rules.ProtocolICMP):
+		return rules.ProtocolICMP, nil
+	case string(rules.ProtocolIGMP):
+		return rules.ProtocolIGMP, nil
+	case string(rules.ProtocolIPv6Encap):
+		return rules.ProtocolIPv6Encap, nil
+	case string(rules.ProtocolIPv6Frag):
+		return rules.ProtocolIPv6Frag, nil
+	case string(rules.ProtocolIPv6ICMP):
+		return rules.ProtocolIPv6ICMP, nil
+	case string(rules.ProtocolIPv6NoNxt):
+		return rules.ProtocolIPv6NoNxt, nil
+	case string(rules.ProtocolIPv6Opts):
+		return rules.ProtocolIPv6Opts, nil
+	case string(rules.ProtocolIPv6Route):
+		return rules.ProtocolIPv6Route, nil
+	case string(rules.ProtocolOSPF):
+		return rules.ProtocolOSPF, nil
+	case string(rules.ProtocolPGM):
+		return rules.ProtocolPGM, nil
+	case string(rules.ProtocolRSVP):
+		return rules.ProtocolRSVP, nil
+	case string(rules.ProtocolSCTP):
+		return rules.ProtocolSCTP, nil
+	case string(rules.ProtocolTCP):
+		return rules.ProtocolTCP, nil
+	case string(rules.ProtocolUDP):
+		return rules.ProtocolUDP, nil
+	case string(rules.ProtocolUDPLite):
+		return rules.ProtocolUDPLite, nil
+	case string(rules.ProtocolVRRP):
+		return rules.ProtocolVRRP, nil
+	}
+
+	// If the protocol wasn't matched above, see if it's an integer.
+	_, err := strconv.Atoi(protocol)
+	if err == nil {
+		return rules.RuleProtocol(protocol), nil
+	}
+
+	return "", fmt.Errorf("unknown protocol for openstack_networking_secgroup_rule_v2: %s", protocol)
+}

--- a/openstack/networking_secgroup_rule_v2_test.go
+++ b/openstack/networking_secgroup_rule_v2_test.go
@@ -1,0 +1,100 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResourceNetworkingSecGroupRuleV2DirectionIngress(t *testing.T) {
+	expected := rules.DirIngress
+
+	actual, err := resourceNetworkingSecGroupRuleV2Direction("ingress")
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestResourceNetworkingSecGroupRuleV2DirectionEgress(t *testing.T) {
+	expected := rules.DirEgress
+
+	actual, err := resourceNetworkingSecGroupRuleV2Direction("egress")
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestResourceNetworkingSecGroupRuleV2DirectionUnknown(t *testing.T) {
+	actual, err := resourceNetworkingSecGroupRuleV2Direction("stuff")
+
+	assert.Error(t, err)
+	assert.Empty(t, actual)
+}
+
+func TestResourceNetworkingSecGroupRuleV2EtherType4(t *testing.T) {
+	expected := rules.EtherType4
+
+	actual, err := resourceNetworkingSecGroupRuleV2EtherType("IPv4")
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestResourceNetworkingSecGroupRuleV2EtherType6(t *testing.T) {
+	expected := rules.EtherType6
+
+	actual, err := resourceNetworkingSecGroupRuleV2EtherType("IPv6")
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestResourceNetworkingSecGroupRuleV2EtherTypeUnknown(t *testing.T) {
+	actual, err := resourceNetworkingSecGroupRuleV2EtherType("something")
+
+	assert.Error(t, err)
+	assert.Empty(t, actual)
+}
+
+func TestResourceNetworkingSecGroupRuleV2ProtocolString(t *testing.T) {
+	protocols := map[string]rules.RuleProtocol{
+		string(rules.ProtocolAH):        rules.ProtocolAH,
+		string(rules.ProtocolDCCP):      rules.ProtocolDCCP,
+		string(rules.ProtocolESP):       rules.ProtocolESP,
+		string(rules.ProtocolEGP):       rules.ProtocolEGP,
+		string(rules.ProtocolGRE):       rules.ProtocolGRE,
+		string(rules.ProtocolICMP):      rules.ProtocolICMP,
+		string(rules.ProtocolIGMP):      rules.ProtocolIGMP,
+		string(rules.ProtocolIPv6Encap): rules.ProtocolIPv6Encap,
+		string(rules.ProtocolIPv6Frag):  rules.ProtocolIPv6Frag,
+		string(rules.ProtocolIPv6ICMP):  rules.ProtocolIPv6ICMP,
+		string(rules.ProtocolIPv6NoNxt): rules.ProtocolIPv6NoNxt,
+		string(rules.ProtocolIPv6Opts):  rules.ProtocolIPv6Opts,
+		string(rules.ProtocolIPv6Route): rules.ProtocolIPv6Route,
+		string(rules.ProtocolOSPF):      rules.ProtocolOSPF,
+		string(rules.ProtocolPGM):       rules.ProtocolPGM,
+		string(rules.ProtocolRSVP):      rules.ProtocolRSVP,
+		string(rules.ProtocolSCTP):      rules.ProtocolSCTP,
+		string(rules.ProtocolTCP):       rules.ProtocolTCP,
+		string(rules.ProtocolUDP):       rules.ProtocolUDP,
+		string(rules.ProtocolUDPLite):   rules.ProtocolUDPLite,
+		string(rules.ProtocolVRRP):      rules.ProtocolVRRP,
+	}
+
+	for name, expected := range protocols {
+		actual, err := resourceNetworkingSecGroupRuleV2Protocol(name)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	}
+}
+
+func TestResourceNetworkingSecGroupRuleV2ProtocolNumber(t *testing.T) {
+	expected := rules.RuleProtocol("6")
+
+	actual, err := resourceNetworkingSecGroupRuleV2Protocol("6")
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}

--- a/openstack/resource_openstack_networking_secgroup_rule_v2.go
+++ b/openstack/resource_openstack_networking_secgroup_rule_v2.go
@@ -3,14 +3,12 @@ package openstack
 import (
 	"fmt"
 	"log"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 )
 
@@ -34,46 +32,54 @@ func resourceNetworkingSecGroupRuleV2() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: false,
 				ForceNew: true,
 			},
+
 			"direction": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
+
 			"ethertype": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
+
 			"port_range_min": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
+
 			"port_range_max": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
+
 			"protocol": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
+
 			"remote_group_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
+
 			"remote_ip_prefix": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -83,11 +89,13 @@ func resourceNetworkingSecGroupRuleV2() *schema.Resource {
 					return strings.ToLower(v.(string))
 				},
 			},
+
 			"security_group_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
+
 			"tenant_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -99,7 +107,6 @@ func resourceNetworkingSecGroupRuleV2() *schema.Resource {
 }
 
 func resourceNetworkingSecGroupRuleV2Create(d *schema.ResourceData, meta interface{}) error {
-
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
@@ -112,7 +119,7 @@ func resourceNetworkingSecGroupRuleV2Create(d *schema.ResourceData, meta interfa
 
 	if protocol == "" {
 		if portRangeMin != 0 || portRangeMax != 0 {
-			return fmt.Errorf("A protocol must be specified when using port_range_min and port_range_max")
+			return fmt.Errorf("A protocol must be specified when using port_range_min and port_range_max for openstack_networking_secgroup_rule_v2")
 		}
 	}
 
@@ -127,75 +134,86 @@ func resourceNetworkingSecGroupRuleV2Create(d *schema.ResourceData, meta interfa
 	}
 
 	if v, ok := d.GetOk("direction"); ok {
-		direction := resourceNetworkingSecGroupRuleV2DetermineDirection(v.(string))
+		direction, err := resourceNetworkingSecGroupRuleV2Direction(v.(string))
+		if err != nil {
+			return err
+		}
 		opts.Direction = direction
 	}
 
 	if v, ok := d.GetOk("ethertype"); ok {
-		ethertype := resourceNetworkingSecGroupRuleV2DetermineEtherType(v.(string))
+		ethertype, err := resourceNetworkingSecGroupRuleV2EtherType(v.(string))
+		if err != nil {
+			return err
+		}
 		opts.EtherType = ethertype
 	}
 
 	if v, ok := d.GetOk("protocol"); ok {
-		protocol := resourceNetworkingSecGroupRuleV2DetermineProtocol(v.(string))
+		protocol, err := resourceNetworkingSecGroupRuleV2Protocol(v.(string))
+		if err != nil {
+			return err
+		}
 		opts.Protocol = protocol
 	}
-	log.Printf("[DEBUG] Create OpenStack Neutron security group: %#v", opts)
 
-	security_group_rule, err := rules.Create(networkingClient, opts).Extract()
+	log.Printf("[DEBUG] openstack_networking_secgroup_rule_v2 create options: %#v", opts)
+
+	sgRule, err := rules.Create(networkingClient, opts).Extract()
 	if err != nil {
-		return err
+		return fmt.Errorf("Error creating openstack_networking_secgroup_rule_v2: %s", err)
 	}
 
-	log.Printf("[DEBUG] OpenStack Neutron Security Group Rule created: %#v", security_group_rule)
+	d.SetId(sgRule.ID)
 
-	d.SetId(security_group_rule.ID)
-
+	log.Printf("[DEBUG] Created openstack_networking_secgroup_rule_v2 %s: %#v", sgRule.ID, sgRule)
 	return resourceNetworkingSecGroupRuleV2Read(d, meta)
 }
 
 func resourceNetworkingSecGroupRuleV2Read(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] Retrieve information about security group rule: %s", d.Id())
-
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
-	security_group_rule, err := rules.Get(networkingClient, d.Id()).Extract()
-
+	sgRule, err := rules.Get(networkingClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "OpenStack Security Group Rule")
+		return CheckDeleted(d, err, "Error getting openstack_networking_secgroup_rule_v2")
 	}
-	d.Set("description", security_group_rule.Description)
-	d.Set("direction", security_group_rule.Direction)
-	d.Set("ethertype", security_group_rule.EtherType)
-	d.Set("protocol", security_group_rule.Protocol)
-	d.Set("port_range_min", security_group_rule.PortRangeMin)
-	d.Set("port_range_max", security_group_rule.PortRangeMax)
-	d.Set("remote_group_id", security_group_rule.RemoteGroupID)
-	d.Set("remote_ip_prefix", security_group_rule.RemoteIPPrefix)
-	d.Set("security_group_id", security_group_rule.SecGroupID)
-	d.Set("tenant_id", security_group_rule.TenantID)
+
+	log.Printf("[DEBUG] Retrieved openstack_networking_secgroup_rule_v2 %s: %#v", d.Id(), sgRule)
+
+	d.Set("description", sgRule.Description)
+	d.Set("direction", sgRule.Direction)
+	d.Set("ethertype", sgRule.EtherType)
+	d.Set("protocol", sgRule.Protocol)
+	d.Set("port_range_min", sgRule.PortRangeMin)
+	d.Set("port_range_max", sgRule.PortRangeMax)
+	d.Set("remote_group_id", sgRule.RemoteGroupID)
+	d.Set("remote_ip_prefix", sgRule.RemoteIPPrefix)
+	d.Set("security_group_id", sgRule.SecGroupID)
+	d.Set("tenant_id", sgRule.TenantID)
 	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceNetworkingSecGroupRuleV2Delete(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] Destroy security group rule: %s", d.Id())
-
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
+	if err := rules.Delete(networkingClient, d.Id()).ExtractErr(); err != nil {
+		return CheckDeleted(d, err, "Error deleting openstack_networking_secgroup_rule_v2")
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE"},
 		Target:     []string{"DELETED"},
-		Refresh:    waitForSecGroupRuleDelete(networkingClient, d.Id()),
+		Refresh:    resourceNetworkingSecGroupRuleV2StateRefreshFunc(networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      5 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -203,120 +221,9 @@ func resourceNetworkingSecGroupRuleV2Delete(d *schema.ResourceData, meta interfa
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error deleting OpenStack Neutron Security Group Rule: %s", err)
+		return fmt.Errorf("Error waiting for openstack_networking_secgroup_rule_v2 %s to delete: %s", d.Id(), err)
 	}
 
 	d.SetId("")
-	return err
-}
-
-func resourceNetworkingSecGroupRuleV2DetermineDirection(v string) rules.RuleDirection {
-	var direction rules.RuleDirection
-	switch v {
-	case "ingress":
-		direction = rules.DirIngress
-	case "egress":
-		direction = rules.DirEgress
-	}
-
-	return direction
-}
-
-func resourceNetworkingSecGroupRuleV2DetermineEtherType(v string) rules.RuleEtherType {
-	var etherType rules.RuleEtherType
-	switch v {
-	case "IPv4":
-		etherType = rules.EtherType4
-	case "IPv6":
-		etherType = rules.EtherType6
-	}
-
-	return etherType
-}
-
-func resourceNetworkingSecGroupRuleV2DetermineProtocol(v string) rules.RuleProtocol {
-	var protocol rules.RuleProtocol
-
-	// Check and see if the requested protocol matched a list of known protocol names.
-	switch v {
-	case "tcp":
-		protocol = rules.ProtocolTCP
-	case "udp":
-		protocol = rules.ProtocolUDP
-	case "icmp":
-		protocol = rules.ProtocolICMP
-	case "ah":
-		protocol = rules.ProtocolAH
-	case "dccp":
-		protocol = rules.ProtocolDCCP
-	case "egp":
-		protocol = rules.ProtocolEGP
-	case "esp":
-		protocol = rules.ProtocolESP
-	case "gre":
-		protocol = rules.ProtocolGRE
-	case "igmp":
-		protocol = rules.ProtocolIGMP
-	case "ipv6-encap":
-		protocol = rules.ProtocolIPv6Encap
-	case "ipv6-frag":
-		protocol = rules.ProtocolIPv6Frag
-	case "ipv6-icmp":
-		protocol = rules.ProtocolIPv6ICMP
-	case "ipv6-nonxt":
-		protocol = rules.ProtocolIPv6NoNxt
-	case "ipv6-opts":
-		protocol = rules.ProtocolIPv6Opts
-	case "ipv6-route":
-		protocol = rules.ProtocolIPv6Route
-	case "ospf":
-		protocol = rules.ProtocolOSPF
-	case "pgm":
-		protocol = rules.ProtocolPGM
-	case "rsvp":
-		protocol = rules.ProtocolRSVP
-	case "sctp":
-		protocol = rules.ProtocolSCTP
-	case "udplite":
-		protocol = rules.ProtocolUDPLite
-	case "vrrp":
-		protocol = rules.ProtocolVRRP
-	}
-
-	// If the protocol wasn't matched above, see if it's an integer.
-	if protocol == "" {
-		_, err := strconv.Atoi(v)
-		if err == nil {
-			protocol = rules.RuleProtocol(v)
-		}
-	}
-
-	return protocol
-}
-
-func waitForSecGroupRuleDelete(networkingClient *gophercloud.ServiceClient, secGroupRuleId string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		log.Printf("[DEBUG] Attempting to delete OpenStack Security Group Rule %s.\n", secGroupRuleId)
-
-		r, err := rules.Get(networkingClient, secGroupRuleId).Extract()
-		if err != nil {
-			if _, ok := err.(gophercloud.ErrDefault404); ok {
-				log.Printf("[DEBUG] Successfully deleted OpenStack Neutron Security Group Rule %s", secGroupRuleId)
-				return r, "DELETED", nil
-			}
-			return r, "ACTIVE", err
-		}
-
-		err = rules.Delete(networkingClient, secGroupRuleId).ExtractErr()
-		if err != nil {
-			if _, ok := err.(gophercloud.ErrDefault404); ok {
-				log.Printf("[DEBUG] Successfully deleted OpenStack Neutron Security Group Rule %s", secGroupRuleId)
-				return r, "DELETED", nil
-			}
-			return r, "ACTIVE", err
-		}
-
-		log.Printf("[DEBUG] OpenStack Neutron Security Group Rule %s still active.\n", secGroupRuleId)
-		return r, "ACTIVE", nil
-	}
+	return nil
 }


### PR DESCRIPTION
Update loging and error messages to use common format between resources.

Move Secgroup Rule helpers into openstack/networking_secgroup_rule_v2.go
and provide additional tests.

We're not adding validation.ValidateFunc for the "direction",
"ethertype" and "protocol" fields because we're checking and casting
those strings values to Gophercloud constants by ourselves.

For #456