### PR TITLE
Networking V2: set QoS bw limit default direction

### DIFF
--- a/openstack/resource_openstack_networking_qos_bandwidth_limit_rule_v2.go
+++ b/openstack/resource_openstack_networking_qos_bandwidth_limit_rule_v2.go
@@ -54,6 +54,7 @@ func resourceNetworkingQoSBandwidthLimitRuleV2() *schema.Resource {
 
 			"direction": {
 				Type:     schema.TypeString,
+				Default:  "egress",
 				Optional: true,
 				ForceNew: false,
 			},

--- a/openstack/resource_openstack_networking_qos_bandwidth_limit_rule_v2_test.go
+++ b/openstack/resource_openstack_networking_qos_bandwidth_limit_rule_v2_test.go
@@ -137,7 +137,6 @@ resource "openstack_networking_qos_bandwidth_limit_rule_v2" "bw_limit_rule_1" {
   qos_policy_id  = "${openstack_networking_qos_policy_v2.qos_policy_1.id}"
   max_kbps       = 3000
   max_burst_kbps = 300
-  direction      = "egress"
 }
 `
 
@@ -150,6 +149,5 @@ resource "openstack_networking_qos_bandwidth_limit_rule_v2" "bw_limit_rule_1" {
   qos_policy_id  = "${openstack_networking_qos_policy_v2.qos_policy_1.id}"
   max_kbps       = 2000
   max_burst_kbps = 100
-  direction      = "ingress"
 }
 `

--- a/website/docs/r/networking_qos_bandwidth_limit_rule_v2.html.markdown
+++ b/website/docs/r/networking_qos_bandwidth_limit_rule_v2.html.markdown
@@ -44,8 +44,8 @@ The following arguments are supported:
 * `max_burst_kbps` - (Optional) The maximum burst size in kilobits of a QoS bandwidth limit rule. Changing this updates the
     maximum burst size in kilobits of the existing QoS bandwidth limit rule.
    
-* `direction` - (Optional) The direction of traffic. Changing this updates the direction of the existing
-    QoS bandwidth limit rule.
+* `direction` - (Optional) The direction of traffic. Defaults to "egress". Changing this updates the direction of the
+    existing QoS bandwidth limit rule.
     
 ## Attributes Reference
 


### PR DESCRIPTION
Set default direction of the
"resource_openstack_networking_qos_bandwidth_limit_rule_v2" to "egress".

For #760 