### PR TITLE
docs: Formalize inline HCL codes to canonical format

### DIFF
--- a/website/docs/d/images_image_v2.html.markdown
+++ b/website/docs/d/images_image_v2.html.markdown
@@ -14,7 +14,7 @@ Use this data source to get the ID of an available OpenStack image.
 
 ```hcl
 data "openstack_images_image_v2" "ubuntu" {
-  name = "Ubuntu 16.04"
+  name        = "Ubuntu 16.04"
   most_recent = true
 
   properties = {

--- a/website/docs/r/blockstorage_volume_attach_v2.html.markdown
+++ b/website/docs/r/blockstorage_volume_attach_v2.html.markdown
@@ -31,13 +31,13 @@ resource "openstack_blockstorage_volume_v2" "volume_1" {
 }
 
 resource "openstack_blockstorage_volume_attach_v2" "va_1" {
-  volume_id = "${openstack_blockstorage_volume_v2.volume_1.id}"
-  device = "auto"
-  host_name = "devstack"
+  volume_id  = "${openstack_blockstorage_volume_v2.volume_1.id}"
+  device     = "auto"
+  host_name  = "devstack"
   ip_address = "192.168.255.10"
-  initiator = "iqn.1993-08.org.debian:01:e9861fb1859"
-  os_type = "linux2"
-  platform = "x86_64"
+  initiator  = "iqn.1993-08.org.debian:01:e9861fb1859"
+  os_type    = "linux2"
+  platform   = "x86_64"
 }
 ```
 

--- a/website/docs/r/blockstorage_volume_attach_v3.html.markdown
+++ b/website/docs/r/blockstorage_volume_attach_v3.html.markdown
@@ -31,13 +31,13 @@ resource "openstack_blockstorage_volume_v3" "volume_1" {
 }
 
 resource "openstack_blockstorage_volume_attach_v3" "va_1" {
-  volume_id = "${openstack_blockstorage_volume_v3.volume_1.id}"
-  device = "auto"
-  host_name = "devstack"
+  volume_id  = "${openstack_blockstorage_volume_v3.volume_1.id}"
+  device     = "auto"
+  host_name  = "devstack"
   ip_address = "192.168.255.10"
-  initiator = "iqn.1993-08.org.debian:01:e9861fb1859"
-  os_type = "linux2"
-  platform = "x86_64"
+  initiator  = "iqn.1993-08.org.debian:01:e9861fb1859"
+  os_type    = "linux2"
+  platform   = "x86_64"
 }
 ```
 

--- a/website/docs/r/compute_flavor_access_v2.html.markdown
+++ b/website/docs/r/compute_flavor_access_v2.html.markdown
@@ -23,10 +23,10 @@ resource "openstack_identity_project_v3" "project_1" {
 }
 
 resource "openstack_compute_flavor_v2" "flavor_1" {
-  name  = "my-flavor"
-  ram   = "8096"
-  vcpus = "2"
-  disk  = "20"
+  name      = "my-flavor"
+  ram       = "8096"
+  vcpus     = "2"
+  disk      = "20"
   is_public = false
 }
 

--- a/website/docs/r/compute_flavor_v2.html.markdown
+++ b/website/docs/r/compute_flavor_v2.html.markdown
@@ -20,7 +20,7 @@ resource "openstack_compute_flavor_v2" "test-flavor" {
   disk  = "20"
 
   extra_specs = {
-    "hw:cpu_policy" = "CPU-POLICY",
+    "hw:cpu_policy"        = "CPU-POLICY",
     "hw:cpu_thread_policy" = "CPU-THREAD-POLICY"
   }
 }

--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -54,7 +54,7 @@ resource "openstack_compute_instance_v2" "myinstance" {
 
 resource "openstack_compute_volume_attach_v2" "attached" {
   instance_id = "${openstack_compute_instance_v2.myinstance.id}"
-  volume_id = "${openstack_blockstorage_volume_v2.myvol.id}"
+  volume_id   = "${openstack_blockstorage_volume_v2.myvol.id}"
 }
 ```
 
