### PR TITLE
Enable import instance

### DIFF
--- a/openstack/compute_instance_v2_networking.go
+++ b/openstack/compute_instance_v2_networking.go
@@ -10,11 +10,9 @@
 package openstack
 
 import (
-	"bytes"
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/tenantnetworks"
@@ -463,8 +461,6 @@ func flattenInstanceNetworks(
 	}
 
 	// Loop through all networks and addresses, merge relevant address details.
-	var buffer bytes.Buffer
-
 	for _, instanceNetwork := range allInstanceNetworks {
 		for _, instanceAddresses := range allInstanceAddresses {
 			// Skip if instanceAddresses has no NICs
@@ -486,17 +482,10 @@ func flattenInstanceNetworks(
 					"port":           instanceNetwork.Port,
 					"access_network": instanceNetwork.AccessNetwork,
 				}
-				buffer.WriteString(v["mac"].(string))
-				if v["port"].(string) != "" {
-					buffer.WriteString("P")
-				}
-				buffer.WriteString("_")
 				networks = append(networks, v)
 			}
 		}
-
 	}
-	os.Setenv("TF_MAC_IMPORT_ORDER", strings.TrimSuffix(buffer.String(), "_")) //For test pass, in other cases must be calcuated and set manually
 
 	log.Printf("[DEBUG] flattenInstanceNetworks: %#v", networks)
 	return networks, nil

--- a/openstack/compute_instance_v2_networking.go
+++ b/openstack/compute_instance_v2_networking.go
@@ -10,9 +10,11 @@
 package openstack
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/tenantnetworks"
@@ -461,6 +463,8 @@ func flattenInstanceNetworks(
 	}
 
 	// Loop through all networks and addresses, merge relevant address details.
+	var buffer bytes.Buffer
+
 	for _, instanceNetwork := range allInstanceNetworks {
 		for _, instanceAddresses := range allInstanceAddresses {
 			// Skip if instanceAddresses has no NICs
@@ -482,10 +486,17 @@ func flattenInstanceNetworks(
 					"port":           instanceNetwork.Port,
 					"access_network": instanceNetwork.AccessNetwork,
 				}
+				buffer.WriteString(v["mac"].(string))
+				if v["port"].(string) != "" {
+					buffer.WriteString("P")
+				}
+				buffer.WriteString("_")
 				networks = append(networks, v)
 			}
 		}
+
 	}
+	os.Setenv("TF_MAC_IMPORT_ORDER", strings.TrimSuffix(buffer.String(), "_")) //For test pass, in other cases must be calcuated and set manually
 
 	log.Printf("[DEBUG] flattenInstanceNetworks: %#v", networks)
 	return networks, nil

--- a/openstack/import_openstack_compute_instance_v2_test.go
+++ b/openstack/import_openstack_compute_instance_v2_test.go
@@ -1,0 +1,57 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccComputeV2Instance_importBasic(t *testing.T) {
+	resourceName := "openstack_compute_instance_v2.instance_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeV2Instance_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stop_before_destroy",
+					"force_delete",
+					"metadata",
+				},
+			},
+		},
+	})
+}
+func TestAccComputeV2Instance_importCrazyNICs(t *testing.T) {
+	resourceName := "openstack_compute_instance_v2.instance_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeV2Instance_crazyNICs,
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stop_before_destroy",
+					"force_delete",
+					"metadata",
+				},
+			},
+		},
+	})
+}

--- a/openstack/import_openstack_compute_instance_v2_test.go
+++ b/openstack/import_openstack_compute_instance_v2_test.go
@@ -31,7 +31,7 @@ func TestAccComputeV2Instance_importBasic(t *testing.T) {
 		},
 	})
 }
-func TestAccComputeV2Instance_importCrazyNICs(t *testing.T) {
+func TestAccComputeV2Instance_importbootFromVolumeForceNew_1(t *testing.T) {
 	resourceName := "openstack_compute_instance_v2.instance_1"
 
 	resource.Test(t, resource.TestCase{
@@ -40,7 +40,7 @@ func TestAccComputeV2Instance_importCrazyNICs(t *testing.T) {
 		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeV2Instance_crazyNICs,
+				Config: testAccComputeV2Instance_bootFromVolumeForceNew_1,
 			},
 			resource.TestStep{
 				ResourceName:      resourceName,


### PR DESCRIPTION
Openstack does not keep track of NIC order after creation
Therefor one must set TF_MAC_IMPORT_ORDER on import in the following format
mac1_mac2P where P tells that it was a specified port on creation time

Example TF_MAC_IMPORT_ORDER='fa:16:3e:cb:c3:88_fa:16:3e:fc:ba:c9P_fa:16:3e:d8:cc:4f' ./terraform import openstack_compute_instance_v2.basic d15f7427-d2ed-4474-a07d-2c7e087ec240
