### PR TITLE
Networking V2: add QoS Policy datasource

### DIFF
--- a/openstack/data_source_openstack_networking_qos_policy_v2.go
+++ b/openstack/data_source_openstack_networking_qos_policy_v2.go
@@ -1,0 +1,170 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceNetworkingQoSPolicyV2() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNetworkingQoSPolicyV2Read,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: false,
+			},
+
+			"project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+				ForceNew: false,
+			},
+
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+				ForceNew: false,
+			},
+
+			"shared": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				ForceNew: false,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: false,
+			},
+
+			"is_default": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				ForceNew: false,
+			},
+
+			"revision_number": {
+				Type:     schema.TypeInt,
+				Computed: true,
+				ForceNew: false,
+			},
+
+			"tags": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"all_tags": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceNetworkingQoSPolicyV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	listOpts := policies.ListOpts{}
+
+	if v, ok := d.GetOk("name"); ok {
+		listOpts.Name = v.(string)
+	}
+
+	if v, ok := d.GetOk("project_id"); ok {
+		listOpts.ProjectID = v.(string)
+	}
+
+	if v, ok := d.GetOk("shared"); ok {
+		shared := v.(bool)
+		listOpts.Shared = &shared
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		listOpts.Description = v.(string)
+	}
+
+	if v, ok := d.GetOk("is_default"); ok {
+		isDefault := v.(bool)
+		listOpts.IsDefault = &isDefault
+	}
+
+	tags := networkV2AttributesTags(d)
+	if len(tags) > 0 {
+		listOpts.Tags = strings.Join(tags, ",")
+	}
+
+	pages, err := policies.List(networkingClient, listOpts).AllPages()
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve openstack_networking_qos_policy_v2: %s", err)
+	}
+
+	allPolicies, err := policies.ExtractPolicies(pages)
+	if err != nil {
+		return fmt.Errorf("Unable to extract openstack_networking_qos_policy_v2: %s", err)
+	}
+
+	if len(allPolicies) < 1 {
+		return fmt.Errorf("Your query returned no openstack_networking_qos_policy_v2. " +
+			"Please change your search criteria and try again.")
+	}
+
+	if len(allPolicies) > 1 {
+		return fmt.Errorf("Your query returned more than one openstack_networking_qos_policy_v2." +
+			" Please try a more specific search criteria")
+	}
+
+	policy := allPolicies[0]
+
+	log.Printf("[DEBUG] Retrieved openstack_networking_qos_policy_v2 %s: %+v", policy.ID, policy)
+	d.SetId(policy.ID)
+
+	d.Set("name", policy.Name)
+	d.Set("project_id", policy.ProjectID)
+	d.Set("shared", policy.Shared)
+	d.Set("is_default", policy.IsDefault)
+	d.Set("description", policy.Description)
+	d.Set("revision_number", policy.RevisionNumber)
+	d.Set("region", GetRegion(d, config))
+
+	if err := d.Set("created_at", policy.CreatedAt.Format(time.RFC3339)); err != nil {
+		log.Printf("[DEBUG] Unable to set openstack_networking_qos_policy_v2 created_at: %s", err)
+	}
+	if err := d.Set("updated_at", policy.UpdatedAt.Format(time.RFC3339)); err != nil {
+		log.Printf("[DEBUG] Unable to set openstack_networking_qos_policy_v2 updated_at: %s", err)
+	}
+
+	return nil
+}