@@ -198,7 +198,7 @@ resource "openstack_compute_instance_v2" "multi-net" {
 resource "openstack_compute_floatingip_associate_v2" "myip" {
   floating_ip = "${openstack_networking_floatingip_v2.myip.address}"
   instance_id = "${openstack_compute_instance_v2.multi-net.id}"
-  fixed_ip = "${openstack_compute_instance_v2.multi-net.network.1.fixed_ip_v4}"
+  fixed_ip    = "${openstack_compute_instance_v2.multi-net.network.1.fixed_ip_v4}"
 }
 ```
 

--- a/website/docs/r/compute_interface_attach_v2.html.markdown
+++ b/website/docs/r/compute_interface_attach_v2.html.markdown
@@ -103,7 +103,7 @@ resource "openstack_compute_instance_v2" "instance_1" {
 }
 
 resource "openstack_compute_interface_attach_v2" "attachments" {
-  count          = 2
+  count       = 2
   instance_id = "${openstack_compute_instance_v2.instance_1.id}"
   port_id     = "${openstack_networking_port_v2.ports.*.id[count.index]}"
 }

--- a/website/docs/r/compute_secgroup_v2.html.markdown
+++ b/website/docs/r/compute_secgroup_v2.html.markdown
@@ -100,10 +100,10 @@ When using ICMP as the `ip_protocol`, the `from_port` sets the ICMP _type_ and t
 
 ```hcl
 rule {
-  from_port = -1
-  to_port = -1
+  from_port   = -1
+  to_port     = -1
   ip_protocol = "icmp"
-  cidr = "0.0.0.0/0"
+  cidr        = "0.0.0.0/0"
 }
 ```
 

--- a/website/docs/r/compute_volume_attach_v2.html.markdown
+++ b/website/docs/r/compute_volume_attach_v2.html.markdown
@@ -85,7 +85,7 @@ resource "openstack_compute_volume_attach_v2" "attach_2" {
   instance_id = "${openstack_compute_instance_v2.instance_1.id}"
   volume_id   = "${openstack_blockstorage_volume_v2.volumes.1.id}"
 
-  depends_on  = ["openstack_compute_volume_attach_v2.attach_1"]
+  depends_on = ["openstack_compute_volume_attach_v2.attach_1"]
 }
 
 output "volume devices" {
@@ -126,7 +126,7 @@ resource "openstack_compute_volume_attach_v2" "va_2" {
   volume_id   = "${openstack_blockstorage_volume_v2.volume_1.id}"
   multiattach = true
 
-  depends_on  = ["openstack_compute_volume_attach_v2.va_1"]
+  depends_on = ["openstack_compute_volume_attach_v2.va_1"]
 }
 ```
 

--- a/website/docs/r/containerinfra_cluster_v1.html.markdown
+++ b/website/docs/r/containerinfra_cluster_v1.html.markdown
@@ -16,11 +16,11 @@ Manages a V1 Magnum cluster resource within OpenStack.
 
 ```hcl
 resource "openstack_containerinfra_cluster_v1" "cluster_1" {
-  name                 = "cluster_1"
-  cluster_template_id  = "b9a45c5c-cd03-4958-82aa-b80bf93cb922"
-  master_count         = 3
-  node_count           = 5
-  keypair              = "ssh_keypair"
+  name                = "cluster_1"
+  cluster_template_id = "b9a45c5c-cd03-4958-82aa-b80bf93cb922"
+  master_count        = 3
+  node_count          = 5
+  keypair             = "ssh_keypair"
 }
 ```
 

--- a/website/docs/r/dns_recordset_v2.html.markdown
+++ b/website/docs/r/dns_recordset_v2.html.markdown
@@ -16,20 +16,20 @@ Manages a DNS record set in the OpenStack DNS Service.
 
 ```hcl
 resource "openstack_dns_zone_v2" "example_zone" {
-  name = "example.com."
-  email = "email2@example.com"
+  name        = "example.com."
+  email       = "email2@example.com"
   description = "a zone"
-  ttl = 6000
-  type = "PRIMARY"
+  ttl         = 6000
+  type        = "PRIMARY"
 }
 
 resource "openstack_dns_recordset_v2" "rs_example_com" {
-  zone_id = "${openstack_dns_zone_v2.example_zone.id}"
-  name = "rs.example.com."
+  zone_id     = "${openstack_dns_zone_v2.example_zone.id}"
+  name        = "rs.example.com."
   description = "An example record set"
-  ttl = 3000
-  type = "A"
-  records = ["10.0.0.1"]
+  ttl         = 3000
+  type        = "A"
+  records     = ["10.0.0.1"]
 }
 ```
 

--- a/website/docs/r/dns_zone_v2.html.markdown
+++ b/website/docs/r/dns_zone_v2.html.markdown
@@ -16,11 +16,11 @@ Manages a DNS zone in the OpenStack DNS Service.
 
 ```hcl
 resource "openstack_dns_zone_v2" "example.com" {
-  name = "example.com."
-  email = "jdoe@example.com"
+  name        = "example.com."
+  email       = "jdoe@example.com"
   description = "An example zone"
-  ttl = 3000
-  type = "PRIMARY"
+  ttl         = 3000
+  type        = "PRIMARY"
 }
 ```
 

--- a/website/docs/r/identity_project_v3.html.markdown
+++ b/website/docs/r/identity_project_v3.html.markdown
@@ -17,7 +17,7 @@ this resource.
 
 ```hcl
 resource "openstack_identity_project_v3" "project_1" {
-  name = "project_1"
+  name        = "project_1"
   description = "A project"
 }
 ```

--- a/website/docs/r/identity_role_assignment_v3.html.markdown
+++ b/website/docs/r/identity_role_assignment_v3.html.markdown
@@ -21,7 +21,7 @@ resource "openstack_identity_project_v3" "project_1" {
 }
 
 resource "openstack_identity_user_v3" "user_1" {
-  name = "user_1"
+  name               = "user_1"
   default_project_id = "${openstack_identity_project_v3.project_1.id}"
 }
 
@@ -30,9 +30,9 @@ resource "openstack_identity_role_v3" "role_1" {
 }
 
 resource "openstack_identity_role_assignment_v3" "role_assignment_1" {
-  user_id = "${openstack_identity_user_v3.user_1.id}"
+  user_id    = "${openstack_identity_user_v3.user_1.id}"
   project_id = "${openstack_identity_project_v3.project_1.id}"
-  role_id = "${openstack_identity_role_v3.role_1.id}"
+  role_id    = "${openstack_identity_role_v3.role_1.id}"
 }
 ```
 

--- a/website/docs/r/identity_user_v3.html.markdown
+++ b/website/docs/r/identity_user_v3.html.markdown
@@ -22,8 +22,8 @@ resource "openstack_identity_project_v3" "project_1" {
 
 resource "openstack_identity_user_v3" "user_1" {
   default_project_id = "${openstack_identity_project_v3.project_1.id}"
-  name = "user_1"
-  description = "A user"
+  name               = "user_1"
+  description        = "A user"
 
   password = "password123"
 

--- a/website/docs/r/images_image_v2.html.markdown
+++ b/website/docs/r/images_image_v2.html.markdown
@@ -14,10 +14,10 @@ Manages a V2 Image resource within OpenStack Glance.
 
 ```hcl
 resource "openstack_images_image_v2" "rancheros" {
-  name   = "RancherOS"
+  name             = "RancherOS"
   image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
   container_format = "bare"
-  disk_format = "qcow2"
+  disk_format      = "qcow2"
 
   properties = {
     key = "value"

--- a/website/docs/r/lb_l7policy_v2.html.markdown
+++ b/website/docs/r/lb_l7policy_v2.html.markdown
@@ -14,26 +14,26 @@ Manages a Load Balancer L7 Policy resource within OpenStack.
 
 ```hcl
 resource "openstack_networking_network_v2" "network_1" {
-  name = "network_1"
+  name           = "network_1"
   admin_state_up = "true"
 }
 
 resource "openstack_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
   ip_version = 4
   network_id = "${openstack_networking_network_v2.network_1.id}"
 }
 
 resource "openstack_lb_loadbalancer_v2" "loadbalancer_1" {
-  name = "loadbalancer_1"
+  name          = "loadbalancer_1"
   vip_subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
 }
 
 resource "openstack_lb_listener_v2" "listener_1" {
-  name = "listener_1"
-  protocol = "HTTP"
-  protocol_port = 8080
+  name            = "listener_1"
+  protocol        = "HTTP"
+  protocol_port   = 8080
   loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"
 }
 

--- a/website/docs/r/lb_l7rule_v2.html.markdown
+++ b/website/docs/r/lb_l7rule_v2.html.markdown
@@ -14,26 +14,26 @@ Manages a V2 L7 Rule resource within OpenStack.
 
 ```hcl
 resource "openstack_networking_network_v2" "network_1" {
-  name = "network_1"
+  name           = "network_1"
   admin_state_up = "true"
 }
 
 resource "openstack_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
   ip_version = 4
   network_id = "${openstack_networking_network_v2.network_1.id}"
 }
 
 resource "openstack_lb_loadbalancer_v2" "loadbalancer_1" {
-  name = "loadbalancer_1"
+  name          = "loadbalancer_1"
   vip_subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
 }
 
 resource "openstack_lb_listener_v2" "listener_1" {
-  name = "listener_1"
-  protocol = "HTTP"
-  protocol_port = 8080
+  name            = "listener_1"
+  protocol        = "HTTP"
+  protocol_port   = 8080
   loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"
 }
 

--- a/website/docs/r/networking_floatingip_associate_v2.html.markdown
+++ b/website/docs/r/networking_floatingip_associate_v2.html.markdown
@@ -21,7 +21,7 @@ resource "openstack_networking_port_v2" "port_1" {
 
 resource "openstack_networking_floatingip_associate_v2" "fip_1" {
   floating_ip = "1.2.3.4"
-  port_id = "${openstack_networking_port_v2.port_1.id}"
+  port_id     = "${openstack_networking_port_v2.port_1.id}"
 }
 ```
 

--- a/website/docs/r/networking_port_secgroup_associate_v2.html.markdown
+++ b/website/docs/r/networking_port_secgroup_associate_v2.html.markdown
@@ -66,8 +66,8 @@ data "openstack_networking_port_v2" "system_port" {
 }
 
 resource "openstack_networking_port_secgroup_associate_v2" "port_1" {
-  port_id = "${data.openstack_networking_port_v2.system_port.id}"
-  enforce = "true"
+  port_id            = "${data.openstack_networking_port_v2.system_port.id}"
+  enforce            = "true"
   security_group_ids = []
 }
 ```

--- a/website/docs/r/networking_qos_dscp_marking_rule_v2.html.markdown
+++ b/website/docs/r/networking_qos_dscp_marking_rule_v2.html.markdown
@@ -21,8 +21,8 @@ resource "openstack_networking_qos_policy_v2" "qos_policy_1" {
 }
 
 resource "openstack_networking_qos_dscp_marking_rule_v2" "dscp_marking_rule_1" {
-  qos_policy_id  = "${openstack_networking_qos_policy_v2.qos_policy_1.id}"
-  dscp_mark      = 26
+  qos_policy_id = "${openstack_networking_qos_policy_v2.qos_policy_1.id}"
+  dscp_mark     = 26
 }
 ```
 

--- a/website/docs/r/networking_qos_minimum_bandwidth_rule_v2.html.markdown
+++ b/website/docs/r/networking_qos_minimum_bandwidth_rule_v2.html.markdown
@@ -21,8 +21,8 @@ resource "openstack_networking_qos_policy_v2" "qos_policy_1" {
 }
 
 resource "openstack_networking_qos_minimum_bandwidth_rule_v2" "minimum_bandwidth_rule_1" {
-  qos_policy_id  = "${openstack_networking_qos_policy_v2.qos_policy_1.id}"
-  min_kbps       = 200
+  qos_policy_id = "${openstack_networking_qos_policy_v2.qos_policy_1.id}"
+  min_kbps      = 200
 }
 ```
 

--- a/website/docs/r/networking_secgroup_v2.html.markdown
+++ b/website/docs/r/networking_secgroup_v2.html.markdown
@@ -66,14 +66,14 @@ separate security group rules such as the following:
 
 ```hcl
 resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_v4" {
-  direction = "egress"
-  ethertype = "IPv4"
+  direction         = "egress"
+  ethertype         = "IPv4"
   security_group_id = "${openstack_networking_secgroup_v2.secgroup.id}"
 }
 
 resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_v6" {
-  direction = "egress"
-  ethertype = "IPv6"
+  direction         = "egress"
+  ethertype         = "IPv6"
   security_group_id = "${openstack_networking_secgroup_v2.secgroup.id}"
 }
 ```

--- a/website/docs/r/networking_subnetpool_v2.html.markdown
+++ b/website/docs/r/networking_subnetpool_v2.html.markdown
@@ -16,9 +16,9 @@ Manages a V2 Neutron subnetpool resource within OpenStack.
 
 ```hcl
 resource "openstack_networking_subnetpool_v2" "subnetpool_1" {
-  name = "subnetpool_1"
+  name       = "subnetpool_1"
   ip_version = 6
-  prefixes = ["fdf7:b13d:dead:beef::/64", "fd65:86cc:a334:39b7::/64"]
+  prefixes   = ["fdf7:b13d:dead:beef::/64", "fd65:86cc:a334:39b7::/64"]
 }
 ```
 
@@ -26,19 +26,19 @@ resource "openstack_networking_subnetpool_v2" "subnetpool_1" {
 
 ```hcl
 resource "openstack_networking_network_v2" "network_1" {
-  name = "network_1"
+  name           = "network_1"
   admin_state_up = "true"
 }
 
 resource "openstack_networking_subnetpool_v2" "subnetpool_1" {
-  name = "subnetpool_1"
+  name     = "subnetpool_1"
   prefixes = ["10.11.12.0/24"]
 }
 
 resource "openstack_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "10.11.12.0/25"
-  network_id = "${openstack_networking_network_v2.network_1.id}"
+  name          = "subnet_1"
+  cidr          = "10.11.12.0/25"
+  network_id    = "${openstack_networking_network_v2.network_1.id}"
   subnetpool_id = "${openstack_networking_subnetpool_v2.subnetpool_1.id}"
 }
 ```

--- a/website/docs/r/networking_trunk_v2.html.markdown
+++ b/website/docs/r/networking_trunk_v2.html.markdown
@@ -14,17 +14,17 @@ Manages a networking V2 trunk resource within OpenStack.
 
 ```hcl
 resource "openstack_networking_network_v2" "network_1" {
-  name = "network_1"
+  name           = "network_1"
   admin_state_up = "true"
 }
 
 resource "openstack_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  network_id = "${openstack_networking_network_v2.network_1.id}"
-  cidr = "192.168.1.0/24"
-  ip_version = 4
+  name        = "subnet_1"
+  network_id  = "${openstack_networking_network_v2.network_1.id}"
+  cidr        = "192.168.1.0/24"
+  ip_version  = 4
   enable_dhcp = true
-  no_gateway = true
+  no_gateway  = true
 }
 
 resource "openstack_networking_port_v2" "parent_port_1" {
@@ -32,8 +32,8 @@ resource "openstack_networking_port_v2" "parent_port_1" {
     "openstack_networking_subnet_v2.subnet_1",
   ]
 
-  name = "parent_port_1"
-  network_id = "${openstack_networking_network_v2.network_1.id}"
+  name           = "parent_port_1"
+  network_id     = "${openstack_networking_network_v2.network_1.id}"
   admin_state_up = "true"
 }
 
@@ -42,25 +42,25 @@ resource "openstack_networking_port_v2" "subport_1" {
     "openstack_networking_subnet_v2.subnet_1",
   ]
 
-  name = "subport_1"
-  network_id = "${openstack_networking_network_v2.network_1.id}"
+  name           = "subport_1"
+  network_id     = "${openstack_networking_network_v2.network_1.id}"
   admin_state_up = "true"
 }
 
 resource "openstack_networking_trunk_v2" "trunk_1" {
-  name = "trunk_1"
+  name           = "trunk_1"
   admin_state_up = "true"
-  port_id = "${openstack_networking_port_v2.parent_port_1.id}"
+  port_id        = "${openstack_networking_port_v2.parent_port_1.id}"
 
   sub_port {
-    port_id = "${openstack_networking_port_v2.subport_1.id}"
-    segmentation_id = 1
+    port_id           = "${openstack_networking_port_v2.subport_1.id}"
+    segmentation_id   = 1
     segmentation_type = "vlan"
   }
 }
 
 resource "openstack_compute_instance_v2" "instance_1" {
-  name = "instance_1"
+  name            = "instance_1"
   security_groups = ["default"]
 
   network {

--- a/website/docs/r/objectstorage_container_v1.html.markdown
+++ b/website/docs/r/objectstorage_container_v1.html.markdown
@@ -24,7 +24,7 @@ resource "openstack_objectstorage_container_v1" "container_1" {
   content_type = "application/json"
 
   versioning {
-    type = "versions"
+    type     = "versions"
     location = "tf-test-container-versions"
   }
 }

--- a/website/docs/r/objectstorage_object_v1.html.markdown
+++ b/website/docs/r/objectstorage_object_v1.html.markdown
@@ -35,7 +35,7 @@ resource "openstack_objectstorage_object_v1" "doc_1" {
   }
 
   content_type = "application/json"
-  content = <<JSON
+  content      = <<JSON
                {
                  "foo" : "bar"
                }

--- a/website/docs/r/objectstorage_tempurl_v1.html.markdown
+++ b/website/docs/r/objectstorage_tempurl_v1.html.markdown
@@ -21,9 +21,9 @@ a new ID and URL.
 ```hcl
 resource "openstack_objectstorage_tempurl_v1" "obj_tempurl" {
   container = "test"
-  object = "container"
-  method = "post"
-  ttl = 20
+  object    = "container"
+  method    = "post"
+  ttl       = 20
 }
 ```
 

--- a/website/docs/r/sharedfilesystem_share_access_v2.html.markdown
+++ b/website/docs/r/sharedfilesystem_share_access_v2.html.markdown
@@ -25,17 +25,17 @@ resource "openstack_networking_network_v2" "network_1" {
 }
 
 resource "openstack_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
   ip_version = 4
   network_id = "${openstack_networking_network_v2.network_1.id}"
 }
 
 resource "openstack_sharedfilesystem_sharenetwork_v2" "sharenetwork_1" {
-  name                = "test_sharenetwork"
-  description         = "test share network with security services"
-  neutron_net_id      = "${openstack_networking_network_v2.network_1.id}"
-  neutron_subnet_id   = "${openstack_networking_subnet_v2.subnet_1.id}"
+  name              = "test_sharenetwork"
+  description       = "test share network with security services"
+  neutron_net_id    = "${openstack_networking_network_v2.network_1.id}"
+  neutron_subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
 }
 
 resource "openstack_sharedfilesystem_share_v2" "share_1" {
@@ -63,8 +63,8 @@ resource "openstack_networking_network_v2" "network_1" {
 }
 
 resource "openstack_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
   ip_version = 4
   network_id = "${openstack_networking_network_v2.network_1.id}"
 }
@@ -82,10 +82,10 @@ resource "openstack_sharedfilesystem_securityservice_v2" "securityservice_1" {
 }
 
 resource "openstack_sharedfilesystem_sharenetwork_v2" "sharenetwork_1" {
-  name                = "test_sharenetwork_secure"
-  description         = "share the secure love"
-  neutron_net_id      = "${openstack_networking_network_v2.network_1.id}"
-  neutron_subnet_id   = "${openstack_networking_subnet_v2.subnet_1.id}"
+  name              = "test_sharenetwork_secure"
+  description       = "share the secure love"
+  neutron_net_id    = "${openstack_networking_network_v2.network_1.id}"
+  neutron_subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
   security_service_ids = [
     "${openstack_sharedfilesystem_securityservice_v2.securityservice_1.id}",
   ]
@@ -99,16 +99,16 @@ resource "openstack_sharedfilesystem_share_v2" "share_1" {
 }
 
 resource "openstack_sharedfilesystem_share_access_v2" "share_access_1" {
-  share_id = "${openstack_sharedfilesystem_share_v2.share_1.id}"
-  access_type = "user"
-  access_to = "windows"
+  share_id     = "${openstack_sharedfilesystem_share_v2.share_1.id}"
+  access_type  = "user"
+  access_to    = "windows"
   access_level = "ro"
 }
 
 resource "openstack_sharedfilesystem_share_access_v2" "share_access_2" {
-  share_id = "${openstack_sharedfilesystem_share_v2.share_1.id}"
-  access_type = "user"
-  access_to = "linux"
+  share_id     = "${openstack_sharedfilesystem_share_v2.share_1.id}"
+  access_type  = "user"
+  access_to    = "linux"
   access_level = "rw"
 }
 

--- a/website/docs/r/sharedfilesystem_share_v2.html.markdown
+++ b/website/docs/r/sharedfilesystem_share_v2.html.markdown
@@ -19,17 +19,17 @@ resource "openstack_networking_network_v2" "network_1" {
 }
 
 resource "openstack_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
   ip_version = 4
   network_id = "${openstack_networking_network_v2.network_1.id}"
 }
 
 resource "openstack_sharedfilesystem_sharenetwork_v2" "sharenetwork_1" {
-  name                = "test_sharenetwork"
-  description         = "test share network with security services"
-  neutron_net_id      = "${openstack_networking_network_v2.network_1.id}"
-  neutron_subnet_id   = "${openstack_networking_subnet_v2.subnet_1.id}"
+  name              = "test_sharenetwork"
+  description       = "test share network with security services"
+  neutron_net_id    = "${openstack_networking_network_v2.network_1.id}"
+  neutron_subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
 }
 
 resource "openstack_sharedfilesystem_share_v2" "share_1" {

--- a/website/docs/r/sharedfilesystem_sharenetwork_v2.html.markdown
+++ b/website/docs/r/sharedfilesystem_sharenetwork_v2.html.markdown
@@ -24,17 +24,17 @@ resource "openstack_networking_network_v2" "network_1" {
 }
 
 resource "openstack_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
   ip_version = 4
   network_id = "${openstack_networking_network_v2.network_1.id}"
 }
 
 resource "openstack_sharedfilesystem_sharenetwork_v2" "sharenetwork_1" {
-  name                = "test_sharenetwork"
-  description         = "test share network"
-  neutron_net_id      = "${openstack_networking_network_v2.network_1.id}"
-  neutron_subnet_id   = "${openstack_networking_subnet_v2.subnet_1.id}"
+  name              = "test_sharenetwork"
+  description       = "test share network"
+  neutron_net_id    = "${openstack_networking_network_v2.network_1.id}"
+  neutron_subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
 }
 ```
 
@@ -47,8 +47,8 @@ resource "openstack_networking_network_v2" "network_1" {
 }
 
 resource "openstack_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
   ip_version = 4
   network_id = "${openstack_networking_network_v2.network_1.id}"
 }
@@ -66,10 +66,10 @@ resource "openstack_sharedfilesystem_securityservice_v2" "securityservice_1" {
 }
 
 resource "openstack_sharedfilesystem_sharenetwork_v2" "sharenetwork_1" {
-  name                = "test_sharenetwork"
-  description         = "test share network with security services"
-  neutron_net_id      = "${openstack_networking_network_v2.network_1.id}"
-  neutron_subnet_id   = "${openstack_networking_subnet_v2.subnet_1.id}"
+  name              = "test_sharenetwork"
+  description       = "test share network with security services"
+  neutron_net_id    = "${openstack_networking_network_v2.network_1.id}"
+  neutron_subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
   security_service_ids = [
     "${openstack_sharedfilesystem_securityservice_v2.securityservice_1.id}",
   ]

--- a/website/docs/r/vpnaas_endpoint_group_v2.html.markdown
+++ b/website/docs/r/vpnaas_endpoint_group_v2.html.markdown
@@ -17,7 +17,7 @@ resource "openstack_vpnaas_endpoint_group_v2" "group_1" {
   name = "Group 1"
   type = "cidr"
   endpoints = ["10.2.0.0/24",
-        "10.3.0.0/24",]
+  "10.3.0.0/24", ]
 }
 ```
 

--- a/website/docs/r/vpnaas_service_v2.html.markdown
+++ b/website/docs/r/vpnaas_service_v2.html.markdown
@@ -14,8 +14,8 @@ Manages a V2 Neutron VPN service resource within OpenStack.
 
 ```hcl
 resource "openstack_vpnaas_service_v2" "service_1" {
-  name = "my_service"
-  router_id = "14a75700-fc03-4602-9294-26ee44f366b3"
+  name           = "my_service"
+  router_id      = "14a75700-fc03-4602-9294-26ee44f366b3"
   admin_state_up = "true"
 }
 ```

--- a/website/docs/r/vpnaas_site_connection_v2.html.markdown
+++ b/website/docs/r/vpnaas_site_connection_v2.html.markdown
@@ -14,14 +14,14 @@ Manages a V2 Neutron IPSec site connection resource within OpenStack.
 
 ```hcl
 resource "openstack_vpnaas_site_connection_v2" "conn_1" {
-  		name = "connection_1"
-  		ikepolicy_id = "${openstack_vpnaas_ike_policy_v2.policy_2.id}"
-  		ipsecpolicy_id = "${openstack_vpnaas_ipsec_policy_v2.policy_1.id}"
-  		vpnservice_id = "${openstack_vpnaas_service_v2.service_1.id}"
-  		psk = "secret"
-  		peer_address = "192.168.10.1"
-  		local_ep_group_id = "${openstack_vpnaas_endpoint_group_v2.group_2.id}"
-  		peer_ep_group_id = "${openstack_vpnaas_endpoint_group_v2.group_1.id}"
+  name              = "connection_1"
+  ikepolicy_id      = "${openstack_vpnaas_ike_policy_v2.policy_2.id}"
+  ipsecpolicy_id    = "${openstack_vpnaas_ipsec_policy_v2.policy_1.id}"
+  vpnservice_id     = "${openstack_vpnaas_service_v2.service_1.id}"
+  psk               = "secret"
+  peer_address      = "192.168.10.1"
+  local_ep_group_id = "${openstack_vpnaas_endpoint_group_v2.group_2.id}"
+  peer_ep_group_id  = "${openstack_vpnaas_endpoint_group_v2.group_1.id}"
 }
 ```
 


### PR DESCRIPTION
Along with the release of Terraform v0.12, Terraform also introduces the officially recommended [Idiomatic Style Conventions](https://www.terraform.io/docs/configuration/style.html) for HCL languages. For better readability of the docs, the inline HCLs in docs should also follow that rule. 

This PR is trying to convert all the existing inline HCL codes into the canonical format. The overall formatting process is done by a tool I developed.

Signed-off-by: imjoey <majunjiev@gmail.com>
