### PR TITLE
Add ability to control caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.22.1 (Unreleased)
 
+IMPROVEMENTS
+
+* Added workaround for cases when Openstack API doesn't provide proper HTTP Cache-Control headers [GH-264]
+
 BUG FIXES
 
 * Fixed the bug where `openstack_identity_auth_scope_v3` caused a panic within the domain-scope [GH-851]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.22.1 (Unreleased)
+
+IMPROVEMENTS
+
+* Added workaround for cases when Openstack API doesn't provide proper HTTP Cache-Control headers ([#264](https://github.com/terraform-providers/terraform-provider-openstack/issues/264))
+
 ## 1.22.0 (September 05, 2019)
 
 FEATURES
@@ -11,7 +16,6 @@ IMPROVEMENTS
 * Added workaround for cases when the OpenContrail API doesn't provide the ID for some load-balancer resources ([#840](https://github.com/terraform-providers/terraform-provider-openstack/issues/840))
 * Set computed attribute to `dns_name` and `dns_domain` for the `openstack_networking_network_v2` and  `openstack_networking_floatingip_v2` resources ([#837](https://github.com/terraform-providers/terraform-provider-openstack/issues/837))
 * Fixed code highlighting in website documentation for the `openstack_compute_instance_v2` resource ([#834](https://github.com/terraform-providers/terraform-provider-openstack/issues/834))
-* Added workaround for cases when Openstack API doesn't provide proper HTTP Cache-Control headers ([#264](https://github.com/terraform-providers/terraform-provider-openstack/issues/264))
 
 BUG FIXES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ IMPROVEMENTS
 * Added workaround for cases when the OpenContrail API doesn't provide the ID for some load-balancer resources [GH-840]
 * Set computed attribute to `dns_name` and `dns_domain` for the `openstack_networking_network_v2` and  `openstack_networking_floatingip_v2` resources [GH-837]
 * Fixed code highlighting in website documentation for the `openstack_compute_instance_v2` resource [GH-834]
+* Added workaround for cases when Openstack API doesn't provide proper HTTP Cache-Control headers [GH-264]
 
 BUG FIXES
 

--- a/openstack/config.go
+++ b/openstack/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	ApplicationCredentialSecret string
 	useOctavia                  bool
 	MaxRetries                  int
+	DisableNoCacheHeader        bool
 
 	OsClient *gophercloud.ProviderClient
 }
@@ -191,9 +192,10 @@ func (c *Config) LoadAndValidate() error {
 	transport := &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: config}
 	client.HTTPClient = http.Client{
 		Transport: &LogRoundTripper{
-			Rt:         transport,
-			OsDebug:    osDebug,
-			MaxRetries: c.MaxRetries,
+			Rt:                   transport,
+			OsDebug:              osDebug,
+			DisableNoCacheHeader: c.DisableNoCacheHeader,
+			MaxRetries:           c.MaxRetries,
 		},
 	}
 

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -216,6 +216,13 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				Description: descriptions["endpoint_overrides"],
 			},
+
+			"disable_no_cache_header": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: descriptions["disable_no_cache_header"],
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -411,6 +418,8 @@ func init() {
 
 		"endpoint_overrides": "A map of services with an endpoint to override what was\n" +
 			"from the Keystone catalog",
+
+		"disable_no_cache_header": "If set to `true`, the HTTP `Cache-Control: no-cache` header will not be added by default to all API requests.",
 	}
 }
 
@@ -443,6 +452,7 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		ApplicationCredentialSecret: d.Get("application_credential_secret").(string),
 		useOctavia:                  d.Get("use_octavia").(bool),
 		MaxRetries:                  d.Get("max_retries").(int),
+		DisableNoCacheHeader:        d.Get("disable_no_cache_header").(bool),
 	}
 
 	v, ok := d.GetOkExists("insecure")

