### PR TITLE
DNS v2: Fix issue where TTL was being cleared

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/fatih/color v1.6.0 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
-	github.com/gophercloud/gophercloud v0.0.0-20190427020117-60507118a582
+	github.com/gophercloud/gophercloud v0.0.0-20190509032623-7892efa714f1
 	github.com/gophercloud/utils v0.0.0-20190313033024-0bcc8e728cb5
 	github.com/hashicorp/go-getter v0.0.0-20180425224130-3f60ec5cfbb2 // indirect
 	github.com/hashicorp/go-hclog v0.0.0-20180402200405-69ff559dc25f // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO
 github.com/googleapis/gax-go v0.0.0-20161107002406-da06d194a00e/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/gophercloud/gophercloud v0.0.0-20190208042652-bc37892e1968/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gophercloud/gophercloud v0.0.0-20190212181753-892256c46858/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
-github.com/gophercloud/gophercloud v0.0.0-20190427020117-60507118a582 h1:04A8HIFV8Ix2XtGB6BiLpygW6ILmO8ZTc+fMnUDPCeo=
-github.com/gophercloud/gophercloud v0.0.0-20190427020117-60507118a582/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
+github.com/gophercloud/gophercloud v0.0.0-20190509032623-7892efa714f1 h1:arOt83fsdoK/BYJm4zQOS9YL3KmUsaAVbQx9nFvNPmg=
+github.com/gophercloud/gophercloud v0.0.0-20190509032623-7892efa714f1/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/utils v0.0.0-20190128072930-fbb6ab446f01/go.mod h1:wjDF8z83zTeg5eMLml5EBSlAhbF7G8DobyI1YsMuyzw=
 github.com/gophercloud/utils v0.0.0-20190313033024-0bcc8e728cb5 h1:8USoe8m65WcTOYy+MUu+EtLJJysSODnoNDNCEWhDMso=
 github.com/gophercloud/utils v0.0.0-20190313033024-0bcc8e728cb5/go.mod h1:SZ9FTKibIotDtCrxAU/evccoyu1yhKST6hgBvwTB5Eg=

--- a/openstack/resource_openstack_dns_recordset_v2.go
+++ b/openstack/resource_openstack_dns_recordset_v2.go
@@ -177,7 +177,8 @@ func resourceDNSRecordSetV2Update(d *schema.ResourceData, meta interface{}) erro
 
 	var updateOpts recordsets.UpdateOpts
 	if d.HasChange("ttl") {
-		updateOpts.TTL = d.Get("ttl").(int)
+		ttl := d.Get("ttl").(int)
+		updateOpts.TTL = &ttl
 	}
 
 	if d.HasChange("records") {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets/requests.go
@@ -122,7 +122,7 @@ type UpdateOpts struct {
 	Description *string `json:"description,omitempty"`
 
 	// TTL is the time to live of the RecordSet.
-	TTL int `json:"ttl,omitempty"`
+	TTL *int `json:"ttl,omitempty"`
 
 	// Records are the DNS records of the RecordSet.
 	Records []string `json:"records,omitempty"`
@@ -135,10 +135,17 @@ func (opts UpdateOpts) ToRecordSetUpdateMap() (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	if opts.TTL > 0 {
-		b["ttl"] = opts.TTL
-	} else {
-		b["ttl"] = nil
+	// If opts.TTL was actually set, use 0 as a special value to send "null",
+	// even though the result from the API is 0.
+	//
+	// Otherwise, don't send the TTL field.
+	if opts.TTL != nil {
+		ttl := *(opts.TTL)
+		if ttl > 0 {
+			b["ttl"] = ttl
+		} else {
+			b["ttl"] = nil
+		}
 	}
 
 	return b, nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ github.com/golang/protobuf/ptypes
 github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
-# github.com/gophercloud/gophercloud v0.0.0-20190427020117-60507118a582
+# github.com/gophercloud/gophercloud v0.0.0-20190509032623-7892efa714f1
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/openstack
 github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions


### PR DESCRIPTION
For https://github.com/gophercloud/gophercloud/issues/1562

Before vendor update:

```
--- FAIL: TestAccDNSV2RecordSet_ensureSameTTL (176.83s)
    testing.go:538: Step 1 error: Check failed: Check 2/2 error: openstack_dns_recordset_v2.recordset_1: Attribute 'ttl' expected "3000", got "0"
```

After vendor update:

```
--- PASS: TestAccDNSV2RecordSet_ensureSameTTL (166.49s)
PASS
ok      github.com/terraform-providers/terraform-provider-openstack/openstack   166.522s
```