### PR TITLE
Networking v2: Add neutron rbac policy resource

### DIFF
--- a/openstack/import_openstack_networking_rbac_policy_v2_test.go
+++ b/openstack/import_openstack_networking_rbac_policy_v2_test.go
@@ -1,0 +1,34 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccNetworkingV2RBACPolicy_importBasic(t *testing.T) {
+	resourceName := "openstack_networking_rbac_policy_v2.rbac_policy_1"
+	var projectName = fmt.Sprintf("ACCPTTEST-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2RBACPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2RBACPolicy_basic(projectName),
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -304,6 +304,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_networking_floatingip_associate_v2":       resourceNetworkingFloatingIPAssociateV2(),
 			"openstack_networking_network_v2":                    resourceNetworkingNetworkV2(),
 			"openstack_networking_port_v2":                       resourceNetworkingPortV2(),
+			"openstack_networking_rbac_policy_v2":                resourceNetworkingRBACPolicyV2(),
 			"openstack_networking_port_secgroup_associate_v2":    resourceNetworkingPortSecGroupAssociateV2(),
 			"openstack_networking_qos_bandwidth_limit_rule_v2":   resourceNetworkingQoSBandwidthLimitRuleV2(),
 			"openstack_networking_qos_dscp_marking_rule_v2":      resourceNetworkingQoSDSCPMarkingRuleV2(),

--- a/openstack/resource_openstack_networking_rbac_policy_v2.go
+++ b/openstack/resource_openstack_networking_rbac_policy_v2.go
@@ -1,0 +1,152 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/rbacpolicies"
+)
+
+func resourceNetworkingRBACPolicyV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNetworkingRBACPolicyV2Create,
+		Read:   resourceNetworkingRBACPolicyV2Read,
+		Update: resourceNetworkingRBACPolicyV2Update,
+		Delete: resourceNetworkingRBACPolicyV2Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"action": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"access_as_external", "access_as_shared",
+				}, false),
+			},
+
+			"object_type": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"network", "qos_policy",
+				}, false),
+			},
+
+			"target_tenant": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"object_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+
+			"project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceNetworkingRBACPolicyV2Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	createOpts := rbacpolicies.CreateOpts{
+		Action:       rbacpolicies.PolicyAction(d.Get("action").(string)),
+		ObjectType:   d.Get("object_type").(string),
+		TargetTenant: d.Get("target_tenant").(string),
+		ObjectID:     d.Get("object_id").(string),
+	}
+
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	rbac, err := rbacpolicies.Create(networkingClient, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating openstack_networking_rbac_policy_v2: %s", err)
+	}
+
+	d.SetId(rbac.ID)
+
+	return resourceNetworkingRBACPolicyV2Read(d, meta)
+}
+
+func resourceNetworkingRBACPolicyV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	rbac, err := rbacpolicies.Get(networkingClient, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "Error retrieving openstack_networking_rbac_policy_v2")
+	}
+
+	log.Printf("[DEBUG] Retrieved RBAC policy %s: %+v", d.Id(), rbac)
+
+	d.Set("action", string(rbac.Action))
+	d.Set("object_type", rbac.ObjectType)
+	d.Set("target_tenant", rbac.TargetTenant)
+	d.Set("object_id", rbac.ObjectID)
+	d.Set("project_id", rbac.ProjectID)
+
+	d.Set("region", GetRegion(d, config))
+
+	return nil
+}
+
+func resourceNetworkingRBACPolicyV2Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	var updateOpts rbacpolicies.UpdateOpts
+
+	if d.HasChange("target_tenant") {
+		updateOpts.TargetTenant = d.Get("target_tenant").(string)
+
+		_, err := rbacpolicies.Update(networkingClient, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("Error updating openstack_networking_rbac_policy_v2: %s", err)
+		}
+	}
+
+	return resourceNetworkingRBACPolicyV2Read(d, meta)
+}
+
+func resourceNetworkingRBACPolicyV2Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	err = rbacpolicies.Delete(networkingClient, d.Id()).ExtractErr()
+	if err != nil {
+		return CheckDeleted(d, err, "Error deleting openstack_networking_rbac_policy_v2")
+	}
+
+	return nil
+}

