### PR TITLE
Make timeout for stop_before_destroy configurable

### DIFF
--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -897,7 +897,7 @@ func resourceComputeInstanceV2Delete(d *schema.ResourceData, meta interface{}) e
 				Pending:    []string{"ACTIVE"},
 				Target:     []string{"SHUTOFF"},
 				Refresh:    ServerV2StateRefreshFunc(computeClient, d.Id()),
-				Timeout:    3 * time.Minute,
+				Timeout:    d.Timeout(schema.TimeoutDelete),
 				Delay:      10 * time.Second,
 				MinTimeout: 3 * time.Second,
 			}


### PR DESCRIPTION
Some machines require more time to do graceful shutdown. Timeout is now hardcoded to three minutes, this PR makes this value configurable.