### PR TITLE
Networking V2: add QoS bw limit rule datasource

### DIFF
--- a/openstack/data_source_openstack_networking_qos_bandwidth_limit_rule_v2.go
+++ b/openstack/data_source_openstack_networking_qos_bandwidth_limit_rule_v2.go
@@ -1,0 +1,104 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/rules"
+)
+
+func dataSourceNetworkingQoSBandwidthLimitRuleV2() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNetworkingQoSBandwidthLimitRuleV2Read,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"qos_policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"max_kbps": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: false,
+			},
+
+			"max_burst_kbps": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: false,
+			},
+
+			"direction": {
+				Type:     schema.TypeString,
+				Computed: true,
+				ForceNew: false,
+			},
+		},
+	}
+}
+
+func dataSourceNetworkingQoSBandwidthLimitRuleV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	listOpts := rules.BandwidthLimitRulesListOpts{}
+
+	if v, ok := d.GetOk("max_kbps"); ok {
+		listOpts.MaxKBps = v.(int)
+	}
+
+	if v, ok := d.GetOk("max_burst_kbps"); ok {
+		listOpts.MaxBurstKBps = v.(int)
+	}
+
+	qosPolicyID := d.Get("qos_policy_id").(string)
+
+	pages, err := rules.ListBandwidthLimitRules(networkingClient, qosPolicyID, listOpts).AllPages()
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve openstack_networking_qos_bandwidth_limit_rule_v2: %s", err)
+	}
+
+	allRules, err := rules.ExtractBandwidthLimitRules(pages)
+	if err != nil {
+		return fmt.Errorf("Unable to extract openstack_networking_qos_bandwidth_limit_rule_v2: %s", err)
+	}
+
+	if len(allRules) < 1 {
+		return fmt.Errorf("Your query returned no openstack_networking_qos_bandwidth_limit_rule_v2. " +
+			"Please change your search criteria and try again.")
+	}
+
+	if len(allRules) > 1 {
+		return fmt.Errorf("Your query returned more than one openstack_networking_qos_bandwidth_limit_rule_v2." +
+			" Please try a more specific search criteria")
+	}
+
+	rule := allRules[0]
+	id := resourceNetworkingQoSRuleV2BuildID(qosPolicyID, rule.ID)
+
+	log.Printf("[DEBUG] Retrieved openstack_networking_qos_bandwidth_limit_rule_v2 %s: %+v", id, rule)
+	d.SetId(id)
+
+	d.Set("qos_policy_id", qosPolicyID)
+	d.Set("max_kbps", rule.MaxKBps)
+	d.Set("max_burst_kbps", rule.MaxBurstKBps)
+	d.Set("direction", rule.Direction)
+	d.Set("region", GetRegion(d, config))
+
+	return nil
+}

