### PR TITLE
Networking V2: add QoS DSCP marking rule resource

### DIFF
--- a/openstack/import_openstack_networking_qos_dscp_marking_rule_v2_test.go
+++ b/openstack/import_openstack_networking_qos_dscp_marking_rule_v2_test.go
@@ -1,0 +1,31 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccNetworkingV2QoSDSCPMarkingRule_importBasic(t *testing.T) {
+	resourceName := "openstack_networking_qos_dscp_marking_rule_v2.dscp_marking_rule_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2QoSDSCPMarkingRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2QoSDSCPMarkingRule_basic,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/openstack/networking_qos_rule_v2.go
+++ b/openstack/networking_qos_rule_v2.go
@@ -40,3 +40,21 @@ func networkingQoSBandwidthLimitRuleV2StateRefreshFunc(client *gophercloud.Servi
 		return policy, "ACTIVE", nil
 	}
 }
+
+func networkingQoSDSCPMarkingRuleV2StateRefreshFunc(client *gophercloud.ServiceClient, policyID, ruleID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		policy, err := rules.GetDSCPMarkingRule(client, policyID, ruleID).ExtractDSCPMarkingRule()
+		if err != nil {
+			if _, ok := err.(gophercloud.ErrDefault404); ok {
+				return policy, "DELETED", nil
+			}
+			if _, ok := err.(gophercloud.ErrDefault409); ok {
+				return policy, "ACTIVE", nil
+			}
+
+			return nil, "", err
+		}
+
+		return policy, "ACTIVE", nil
+	}
+}

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -303,6 +303,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_networking_port_v2":                     resourceNetworkingPortV2(),
 			"openstack_networking_port_secgroup_associate_v2":  resourceNetworkingPortSecGroupAssociateV2(),
 			"openstack_networking_qos_bandwidth_limit_rule_v2": resourceNetworkingQoSBandwidthLimitRuleV2(),
+			"openstack_networking_qos_dscp_marking_rule_v2":    resourceNetworkingQoSDSCPMarkingRuleV2(),
 			"openstack_networking_qos_policy_v2":               resourceNetworkingQoSPolicyV2(),
 			"openstack_networking_router_v2":                   resourceNetworkingRouterV2(),
 			"openstack_networking_router_interface_v2":         resourceNetworkingRouterInterfaceV2(),