--- a/openstack/resource_openstack_networking_rbac_policy_v2_test.go
+++ b/openstack/resource_openstack_networking_rbac_policy_v2_test.go
@@ -1,0 +1,168 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/rbacpolicies"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+)
+
+func TestAccNetworkingV2RBACPolicy_basic(t *testing.T) {
+	var rbac rbacpolicies.RBACPolicy
+	var project projects.Project
+	var network networks.Network
+	var projectOneName = fmt.Sprintf("ACCPTTEST-%s", acctest.RandString(5))
+	var projectTwoName = fmt.Sprintf("ACCPTTEST-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2RBACPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2RBACPolicy_basic(projectOneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityV3ProjectExists("openstack_identity_project_v3.project_1", &project),
+					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
+					testAccCheckNetworkingV2RBACPolicyExists("openstack_networking_rbac_policy_v2.rbac_policy_1", &rbac),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_rbac_policy_v2.rbac_policy_1", "action", "access_as_shared"),
+					resource.TestCheckResourceAttrPtr(
+						"openstack_networking_rbac_policy_v2.rbac_policy_1", "action", (*string)(&rbac.Action)),
+					resource.TestCheckResourceAttrPtr(
+						"openstack_networking_rbac_policy_v2.rbac_policy_1", "object_id", &network.ID),
+					resource.TestCheckResourceAttrPtr(
+						"openstack_networking_rbac_policy_v2.rbac_policy_1", "object_type", &rbac.ObjectType),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_rbac_policy_v2.rbac_policy_1", "object_type", "network"),
+					resource.TestCheckResourceAttrPtr(
+						"openstack_networking_rbac_policy_v2.rbac_policy_1", "target_tenant", &project.ID),
+				),
+			},
+			{
+				Config: testAccNetworkingV2RBACPolicy_update(projectTwoName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityV3ProjectExists("openstack_identity_project_v3.project_2", &project),
+					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
+					testAccCheckNetworkingV2RBACPolicyExists("openstack_networking_rbac_policy_v2.rbac_policy_1", &rbac),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_rbac_policy_v2.rbac_policy_1", "action", "access_as_shared"),
+					resource.TestCheckResourceAttrPtr(
+						"openstack_networking_rbac_policy_v2.rbac_policy_1", "action", (*string)(&rbac.Action)),
+					resource.TestCheckResourceAttrPtr(
+						"openstack_networking_rbac_policy_v2.rbac_policy_1", "object_id", &network.ID),
+					resource.TestCheckResourceAttrPtr(
+						"openstack_networking_rbac_policy_v2.rbac_policy_1", "object_type", &rbac.ObjectType),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_rbac_policy_v2.rbac_policy_1", "object_type", "network"),
+					resource.TestCheckResourceAttrPtr(
+						"openstack_networking_rbac_policy_v2.rbac_policy_1", "target_tenant", &project.ID),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckNetworkingV2RBACPolicyDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "openstack_networking_rbac_policy_v2" {
+			continue
+		}
+
+		_, err := rbacpolicies.Get(networkingClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Project still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckNetworkingV2RBACPolicyExists(n string, rbac *rbacpolicies.RBACPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+		}
+
+		found, err := rbacpolicies.Get(networkingClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("Project not found")
+		}
+
+		*rbac = *found
+
+		return nil
+	}
+}
+
+func testAccNetworkingV2RBACPolicy_basic(projectName string) string {
+	return fmt.Sprintf(`
+    resource "openstack_identity_project_v3" "project_1" {
+      name        = "%s"
+      description = "A project"
+    }
+
+    resource "openstack_networking_network_v2" "network_1" {
+      name           = "network_1"
+      admin_state_up = "false"
+    }
+
+    resource "openstack_networking_rbac_policy_v2" "rbac_policy_1" {
+      action        = "access_as_shared"
+      object_id     = "${openstack_networking_network_v2.network_1.id}"
+      object_type   = "network"
+      target_tenant = "${openstack_identity_project_v3.project_1.id}"
+    }
+  `, projectName)
+}
+
+func testAccNetworkingV2RBACPolicy_update(projectName string) string {
+	return fmt.Sprintf(`
+    resource "openstack_identity_project_v3" "project_2" {
+      name        = "%s"
+      description = "The second project"
+    }
+
+    resource "openstack_networking_network_v2" "network_1" {
+      name           = "network_1"
+      admin_state_up = "false"
+    }
+
+    resource "openstack_networking_rbac_policy_v2" "rbac_policy_1" {
+      action        = "access_as_shared"
+      object_id     = "${openstack_networking_network_v2.network_1.id}"
+      object_type   = "network"
+      target_tenant = "${openstack_identity_project_v3.project_2.id}"
+    }
+  `, projectName)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/rbacpolicies/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/rbacpolicies/doc.go
@@ -1,0 +1,79 @@
+/*
+Package rbacpolicies contains functionality for working with Neutron RBAC Policies.
+Role-Based Access Control (RBAC) policy framework enables both operators
+and users to grant access to resources for specific projects.
+
+Sharing an object with a specific project is accomplished by creating a
+policy entry that permits the target project the access_as_shared action
+on that object.
+
+To make a network available as an external network for specific projects
+rather than all projects, use the access_as_external action.
+If a network is marked as external during creation, it now implicitly creates
+a wildcard RBAC policy granting everyone access to preserve previous behavior
+before this feature was added.
+
+Example to Create a RBAC Policy
+
+	createOpts := rbacpolicies.CreateOpts{
+		Action:       rbacpolicies.ActionAccessShared,
+		ObjectType:   "network",
+                TargetTenant: "6e547a3bcfe44702889fdeff3c3520c3",
+                ObjectID:     "240d22bf-bd17-4238-9758-25f72610ecdc"
+	}
+
+	rbacPolicy, err := rbacpolicies.Create(rbacClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to List RBAC Policies
+
+	listOpts := rbacpolicies.ListOpts{
+		TenantID: "a99e9b4e620e4db09a2dfb6e42a01e66",
+	}
+
+	allPages, err := rbacpolicies.List(rbacClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allRBACPolicies, err := rbacpolicies.ExtractRBACPolicies(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, rbacpolicy := range allRBACPolicies {
+		fmt.Printf("%+v", rbacpolicy)
+	}
+
+Example to Delete a RBAC Policy
+
+	rbacPolicyID := "94fe107f-da78-4d92-a9d7-5611b06dad8d"
+	err := rbacpolicies.Delete(rbacClient, rbacPolicyID).ExtractErr()
+	if err != nil {
+	  panic(err)
+	}
+
+Example to Get RBAC Policy by ID
+
+	rbacPolicyID := "94fe107f-da78-4d92-a9d7-5611b06dad8d"
+	rbacpolicy, err := rbacpolicies.Get(rbacClient, rbacPolicyID).Extract()
+	if err != nil {
+	  panic(err)
+	}
+	fmt.Printf("%+v", rbacpolicy)
+
+Example to Update a RBAC Policy
+
+	rbacPolicyID := "570b0306-afb5-4d3b-ab47-458fdc16baaa"
+	updateOpts := rbacpolicies.UpdateOpts{
+		TargetTenant: "9d766060b6354c9e8e2da44cab0e8f38",
+	}
+	rbacPolicy, err := rbacpolicies.Update(rbacClient, rbacPolicyID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+*/
+package rbacpolicies

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/rbacpolicies/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/rbacpolicies/requests.go
@@ -1,0 +1,146 @@
+package rbacpolicies
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToRBACPolicyListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the rbac attributes you want to see returned. SortKey allows you to sort
+// by a particular rbac attribute. SortDir sets the direction, and is either
+// `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	TargetTenant string       `q:"target_tenant"`
+	ObjectType   string       `q:"object_type"`
+	ObjectID     string       `q:"object_id"`
+	Action       PolicyAction `q:"action"`
+	TenantID     string       `q:"tenant_id"`
+	ProjectID    string       `q:"project_id"`
+	Marker       string       `q:"marker"`
+	Limit        int          `q:"limit"`
+	SortKey      string       `q:"sort_key"`
+	SortDir      string       `q:"sort_dir"`
+	Tags         string       `q:"tags"`
+	TagsAny      string       `q:"tags-any"`
+	NotTags      string       `q:"not-tags"`
+	NotTagsAny   string       `q:"not-tags-any"`
+}
+
+// ToRBACPolicyListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToRBACPolicyListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// rbac policies. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToRBACPolicyListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return RBACPolicyPage{pagination.LinkedPageBase{PageResult: r}}
+
+	})
+}
+
+// Get retrieves a specific rbac policy based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
+	return
+}
+
+// PolicyAction maps to Action for the RBAC policy.
+// Which allows access_as_external or access_as_shared.
+type PolicyAction string
+
+const (
+	// ActionAccessExternal returns Action for the RBAC policy as access_as_external.
+	ActionAccessExternal PolicyAction = "access_as_external"
+
+	// ActionAccessShared returns Action for the RBAC policy as access_as_shared.
+	ActionAccessShared PolicyAction = "access_as_shared"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToRBACPolicyCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts represents options used to create a rbac-policy.
+type CreateOpts struct {
+	Action       PolicyAction `json:"action" required:"true"`
+	ObjectType   string       `json:"object_type" required:"true"`
+	TargetTenant string       `json:"target_tenant" required:"true"`
+	ObjectID     string       `json:"object_id" required:"true"`
+}
+
+// ToRBACPolicyCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToRBACPolicyCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "rbac_policy")
+}
+
+// Create accepts a CreateOpts struct and creates a new rbac-policy using the values
+// provided.
+//
+// The tenant ID that is contained in the URI is the tenant that creates the
+// rbac-policy.
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToRBACPolicyCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(createURL(c), b, &r.Body, nil)
+	return
+}
+
+// Delete accepts a unique ID and deletes the rbac-policy associated with it.
+func Delete(c *gophercloud.ServiceClient, rbacPolicyID string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, rbacPolicyID), nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToRBACPolicyUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents options used to update a rbac-policy.
+type UpdateOpts struct {
+	TargetTenant string `json:"target_tenant" required:"true"`
+}
+
+// ToRBACPolicyUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToRBACPolicyUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "rbac_policy")
+}
+
+// Update accepts a UpdateOpts struct and updates an existing rbac-policy using the
+// values provided.
+func Update(c *gophercloud.ServiceClient, rbacPolicyID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToRBACPolicyUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, rbacPolicyID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201},
+	})
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/rbacpolicies/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/rbacpolicies/results.go
@@ -1,0 +1,101 @@
+package rbacpolicies
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts RBAC Policy resource.
+func (r commonResult) Extract() (*RBACPolicy, error) {
+	var s RBACPolicy
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "rbac_policy")
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a RBAC Policy.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a RBAC Policy.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a RBAC Policy.
+type UpdateResult struct {
+	commonResult
+}
+
+// RBACPolicy represents a RBAC policy.
+type RBACPolicy struct {
+	// UUID of the RBAC policy.
+	ID string `json:"id"`
+
+	// Action for the RBAC policy which is access_as_external or access_as_shared.
+	Action PolicyAction `json:"action"`
+
+	// ObjectID is the ID of the object_type resource.
+	// An object_type of network returns a network ID and
+	// object_type of qos-policy returns a QoS ID.
+	ObjectID string `json:"object_id"`
+
+	// ObjectType is the type of the object that the RBAC policy affects.
+	// Types include qos-policy or network.
+	ObjectType string `json:"object_type"`
+
+	// TenantID is the ID of the project that owns the resource.
+	TenantID string `json:"tenant_id"`
+
+	// TargetTenant is the ID of the tenant to which the RBAC policy will be enforced.
+	TargetTenant string `json:"target_tenant"`
+
+	// ProjectID is the ID of the project.
+	ProjectID string `json:"project_id"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
+}
+
+// RBACPolicyPage is the page returned by a pager when traversing over a
+// collection of rbac policies.
+type RBACPolicyPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty checks whether a RBACPolicyPage struct is empty.
+func (r RBACPolicyPage) IsEmpty() (bool, error) {
+	is, err := ExtractRBACPolicies(r)
+	return len(is) == 0, err
+}
+
+// ExtractRBACPolicies accepts a Page struct, specifically a RBAC Policy struct,
+// and extracts the elements into a slice of RBAC Policy structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractRBACPolicies(r pagination.Page) ([]RBACPolicy, error) {
+	var s []RBACPolicy
+	err := ExtractRBACPolicesInto(r, &s)
+	return s, err
+}
+
+// ExtractRBACPolicesInto extracts the elements into a slice of RBAC Policy structs.
+func ExtractRBACPolicesInto(r pagination.Page, v interface{}) error {
+	return r.(RBACPolicyPage).Result.ExtractIntoSlicePtr(v, "rbac_policies")
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/rbacpolicies/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/rbacpolicies/urls.go
@@ -1,0 +1,31 @@
+package rbacpolicies
+
+import "github.com/gophercloud/gophercloud"
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("rbac-policies", id)
+}
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("rbac-policies")
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -144,6 +144,7 @@ github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecuri
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/provider
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/rules
+github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/rbacpolicies
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools

--- a/website/docs/r/networking_rbac_policy_v2.html.markdown
+++ b/website/docs/r/networking_rbac_policy_v2.html.markdown
@@ -1,0 +1,82 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_networking_rbac_policy_v2"
+sidebar_current: "docs-openstack-resource-networking-rbac-policy-v2"
+description: |-
+  Creates an RBAC policy for an OpenStack V2 resource.
+---
+
+# openstack\_networking\_rbac\_policy\_v2
+
+The RBAC policy resource contains functionality for working with Neutron RBAC
+Policies. Role-Based Access Control (RBAC) policy framework enables both
+operators and users to grant access to resources for specific projects.
+
+Sharing an object with a specific project is accomplished by creating a
+policy entry that permits the target project the `access_as_shared` action
+on that object.
+
+To make a network available as an external network for specific projects
+rather than all projects, use the `access_as_external` action.
+If a network is marked as external during creation, it now implicitly creates
+a wildcard RBAC policy granting everyone access to preserve previous behavior
+before this feature was added.
+
+## Example Usage
+
+```hcl
+resource "openstack_networking_network_v2" "network_1" {
+  name           = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_rbac_policy_v2" "rbac_policy_1" {
+  action        = "access_as_shared"
+  object_id     = "${openstack_networking_network_v2.network_1.id}"
+  object_type   = "network"
+  target_tenant = "20415a973c9e45d3917f078950644697"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional) The region in which to obtain the V2 networking client.
+    A networking client is needed to configure a routing entry on a subnet. If omitted, the
+    `region` argument of the provider is used. Changing this creates a new
+    routing entry.
+
+* `action` - (Required) Action for the RBAC policy. Can either be
+  `access_as_external` or `access_as_shared`.
+
+* `object_id` - (Required) The ID of the `object_type` resource. An
+  `object_type` of `network` returns a network ID and an `object_type` of
+   `qos_policy` returns a QoS ID.
+
+* `object_type` - (Required) The type of the object that the RBAC policy
+  affects. Can either be `qos-policy` or `network`.
+
+* `target_tenant` - (Required) The ID of the tenant to which the RBAC policy
+  will be enforced.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `action` - See Argument Reference above.
+* `object_id` - See Argument Reference above.
+* `object_type` - See Argument Reference above.
+* `target_tenant` - See Argument Reference above.
+* `tenant_id` - The owner of the RBAC policy.
+
+## Notes
+
+## Import
+
+RBAC policies can be imported using the `id`, e.g.
+
+```
+$ terraform import openstack_networking_rbac_policy_v2.rbac_policy_1 eae26a3e-1c33-4cc1-9c31-0cd729c438a1
+```

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -309,6 +309,9 @@
             <li<%= sidebar_current("docs-openstack-resource-networking-trunk-v2") %>>
               <a href="/docs/providers/openstack/r/networking_trunk_v2.html">openstack_networking_trunk_v2</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-resource-networking-rbac-policy-v2") %>>
+              <a href="/docs/providers/openstack/r/networking_rbac_policy_v2.html">openstack_networking_rbac_policy_v2</a>
+            </li>
           </ul>
         </li>
 


### PR DESCRIPTION
Resolves #810
@jtopjian, @ozerovandrei acceptance tests require admin permissions, therefore they'll be skipped in OpenLab environment. Please run these tests locally.

/cc @BugRoger I renamed the initial resource name from `openstack_networking_rbacpolicies_v2` to `openstack_networking_rbac_policy_v2`