### PR TITLE
Networking v2: Make port dns_name computed

### DIFF
--- a/openstack/resource_openstack_networking_port_v2.go
+++ b/openstack/resource_openstack_networking_port_v2.go
@@ -256,6 +256,7 @@ func resourceNetworkingPortV2() *schema.Resource {
 			"dns_name": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"dns_assignment": {


### PR DESCRIPTION
The OpenStack Compute service will set a port's dns_name to the name of
the instance when the OpenStack environment has the DNS extension
enabled. Because of this behavior, the dns_name needs to be set to
Computed or else the dns_name will be changed to an empty string on the
next apply.

For #742 