--- a/openstack/resource_openstack_networking_qos_dscp_marking_rule_v2.go
+++ b/openstack/resource_openstack_networking_qos_dscp_marking_rule_v2.go
@@ -1,0 +1,177 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/rules"
+)
+
+func resourceNetworkingQoSDSCPMarkingRuleV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNetworkingQoSDSCPMarkingRuleV2Create,
+		Read:   resourceNetworkingQoSDSCPMarkingRuleV2Read,
+		Update: resourceNetworkingQoSDSCPMarkingRuleV2Update,
+		Delete: resourceNetworkingQoSDSCPMarkingRuleV2Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"qos_policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"dscp_mark": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: false,
+			},
+		},
+	}
+}
+
+func resourceNetworkingQoSDSCPMarkingRuleV2Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	createOpts := rules.CreateDSCPMarkingRuleOpts{
+		DSCPMark: d.Get("dscp_mark").(int),
+	}
+	qosPolicyID := d.Get("qos_policy_id").(string)
+
+	log.Printf("[DEBUG] openstack_networking_qos_dscp_marking_rule_v2 create options: %#v", createOpts)
+	r, err := rules.CreateDSCPMarkingRule(networkingClient, qosPolicyID, createOpts).ExtractDSCPMarkingRule()
+	if err != nil {
+		return fmt.Errorf("Error creating openstack_networking_qos_dscp_marking_rule_v2: %s", err)
+	}
+
+	log.Printf("[DEBUG] Waiting for openstack_networking_qos_dscp_marking_rule_v2 %s to become available.", r.ID)
+
+	stateConf := &resource.StateChangeConf{
+		Target:     []string{"ACTIVE"},
+		Refresh:    networkingQoSDSCPMarkingRuleV2StateRefreshFunc(networkingClient, qosPolicyID, r.ID),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for openstack_networking_qos_dscp_marking_rule_v2 %s to become available: %s", r.ID, err)
+	}
+
+	id := resourceNetworkingQoSRuleV2BuildID(qosPolicyID, r.ID)
+	d.SetId(id)
+
+	log.Printf("[DEBUG] Created openstack_networking_qos_dscp_marking_rule_v2 %s: %#v", id, r)
+
+	return resourceNetworkingQoSDSCPMarkingRuleV2Read(d, meta)
+}
+
+func resourceNetworkingQoSDSCPMarkingRuleV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	qosPolicyID, qosRuleID, err := resourceNetworkingQoSRuleV2ParseID(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error reading openstack_networking_qos_dscp_marking_rule_v2 ID %s: %s", d.Id(), err)
+	}
+
+	r, err := rules.GetDSCPMarkingRule(networkingClient, qosPolicyID, qosRuleID).ExtractDSCPMarkingRule()
+	if err != nil {
+		return CheckDeleted(d, err, "Error getting openstack_networking_qos_dscp_marking_rule_v2")
+	}
+
+	log.Printf("[DEBUG] Retrieved openstack_networking_qos_dscp_marking_rule_v2 %s: %#v", d.Id(), r)
+
+	d.Set("qos_policy_id", qosPolicyID)
+	d.Set("dscp_mark", r.DSCPMark)
+	d.Set("region", GetRegion(d, config))
+
+	return nil
+}
+
+func resourceNetworkingQoSDSCPMarkingRuleV2Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	qosPolicyID, qosRuleID, err := resourceNetworkingQoSRuleV2ParseID(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error reading openstack_networking_qos_dscp_marking_rule_v2 ID %s: %s", d.Id(), err)
+	}
+
+	if d.HasChange("dscp_mark") {
+		dscpMark := d.Get("dscp_mark").(int)
+		updateOpts := rules.UpdateDSCPMarkingRuleOpts{
+			DSCPMark: &dscpMark,
+		}
+		log.Printf("[DEBUG] openstack_networking_qos_dscp_marking_rule_v2 %s update options: %#v", d.Id(), updateOpts)
+		_, err = rules.UpdateDSCPMarkingRule(networkingClient, qosPolicyID, qosRuleID, updateOpts).ExtractDSCPMarkingRule()
+		if err != nil {
+			return fmt.Errorf("Error updating openstack_networking_qos_dscp_marking_rule_v2 %s: %s", d.Id(), err)
+		}
+	}
+
+	return resourceNetworkingQoSDSCPMarkingRuleV2Read(d, meta)
+}
+
+func resourceNetworkingQoSDSCPMarkingRuleV2Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	qosPolicyID, qosRuleID, err := resourceNetworkingQoSRuleV2ParseID(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error reading openstack_networking_qos_dscp_marking_rule_v2 ID %s: %s", d.Id(), err)
+	}
+
+	if err := rules.DeleteDSCPMarkingRule(networkingClient, qosPolicyID, qosRuleID).ExtractErr(); err != nil {
+		return CheckDeleted(d, err, "Error getting openstack_networking_qos_dscp_marking_rule_v2")
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"ACTIVE"},
+		Target:     []string{"DELETED"},
+		Refresh:    networkingQoSDSCPMarkingRuleV2StateRefreshFunc(networkingClient, qosPolicyID, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for openstack_networking_qos_dscp_marking_rule_v2 %s to delete: %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/openstack/resource_openstack_networking_qos_dscp_marking_rule_v2_test.go
+++ b/openstack/resource_openstack_networking_qos_dscp_marking_rule_v2_test.go
@@ -1,0 +1,143 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/rules"
+)
+
+func TestAccNetworkingV2QoSDSCPMarkingRule_basic(t *testing.T) {
+	var (
+		policy policies.Policy
+		rule   rules.DSCPMarkingRule
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2QoSDSCPMarkingRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2QoSDSCPMarkingRule_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2QoSPolicyExists(
+						"openstack_networking_qos_policy_v2.qos_policy_1", &policy),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_qos_policy_v2.qos_policy_1", "name", "qos_policy_1"),
+					testAccCheckNetworkingV2QoSDSCPMarkingRuleExists(
+						"openstack_networking_qos_dscp_marking_rule_v2.dscp_marking_rule_1", &rule),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_qos_dscp_marking_rule_v2.dscp_marking_rule_1", "dscp_mark", "26"),
+				),
+			},
+			{
+				Config: testAccNetworkingV2QoSDSCPMarkingRule_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2QoSPolicyExists(
+						"openstack_networking_qos_policy_v2.qos_policy_1", &policy),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_qos_policy_v2.qos_policy_1", "name", "qos_policy_1"),
+					testAccCheckNetworkingV2QoSDSCPMarkingRuleExists(
+						"openstack_networking_qos_dscp_marking_rule_v2.dscp_marking_rule_1", &rule),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_qos_dscp_marking_rule_v2.dscp_marking_rule_1", "dscp_mark", "20"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckNetworkingV2QoSDSCPMarkingRuleExists(n string, rule *rules.DSCPMarkingRule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+		}
+
+		qosPolicyID, qosRuleID, err := resourceNetworkingQoSRuleV2ParseID(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error reading openstack_networking_qos_dscp_marking_rule_v2 ID %s: %s", rs.Primary.ID, err)
+		}
+
+		found, err := rules.GetDSCPMarkingRule(networkingClient, qosPolicyID, qosRuleID).ExtractDSCPMarkingRule()
+		if err != nil {
+			return err
+		}
+
+		foundID := resourceNetworkingQoSRuleV2BuildID(qosPolicyID, found.ID)
+
+		if foundID != rs.Primary.ID {
+			return fmt.Errorf("QoS dscp marking rule not found")
+		}
+
+		*rule = *found
+
+		return nil
+	}
+}
+
+func testAccCheckNetworkingV2QoSDSCPMarkingRuleDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "openstack_networking_qos_dscp_marking_rule_v2" {
+			continue
+		}
+
+		qosPolicyID, qosRuleID, err := resourceNetworkingQoSRuleV2ParseID(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error reading openstack_networking_qos_dscp_marking_rule_v2 ID %s: %s", rs.Primary.ID, err)
+		}
+
+		_, err = rules.GetDSCPMarkingRule(networkingClient, qosPolicyID, qosRuleID).ExtractDSCPMarkingRule()
+		if err == nil {
+			return fmt.Errorf("QoS rule still exists")
+		}
+	}
+
+	return nil
+}
+
+const testAccNetworkingV2QoSDSCPMarkingRule_basic = `
+resource "openstack_networking_qos_policy_v2" "qos_policy_1" {
+  name = "qos_policy_1"
+}
+
+resource "openstack_networking_qos_dscp_marking_rule_v2" "dscp_marking_rule_1" {
+  qos_policy_id  = "${openstack_networking_qos_policy_v2.qos_policy_1.id}"
+  dscp_mark      = 26
+}
+`
+
+const testAccNetworkingV2QoSDSCPMarkingRule_update = `
+resource "openstack_networking_qos_policy_v2" "qos_policy_1" {
+  name = "qos_policy_1"
+}
+
+resource "openstack_networking_qos_dscp_marking_rule_v2" "dscp_marking_rule_1" {
+  qos_policy_id  = "${openstack_networking_qos_policy_v2.qos_policy_1.id}"
+  dscp_mark      = 20
+}
+`

