### PR TITLE
Acc Tests: Update lowercase security group test

### DIFF
--- a/openstack/resource_openstack_compute_secgroup_v2_test.go
+++ b/openstack/resource_openstack_compute_secgroup_v2_test.go
@@ -137,7 +137,7 @@ func TestAccComputeV2SecGroup_lowerCaseCIDR(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2SecGroupExists("openstack_compute_secgroup_v2.sg_1", &secgroup),
 					resource.TestCheckResourceAttr(
-						"openstack_compute_secgroup_v2.sg_1", "rule.3862435458.cidr", "2001:558:fc00::/39"),
+						"openstack_compute_secgroup_v2.sg_1", "rule.768649014.cidr", "2001:558:fc00::/39"),
 				),
 			},
 		},
@@ -366,9 +366,9 @@ resource "openstack_compute_secgroup_v2" "sg_1" {
   name = "sg_1"
   description = "first test security group"
   rule {
-    from_port = 0
-    to_port = 0
-    ip_protocol = "icmp"
+    from_port = 22
+    to_port = 22
+    ip_protocol = "tcp"
     cidr = "2001:558:FC00::/39"
   }
 }


### PR DESCRIPTION
A recent update to Neutron will cause an ipv6 icmp security group rule
to be returned with a protocol of ipv6-icmp.

We can't update the test to use ipv6-icmp since Nova does not allow this
protocol type.

As a workaround, we change the protocol to tcp.

/cc @kayrus 