--- a/openstack/data_source_openstack_networking_qos_bandwidth_limit_rule_v2_test.go
+++ b/openstack/data_source_openstack_networking_qos_bandwidth_limit_rule_v2_test.go
@@ -1,0 +1,94 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccNetworkingV2QoSBandwidthLimitRuleDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2QoSBandwidthLimitRule_dataSource,
+			},
+			{
+				Config: testAccOpenStackNetworkingQoSBandwidthLimitRuleV2DataSource_max_kbps,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingQoSBandwidthLimitRuleV2DataSourceID("data.openstack_networking_qos_bandwidth_limit_rule_v2.bw_limit_rule_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_qos_bandwidth_limit_rule_v2.bw_limit_rule_1", "max_kbps", "3000"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_qos_bandwidth_limit_rule_v2.bw_limit_rule_1", "max_burst_kbps", "300"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_qos_bandwidth_limit_rule_v2.bw_limit_rule_1", "direction", "egress"),
+				),
+			},
+			{
+				Config: testAccOpenStackNetworkingQoSBandwidthLimitRuleV2DataSource_max_burst_kbps,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingQoSBandwidthLimitRuleV2DataSourceID("data.openstack_networking_qos_bandwidth_limit_rule_v2.bw_limit_rule_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_qos_bandwidth_limit_rule_v2.bw_limit_rule_1", "max_kbps", "3000"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_qos_bandwidth_limit_rule_v2.bw_limit_rule_1", "max_burst_kbps", "300"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_qos_bandwidth_limit_rule_v2.bw_limit_rule_1", "direction", "egress"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckNetworkingQoSBandwidthLimitRuleV2DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find QoS bw limit data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("QoS bw limit data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccNetworkingV2QoSBandwidthLimitRule_dataSource = `
+resource "openstack_networking_qos_policy_v2" "qos_policy_1" {
+  name = "qos_policy_1"
+}
+
+resource "openstack_networking_qos_bandwidth_limit_rule_v2" "bw_limit_rule_1" {
+  qos_policy_id  = "${openstack_networking_qos_policy_v2.qos_policy_1.id}"
+  max_kbps       = 3000
+  max_burst_kbps = 300
+  direction      = "egress"
+}
+`
+
+var testAccOpenStackNetworkingQoSBandwidthLimitRuleV2DataSource_max_kbps = fmt.Sprintf(`
+%s
+
+data "openstack_networking_qos_bandwidth_limit_rule_v2" "bw_limit_rule_1" {
+  qos_policy_id = "${openstack_networking_qos_policy_v2.qos_policy_1.id}"
+  max_kbps      = "${openstack_networking_qos_bandwidth_limit_rule_v2.bw_limit_rule_1.max_kbps}"
+}
+`, testAccNetworkingV2QoSBandwidthLimitRule_dataSource)
+
+var testAccOpenStackNetworkingQoSBandwidthLimitRuleV2DataSource_max_burst_kbps = fmt.Sprintf(`
+%s
+
+data "openstack_networking_qos_bandwidth_limit_rule_v2" "bw_limit_rule_1" {
+  qos_policy_id  = "${openstack_networking_qos_policy_v2.qos_policy_1.id}"
+  max_burst_kbps = "${openstack_networking_qos_bandwidth_limit_rule_v2.bw_limit_rule_1.max_burst_kbps}"
+}
+`, testAccNetworkingV2QoSBandwidthLimitRule_dataSource)

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -238,6 +238,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_images_image_v2":                        dataSourceImagesImageV2(),
 			"openstack_networking_addressscope_v2":             dataSourceNetworkingAddressScopeV2(),
 			"openstack_networking_network_v2":                  dataSourceNetworkingNetworkV2(),
+			"openstack_networking_qos_bandwidth_limit_rule_v2": dataSourceNetworkingQoSBandwidthLimitRuleV2(),
 			"openstack_networking_qos_policy_v2":               dataSourceNetworkingQoSPolicyV2(),
 			"openstack_networking_subnet_v2":                   dataSourceNetworkingSubnetV2(),
 			"openstack_networking_secgroup_v2":                 dataSourceNetworkingSecGroupV2(),

--- a/website/docs/d/networking_qos_bandwidth_limit_rule_v2.html.markdown
+++ b/website/docs/d/networking_qos_bandwidth_limit_rule_v2.html.markdown
@@ -1,0 +1,45 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_networking_qos_bandwidth_limit_rule_v2"
+sidebar_current: "docs-openstack-datasource-networking-qos-bandwidth-limit-rule-v2"
+description: |-
+  Get information on an OpenStack QoS Bandwidth limit rule.
+---
+
+# openstack\_networking\_qos\_bandwidth\_limit\_rule\_v2
+
+Use this data source to get the ID of an available OpenStack QoS bandwidth limit rule.
+
+## Example Usage
+
+```hcl
+data "openstack_networking_qos_bandwidth_limit_rule_v2" "qos_bandwidth_limit_rule_1" {
+  max_kbps = 300
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional) The region in which to obtain the V2 Networking client.
+    A Networking client is needed to create a Neutron QoS bandwidth limit rule. If omitted, the
+    `region` argument of the provider is used.
+    
+* `qos_policy_id` - (Required) The QoS policy reference.
+   
+* `max_kbps` - (Optional) The maximum kilobits per second of a QoS bandwidth limit rule.
+
+* `max_burst_kbps` - (Optional) The maximum burst size in kilobits of a QoS bandwidth limit rule.
+   
+* `direction` - (Optional) The direction of traffic.
+
+
+## Attributes Reference
+
+`id` is set to the `qos_policy_id/bandwidth_limit_rule_id` format of the found QoS bandwidth limit rule.
+In addition, the following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `qos_policy_id` - See Argument Reference above.
+* `max_kbps` - See Argument Reference above.
+* `max_burst_kbps` - See Argument Reference above.
+* `direction` - See Argument Reference above.

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -73,6 +73,9 @@
             <li<%= sidebar_current("docs-openstack-datasource-networking-network-v2") %>>
               <a href="/docs/providers/openstack/d/networking_network_v2.html">openstack_networking_network_v2</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-datasource-networking-qos-bandwidth-limit-rule-v2") %>>
+              <a href="/docs/providers/openstack/d/networking_qos_bandwidth_limit_rule_v2.html">openstack_networking_qos_bandwidth_limit_rule_v2</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-datasource-networking-qos-policy-v2") %>>
               <a href="/docs/providers/openstack/d/networking_qos_policy_v2.html">openstack_networking_qos_policy_v2</a>
             </li>


### PR DESCRIPTION
Implement openstack_networking_qos_bandwidth_limit_rule_v2 datasource
with tests and website documentation.

For #760 