--- a/website/docs/r/networking_qos_dscp_marking_rule_v2.html.markdown
+++ b/website/docs/r/networking_qos_dscp_marking_rule_v2.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_networking_qos_dscp_marking_rule_v2"
+sidebar_current: "docs-openstack-resource-networking-qos-dscp-marking-rule-v2"
+description: |-
+  Manages a V2 Neutron QoS DSCP marking rule resource within OpenStack.
+---
+
+# openstack\_networking\_qos\_dscp\_marking\_rule\_v2
+
+Manages a V2 Neutron QoS DSCP marking rule resource within OpenStack.
+
+## Example Usage
+
+### Create a QoS Policy with some DSCP marking rule
+
+```hcl
+resource "openstack_networking_qos_policy_v2" "qos_policy_1" {
+  name        = "qos_policy_1"
+  description = "dscp_mark"
+}
+
+resource "openstack_networking_qos_dscp_marking_rule_v2" "dscp_marking_rule_1" {
+  qos_policy_id  = "${openstack_networking_qos_policy_v2.qos_policy_1.id}"
+  dscp_mark      = 26
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional) The region in which to obtain the V2 Networking client.
+    A Networking client is needed to create a Neutron QoS DSCP marking rule. If omitted, the
+    `region` argument of the provider is used. Changing this creates a new QoS DSCP marking rule.
+    
+* `qos_policy_id` - (Required) The QoS policy reference. Changing this creates a new QoS DSCP marking rule.
+   
+* `dscp_mark` - (Required) The value of DSCP mark. Changing this updates the DSCP mark value existing
+    QoS DSCP marking rule.
+    
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `qos_policy_id` - See Argument Reference above.
+* `dscp_mark` - See Argument Reference above.
+
+## Import
+
+QoS DSCP marking rules can be imported using the `qos_policy_id/dscp_marking_rule_id` format, e.g.
+
+```
+$ terraform import openstack_networking_qos_dscp_marking_rule_v2.dscp_marking_rule_1 d6ae28ce-fcb5-4180-aa62-d260a27e09ae/46dfb556-b92f-48ce-94c5-9a9e2140de94
+```

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -264,6 +264,9 @@
             <li<%= sidebar_current("docs-openstack-resource-networking-qos-bandwidth-limit-rule-v2") %>>
               <a href="/docs/providers/openstack/r/networking_qos_bandwidth_limit_rule_v2.html">openstack_networking_qos_bandwidth_limit_rule_v2</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-resource-networking-qos-dscp-marking-rule-v2") %>>
+              <a href="/docs/providers/openstack/r/networking_qos_dscp_marking_rule_v2.html">openstack_networking_qos_dscp_marking_rule_v2</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-resource-networking-qos-policy-v2") %>>
               <a href="/docs/providers/openstack/r/networking_qos_policy_v2.html">openstack_networking_qos_policy_v2</a>
             </li>


### PR DESCRIPTION
Add "openstack_networking_qos_dscp_marking_rule_v2" resource with
tests and website documentation.

For #760 