--- a/openstack/types.go
+++ b/openstack/types.go
@@ -42,7 +42,7 @@ func (lrt *LogRoundTripper) RoundTrip(request *http.Request) (*http.Response, er
 	// for future reference, this is how to access the Transport struct:
 	//tlsconfig := lrt.Rt.(*http.Transport).TLSClientConfig
 
-	// set Cache-Control header to no-cache on request to force Openstack to reply with this header as well.
+	// set Cache-Control header to no-cache on request to force HTTP caches (if any) to go upstream.
 	// This is a work-around until all Openstack APIs implement proper Cache-Control headers by their own.
 	// The guidelines for this were added to http://specs.openstack.org/openstack/api-sig/guidelines/http/caching.html in 03/2018.
 	request.Header.Set("Cache-Control", "no-cache")

--- a/openstack/types.go
+++ b/openstack/types.go
@@ -42,6 +42,11 @@ func (lrt *LogRoundTripper) RoundTrip(request *http.Request) (*http.Response, er
 	// for future reference, this is how to access the Transport struct:
 	//tlsconfig := lrt.Rt.(*http.Transport).TLSClientConfig
 
+	// set Cache-Control header to no-cache on request to force Openstack to reply with this header as well.
+	// This is a work-around until all Openstack APIs implement proper Cache-Control headers by their own.
+	// The guidelines for this were added to http://specs.openstack.org/openstack/api-sig/guidelines/http/caching.html in 03/2018.
+	request.Header.Set("Cache-Control", "no-cache")
+
 	var err error
 
 	if lrt.OsDebug {

--- a/openstack/types.go
+++ b/openstack/types.go
@@ -26,9 +26,10 @@ import (
 // LogRoundTripper satisfies the http.RoundTripper interface and is used to
 // customize the default http client RoundTripper to allow for logging.
 type LogRoundTripper struct {
-	Rt         http.RoundTripper
-	OsDebug    bool
-	MaxRetries int
+	Rt                   http.RoundTripper
+	OsDebug              bool
+	DisableNoCacheHeader bool
+	MaxRetries           int
 }
 
 // RoundTrip performs a round-trip HTTP request and logs relevant information about it.
@@ -42,10 +43,12 @@ func (lrt *LogRoundTripper) RoundTrip(request *http.Request) (*http.Response, er
 	// for future reference, this is how to access the Transport struct:
 	//tlsconfig := lrt.Rt.(*http.Transport).TLSClientConfig
 
-	// set Cache-Control header to no-cache on request to force HTTP caches (if any) to go upstream.
-	// This is a work-around until all Openstack APIs implement proper Cache-Control headers by their own.
-	// The guidelines for this were added to http://specs.openstack.org/openstack/api-sig/guidelines/http/caching.html in 03/2018.
-	request.Header.Set("Cache-Control", "no-cache")
+	if !lrt.DisableNoCacheHeader {
+		// set Cache-Control header to no-cache on request to force HTTP caches (if any) to go upstream.
+		// This is a work-around until all Openstack APIs implement proper Cache-Control headers by their own.
+		// The guidelines for this were added to http://specs.openstack.org/openstack/api-sig/guidelines/http/caching.html in 03/2018.
+		request.Header.Set("Cache-Control", "no-cache")
+	}
 
 	var err error
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -148,6 +148,11 @@ The following arguments are supported:
 * `use_octavia` - (Optional) If set to `true`, API requests will go the Load Balancer
   service (Octavia) instead of the Networking service (Neutron).
 
+* `disable_no_cache_header` - (Optional) If set to `true`, the HTTP
+  `Cache-Control: no-cache` header will not be added by default to all API requests.
+  If omitted this header is added to all API requests to force HTTP caches (if any)
+  to go upstream instead of serving cached responses.
+
 ## Overriding Service API Endpoints
 
 There might be a situation in which you want or need to override an API endpoint


### PR DESCRIPTION
Added workaround for cases when Openstack API doesn't provide proper HTTP Cache-Control headers [GH-264]

Also see:
- https://github.com/gophercloud/gophercloud/issues/727
- http://specs.openstack.org/openstack/api-sig/guidelines/http/caching.html