### PR TITLE
Networking V2: add QoS policy field for Port

### DIFF
--- a/openstack/networking_port_v2.go
+++ b/openstack/networking_port_v2.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/extradhcpopts"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsbinding"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -23,6 +24,7 @@ type portExtended struct {
 	portsecurity.PortSecurityExt
 	portsbinding.PortsBindingExt
 	dns.PortDNSExt
+	policies.QoSPolicyExt
 }
 
 func resourceNetworkingPortV2StateRefreshFunc(client *gophercloud.ServiceClient, portID string) resource.StateRefreshFunc {

--- a/website/docs/r/networking_port_v2.html.markdown
+++ b/website/docs/r/networking_port_v2.html.markdown
@@ -142,6 +142,8 @@ The following arguments are supported:
 
 * `dns_name` - (Optional) The port DNS name. Available, when Neutron DNS extension
     is enabled.
+    
+* `qos_policy_id` - (Optional) Reference to the associated QoS policy.
 
 The `fixed_ip` block supports:
 
@@ -208,6 +210,7 @@ The following attributes are exported:
 * `binding` - See Argument Reference above.
 * `dns_name` - See Argument Reference above.
 * `dns_assignment` - The list of maps representing port DNS assignments.
+* `qos_policy_id` - See Argument Reference above.
 
 ## Import
 


### PR DESCRIPTION
Add "qos_policy_id" attribute for "openstack_networking_port_v2"
resource.

Update tests and docs.

For #760, #246 