--- a/openstack/data_source_openstack_networking_qos_policy_v2_test.go
+++ b/openstack/data_source_openstack_networking_qos_policy_v2_test.go
@@ -1,0 +1,97 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccNetworkingV2QoSPolicyDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2QoSPolicyDataSource,
+			},
+			{
+				Config: testAccOpenStackNetworkingQoSPolicyV2DataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingQoSPolicyV2DataSourceID("data.openstack_networking_qos_policy_v2.qos_policy_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_qos_policy_v2.qos_policy_1", "name", "qos_policy_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_qos_policy_v2.qos_policy_1", "description", "terraform qos policy acceptance test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2QoSPolicyDataSource_description(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2QoSPolicyDataSource,
+			},
+			{
+				Config: testAccOpenStackNetworkingQoSPolicyV2DataSource_description,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingQoSPolicyV2DataSourceID("data.openstack_networking_qos_policy_v2.qos_policy_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_qos_policy_v2.qos_policy_1", "name", "qos_policy_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_qos_policy_v2.qos_policy_1", "description", "terraform qos policy acceptance test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckNetworkingQoSPolicyV2DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find QoS policy data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("QoS policy data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccNetworkingV2QoSPolicyDataSource = `
+resource "openstack_networking_qos_policy_v2" "qos_policy_1" {
+  name        = "qos_policy_1"
+  description = "terraform qos policy acceptance test"
+}
+`
+
+var testAccOpenStackNetworkingQoSPolicyV2DataSource_basic = fmt.Sprintf(`
+%s
+
+data "openstack_networking_qos_policy_v2" "qos_policy_1" {
+  name = "${openstack_networking_qos_policy_v2.qos_policy_1.name}"
+}
+`, testAccNetworkingV2QoSPolicyDataSource)
+
+var testAccOpenStackNetworkingQoSPolicyV2DataSource_description = fmt.Sprintf(`
+%s
+
+data "openstack_networking_qos_policy_v2" "qos_policy_1" {
+  description = "${openstack_networking_qos_policy_v2.qos_policy_1.description}"
+}
+`, testAccNetworkingV2QoSPolicyDataSource)

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -238,6 +238,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_images_image_v2":                        dataSourceImagesImageV2(),
 			"openstack_networking_addressscope_v2":             dataSourceNetworkingAddressScopeV2(),
 			"openstack_networking_network_v2":                  dataSourceNetworkingNetworkV2(),
+			"openstack_networking_qos_policy_v2":               dataSourceNetworkingQoSPolicyV2(),
 			"openstack_networking_subnet_v2":                   dataSourceNetworkingSubnetV2(),
 			"openstack_networking_secgroup_v2":                 dataSourceNetworkingSecGroupV2(),
 			"openstack_networking_subnetpool_v2":               dataSourceNetworkingSubnetPoolV2(),

--- a/website/docs/d/networking_qos_policy_v2.html.markdown
+++ b/website/docs/d/networking_qos_policy_v2.html.markdown
@@ -1,0 +1,52 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_networking_qos_policy_v2"
+sidebar_current: "docs-openstack-datasource-networking-qos-policy-v2"
+description: |-
+  Get information on an OpenStack QoS Policy.
+---
+
+# openstack\_networking\_qos\_policy\_v2
+
+Use this data source to get the ID of an available OpenStack QoS policy.
+
+## Example Usage
+
+```hcl
+data "openstack_networking_qos_policy_v2" "qos_policy_1" {
+  name = "qos_policy_1"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional) The region in which to obtain the V2 Networking client.
+    A Networking client is needed to retrieve a QoS policy ID. If omitted, the
+    `region` argument of the provider is used.
+
+* `name` - (Optional) The name of the QoS policy.
+
+* `project_id` - (Optional) The owner of the QoS policy.
+
+* `shared` - (Optional) Whether this QoS policy is shared across all projects.
+
+* `description` - (Optional) The human-readable description for the QoS policy.
+
+* `is_default` - (Optional) Whether the QoS policy is default policy or not.
+
+* `tags` - (Optional) The list of QoS policy tags to filter.
+
+## Attributes Reference
+
+`id` is set to the ID of the found QoS policy. In addition, the following attributes
+are exported:
+
+* `region` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `created_at` -  The time at which QoS policy was created.
+* `updated_at` - The time at which QoS policy was created.
+* `shared` - See Argument Reference above.
+* `description` - See Argument Reference above.
+* `is_default` - See Argument Reference above.
+* `revision_number` - The revision number of the QoS policy.
+* `all_tags` - The set of string tags applied on the QoS policy.

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -73,6 +73,9 @@
             <li<%= sidebar_current("docs-openstack-datasource-networking-network-v2") %>>
               <a href="/docs/providers/openstack/d/networking_network_v2.html">openstack_networking_network_v2</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-datasource-networking-qos-policy-v2") %>>
+              <a href="/docs/providers/openstack/d/networking_qos_policy_v2.html">openstack_networking_qos_policy_v2</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-datasource-networking-router-v2") %>>
               <a href="/docs/providers/openstack/d/networking_router_v2.html">openstack_networking_router_v2</a>
             </li>


### PR DESCRIPTION
Implement openstack_networking_qos_policy_v2 datasource with tests and
website documentation.

For #760 