### PR TITLE
openstack_compute_volume_attach_v3 doesn't exist

### DIFF
--- a/website/docs/r/blockstorage_volume_attach_v3.html.markdown
+++ b/website/docs/r/blockstorage_volume_attach_v3.html.markdown
@@ -20,7 +20,7 @@ such as a bare-metal server or a remote virtual machine in a
 different cloud provider.
 
 This does not actually attach a volume to an instance. Please use
-the `openstack_compute_volume_attach_v3` resource for that.
+the `openstack_compute_volume_attach_v2` resource for that.
 
 ## Example Usage
 


### PR DESCRIPTION
openstack_compute_volume_attach_v3 doesn't exist as a resource. openstack_compute_volume_attach_v2 only exists which is using underlying nova API.