### PR TITLE
Networking V2: add QoS dscp marking datasource

### DIFF
--- a/openstack/data_source_networking_qos_dscp_marking_rule_v2.go
+++ b/openstack/data_source_networking_qos_dscp_marking_rule_v2.go
@@ -1,0 +1,84 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/rules"
+)
+
+func dataSourceNetworkingQoSDSCPMarkingRuleV2() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNetworkingQoSDSCPMarkingRuleV2Read,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"qos_policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"dscp_mark": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: false,
+			},
+		},
+	}
+}
+
+func dataSourceNetworkingQoSDSCPMarkingRuleV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	listOpts := rules.DSCPMarkingRulesListOpts{}
+
+	if v, ok := d.GetOk("dscp_mark"); ok {
+		listOpts.DSCPMark = v.(int)
+	}
+
+	qosPolicyID := d.Get("qos_policy_id").(string)
+
+	pages, err := rules.ListDSCPMarkingRules(networkingClient, qosPolicyID, listOpts).AllPages()
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve openstack_networking_qos_dscp_marking_rule_v2: %s", err)
+	}
+
+	allRules, err := rules.ExtractDSCPMarkingRules(pages)
+	if err != nil {
+		return fmt.Errorf("Unable to extract openstack_networking_qos_dscp_marking_rule_v2: %s", err)
+	}
+
+	if len(allRules) < 1 {
+		return fmt.Errorf("Your query returned no openstack_networking_qos_dscp_marking_rule_v2. " +
+			"Please change your search criteria and try again.")
+	}
+
+	if len(allRules) > 1 {
+		return fmt.Errorf("Your query returned more than one openstack_networking_qos_dscp_marking_rule_v2." +
+			" Please try a more specific search criteria")
+	}
+
+	rule := allRules[0]
+	id := resourceNetworkingQoSRuleV2BuildID(qosPolicyID, rule.ID)
+
+	log.Printf("[DEBUG] Retrieved openstack_networking_qos_dscp_marking_rule_v2 %s: %+v", id, rule)
+	d.SetId(id)
+
+	d.Set("qos_policy_id", qosPolicyID)
+	d.Set("dscp_mark", rule.DSCPMark)
+	d.Set("region", GetRegion(d, config))
+
+	return nil
+}

--- a/openstack/data_source_networking_qos_dscp_marking_rule_v2_test.go
+++ b/openstack/data_source_networking_qos_dscp_marking_rule_v2_test.go
@@ -1,0 +1,65 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccNetworkingV2QoSDSCPMarkingRuleDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2QoSDSCPMarkingRule_dataSource,
+			},
+			{
+				Config: testAccOpenStackNetworkingQoSDSCPMarkingRuleV2DataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingQoSDSCPMarkingRuleV2DataSourceID("data.openstack_networking_qos_dscp_marking_rule_v2.dscp_mark_rule_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_qos_dscp_marking_rule_v2.dscp_mark_rule_1", "dscp_mark", "26"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckNetworkingQoSDSCPMarkingRuleV2DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find QoS DSCP marking data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("QoS DSCP marking data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccNetworkingV2QoSDSCPMarkingRule_dataSource = `
+resource "openstack_networking_qos_policy_v2" "qos_policy_1" {
+  name = "qos_policy_1"
+}
+resource "openstack_networking_qos_dscp_marking_rule_v2" "dscp_mark_rule_1" {
+  qos_policy_id  = "${openstack_networking_qos_policy_v2.qos_policy_1.id}"
+  dscp_mark      = 26
+}
+`
+
+var testAccOpenStackNetworkingQoSDSCPMarkingRuleV2DataSource_basic = fmt.Sprintf(`
+%s
+data "openstack_networking_qos_dscp_marking_rule_v2" "dscp_mark_rule_1" {
+  qos_policy_id = "${openstack_networking_qos_policy_v2.qos_policy_1.id}"
+  dscp_mark     = "${openstack_networking_qos_dscp_marking_rule_v2.dscp_mark_rule_1.dscp_mark}"
+}
+`, testAccNetworkingV2QoSDSCPMarkingRule_dataSource)

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -239,6 +239,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_networking_addressscope_v2":             dataSourceNetworkingAddressScopeV2(),
 			"openstack_networking_network_v2":                  dataSourceNetworkingNetworkV2(),
 			"openstack_networking_qos_bandwidth_limit_rule_v2": dataSourceNetworkingQoSBandwidthLimitRuleV2(),
+			"openstack_networking_qos_dscp_marking_rule_v2":    dataSourceNetworkingQoSDSCPMarkingRuleV2(),
 			"openstack_networking_qos_policy_v2":               dataSourceNetworkingQoSPolicyV2(),
 			"openstack_networking_subnet_v2":                   dataSourceNetworkingSubnetV2(),
 			"openstack_networking_secgroup_v2":                 dataSourceNetworkingSecGroupV2(),

--- a/website/docs/d/networking_qos_dscp_marking_rule_v2.html.markdown
+++ b/website/docs/d/networking_qos_dscp_marking_rule_v2.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_networking_qos_dscp_marking_rule_v2"
+sidebar_current: "docs-openstack-datasource-networking-qos-dscp-marking-rule-v2"
+description: |-
+  Get information on an OpenStack QoS DSCP marking rule.
+---
+
+# openstack\_networking\_qos\_dscp\_marking\_rule\_v2
+
+Use this data source to get the ID of an available OpenStack QoS DSCP marking rule.
+
+## Example Usage
+
+```hcl
+data "openstack_networking_qos_dscp_marking_rule_v2" "qos_dscp_marking_rule_1" {
+  dscp_mark = 26
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional) The region in which to obtain the V2 Networking client.
+    A Networking client is needed to create a Neutron QoS DSCP marking rule. If omitted, the
+    `region` argument of the provider is used.
+
+* `qos_policy_id` - (Required) The QoS policy reference.
+
+* `dscp_mark` - (Optional) The value of a DSCP mark.
+
+
+## Attributes Reference
+
+`id` is set to the `qos_policy_id/dscp_marking_rule_id` format of the found QoS DSCP marking rule.
+In addition, the following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `qos_policy_id` - See Argument Reference above.
+* `dscp_mark` - See Argument Reference above.

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -76,6 +76,9 @@
             <li<%= sidebar_current("docs-openstack-datasource-networking-qos-bandwidth-limit-rule-v2") %>>
               <a href="/docs/providers/openstack/d/networking_qos_bandwidth_limit_rule_v2.html">openstack_networking_qos_bandwidth_limit_rule_v2</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-datasource-networking-qos-dscp-marking-rule-v2") %>>
+              <a href="/docs/providers/openstack/d/networking_qos_dscp_marking_rule_v2.html">openstack_networking_qos_dscp_marking_rule_v2</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-datasource-networking-qos-policy-v2") %>>
               <a href="/docs/providers/openstack/d/networking_qos_policy_v2.html">openstack_networking_qos_policy_v2</a>
             </li>


### PR DESCRIPTION
Implement openstack_networking_qos_dscp_marking_rule_v2 datasource
with tests and website documentation.

For #760 