### PR TITLE
Networking V2: group QoS policy imports

### DIFF
--- a/openstack/networking_qos_policy_v2.go
+++ b/openstack/networking_qos_policy_v2.go
@@ -1,9 +1,10 @@
 package openstack
 
 import (
+	"github.com/hashicorp/terraform/helper/resource"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies"
-	"github.com/hashicorp/terraform/helper/resource"
 )
 
 // QoSPolicyCreateOpts represents the attributes used when creating a new QoS policy.

--- a/openstack/resource_openstack_networking_qos_policy_v2.go
+++ b/openstack/resource_openstack_networking_qos_policy_v2.go
@@ -5,10 +5,11 @@ import (
 	"log"
 	"time"
 
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies"
 )
 
 func resourceNetworkingQoSPolicyV2() *schema.Resource {

--- a/openstack/resource_openstack_networking_qos_policy_v2_test.go
+++ b/openstack/resource_openstack_networking_qos_policy_v2_test.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies"
 )
 
 func TestAccNetworkingV2QoSPolicyBasic(t *testing.T) {


### PR DESCRIPTION
Groups imports for "openstack_networking_qos_policy" resource the same
way as it done for other resources.