### PR TITLE
Networking V2: add QoS policy field for Network

### DIFF
--- a/openstack/networking_network_v2.go
+++ b/openstack/networking_network_v2.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/mtu"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/provider"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vlantransparent"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/pagination"
@@ -25,6 +26,7 @@ type networkExtended struct {
 	portsecurity.PortSecurityExt
 	mtu.NetworkMTUExt
 	dns.NetworkDNSExt
+	policies.QoSPolicyExt
 }
 
 // networkingNetworkV2ID retrieves network ID by the provided name.

--- a/website/docs/r/networking_network_v2.html.markdown
+++ b/website/docs/r/networking_network_v2.html.markdown
@@ -119,6 +119,8 @@ The following arguments are supported:
     extension is enabled. The `dns_domain` of a network in conjunction with the
     `dns_name` attribute of its ports will be published in an external DNS
     service when Neutron is configured to integrate with such a service.
+    
+* `qos_policy_id` - (Optional) Reference to the associated QoS policy.
 
 The `segments` block supports:
 
@@ -145,6 +147,7 @@ The following attributes are exported:
 * `port_security_enabled` - See Argument Reference above.
 * `mtu` - See Argument Reference above.
 * `dns_domain` - See Argument Reference above.
+* `qos_policy_id` - See Argument Reference above.
 
 ## Import
 


### PR DESCRIPTION
Add "qos_policy_id" attribute for "openstack_networking_network_v2"
resource.

Update tests and docs.

For #760 