### PR TITLE
LoadBalancer V2: add timeout options for listener

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-openstack
 
 require (
-	github.com/gophercloud/gophercloud v0.4.1-0.20190919023608-3d65851f4b68
+	github.com/gophercloud/gophercloud v0.4.1-0.20190919160002-34bae44cf812
 	github.com/gophercloud/utils v0.0.0-20190313033024-0bcc8e728cb5
 	github.com/hashicorp/terraform v0.12.8
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -141,10 +141,6 @@ github.com/googleapis/gax-go/v2 v2.0.3 h1:siORttZ36U2R/WjiJuDz8znElWBiAlO9rVt+mq
 github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
 github.com/gophercloud/gophercloud v0.0.0-20190208042652-bc37892e1968/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gophercloud/gophercloud v0.0.0-20190212181753-892256c46858/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
-github.com/gophercloud/gophercloud v0.3.1-0.20190807175045-25a84d593c97 h1:aK7cPPR1f79MwKk6jqkcmRx94sgdGId9sDIzRvd4CZ4=
-github.com/gophercloud/gophercloud v0.3.1-0.20190807175045-25a84d593c97/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
-github.com/gophercloud/gophercloud v0.4.0 h1:4iXQnHF7LKOl7ncQsRibnUmfx/unxT3rLAniYRB8kQQ=
-github.com/gophercloud/gophercloud v0.4.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/gophercloud v0.4.1-0.20190919160002-34bae44cf812 h1:HH08ExBAaU0cS0Hi9G9rmqdCHLi5+gTOu9euPcsZNNU=
 github.com/gophercloud/gophercloud v0.4.1-0.20190919160002-34bae44cf812/go.mod h1:OKfORD99ar9Nkmj0z4HEsUmwqqLgQB+z9jwKpJOGQVA=
 github.com/gophercloud/utils v0.0.0-20190128072930-fbb6ab446f01/go.mod h1:wjDF8z83zTeg5eMLml5EBSlAhbF7G8DobyI1YsMuyzw=

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,12 @@ github.com/googleapis/gax-go/v2 v2.0.3 h1:siORttZ36U2R/WjiJuDz8znElWBiAlO9rVt+mq
 github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
 github.com/gophercloud/gophercloud v0.0.0-20190208042652-bc37892e1968/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gophercloud/gophercloud v0.0.0-20190212181753-892256c46858/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
-github.com/gophercloud/gophercloud v0.4.1-0.20190919023608-3d65851f4b68 h1:pn7HEmMpOIPaWugIeSY/F3u9MSaZrsU5Xa0bf4qugF8=
-github.com/gophercloud/gophercloud v0.4.1-0.20190919023608-3d65851f4b68/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
+github.com/gophercloud/gophercloud v0.3.1-0.20190807175045-25a84d593c97 h1:aK7cPPR1f79MwKk6jqkcmRx94sgdGId9sDIzRvd4CZ4=
+github.com/gophercloud/gophercloud v0.3.1-0.20190807175045-25a84d593c97/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
+github.com/gophercloud/gophercloud v0.4.0 h1:4iXQnHF7LKOl7ncQsRibnUmfx/unxT3rLAniYRB8kQQ=
+github.com/gophercloud/gophercloud v0.4.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
+github.com/gophercloud/gophercloud v0.4.1-0.20190919160002-34bae44cf812 h1:HH08ExBAaU0cS0Hi9G9rmqdCHLi5+gTOu9euPcsZNNU=
+github.com/gophercloud/gophercloud v0.4.1-0.20190919160002-34bae44cf812/go.mod h1:OKfORD99ar9Nkmj0z4HEsUmwqqLgQB+z9jwKpJOGQVA=
 github.com/gophercloud/utils v0.0.0-20190128072930-fbb6ab446f01/go.mod h1:wjDF8z83zTeg5eMLml5EBSlAhbF7G8DobyI1YsMuyzw=
 github.com/gophercloud/utils v0.0.0-20190313033024-0bcc8e728cb5 h1:8USoe8m65WcTOYy+MUu+EtLJJysSODnoNDNCEWhDMso=
 github.com/gophercloud/utils v0.0.0-20190313033024-0bcc8e728cb5/go.mod h1:SZ9FTKibIotDtCrxAU/evccoyu1yhKST6hgBvwTB5Eg=

--- a/openstack/provider_test.go
+++ b/openstack/provider_test.go
@@ -123,6 +123,14 @@ func testAccPreCheckLB(t *testing.T) {
 	}
 }
 
+func testAccPreCheckUseOctavia(t *testing.T) {
+	testAccPreCheckRequiredEnvVars(t)
+
+	if OS_USE_OCTAVIA == "" {
+		t.Skip("This environment does not support Octavia tests")
+	}
+}
+
 func testAccPreCheckFW(t *testing.T) {
 	testAccPreCheckRequiredEnvVars(t)
 

--- a/openstack/resource_openstack_lb_listener_v2.go
+++ b/openstack/resource_openstack_lb_listener_v2.go
@@ -8,7 +8,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners"
+	octavialisteners "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
+	neutronlisteners "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners"
 )
 
 func resourceListenerV2() *schema.Resource {
@@ -107,6 +108,30 @@ func resourceListenerV2() *schema.Resource {
 				Default:  true,
 				Optional: true,
 			},
+
+			"timeout_client_data": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+
+			"timeout_member_connect": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+
+			"timeout_member_data": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+
+			"timeout_tcp_inspect": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -118,6 +143,7 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
+	lbID := d.Get("loadbalancer_id").(string)
 	adminStateUp := d.Get("admin_state_up").(bool)
 	var sniContainerRefs []string
 	if raw, ok := d.GetOk("sni_container_refs"); ok {
@@ -125,39 +151,89 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 			sniContainerRefs = append(sniContainerRefs, v.(string))
 		}
 	}
-	createOpts := listeners.CreateOpts{
-		Protocol:               listeners.Protocol(d.Get("protocol").(string)),
-		ProtocolPort:           d.Get("protocol_port").(int),
-		TenantID:               d.Get("tenant_id").(string),
-		LoadbalancerID:         d.Get("loadbalancer_id").(string),
-		Name:                   d.Get("name").(string),
-		DefaultPoolID:          d.Get("default_pool_id").(string),
-		Description:            d.Get("description").(string),
-		DefaultTlsContainerRef: d.Get("default_tls_container_ref").(string),
-		SniContainerRefs:       sniContainerRefs,
-		AdminStateUp:           &adminStateUp,
-	}
 
-	if v, ok := d.GetOk("connection_limit"); ok {
-		connectionLimit := v.(int)
-		createOpts.ConnLimit = &connectionLimit
-	}
-
-	log.Printf("[DEBUG] Create Options: %#v", createOpts)
-
-	lbID := createOpts.LoadbalancerID
 	timeout := d.Timeout(schema.TimeoutCreate)
 
-	// Wait for LoadBalancer to become active before continuing
+	// Wait for LoadBalancer to become active before continuing.
 	err = waitForLBV2LoadBalancer(lbClient, lbID, "ACTIVE", lbPendingStatuses, timeout)
 	if err != nil {
 		return err
 	}
 
+	// Choose either the Octavia or Neutron create options.
+	var createOpts neutronlisteners.CreateOptsBuilder
+	if config.useOctavia {
+		// Use Octavia.
+		opts := octavialisteners.CreateOpts{
+			Protocol:               octavialisteners.Protocol(d.Get("protocol").(string)),
+			ProtocolPort:           d.Get("protocol_port").(int),
+			ProjectID:              d.Get("tenant_id").(string),
+			LoadbalancerID:         lbID,
+			Name:                   d.Get("name").(string),
+			DefaultPoolID:          d.Get("default_pool_id").(string),
+			Description:            d.Get("description").(string),
+			DefaultTlsContainerRef: d.Get("default_tls_container_ref").(string),
+			SniContainerRefs:       sniContainerRefs,
+			AdminStateUp:           &adminStateUp,
+		}
+
+		if v, ok := d.GetOk("connection_limit"); ok {
+			connectionLimit := v.(int)
+			opts.ConnLimit = &connectionLimit
+		}
+
+		if v, ok := d.GetOk("timeout_client_data"); ok {
+			timeoutClientData := v.(int)
+			opts.TimeoutClientData = &timeoutClientData
+		}
+
+		if v, ok := d.GetOk("timeout_member_connect"); ok {
+			timeoutMemberConnect := v.(int)
+			opts.TimeoutMemberConnect = &timeoutMemberConnect
+		}
+
+		if v, ok := d.GetOk("timeout_member_data"); ok {
+			timeoutMemberData := v.(int)
+			opts.TimeoutMemberData = &timeoutMemberData
+		}
+
+		if v, ok := d.GetOk("timeout_tcp_inspect"); ok {
+			timeoutTCPInspect := v.(int)
+			opts.TimeoutTCPInspect = &timeoutTCPInspect
+		}
+
+		log.Printf("[DEBUG] Create Options: %#v", opts)
+
+		createOpts = opts
+	} else {
+		// Use Neutron.
+		opts := neutronlisteners.CreateOpts{
+			Protocol:               neutronlisteners.Protocol(d.Get("protocol").(string)),
+			ProtocolPort:           d.Get("protocol_port").(int),
+			TenantID:               d.Get("tenant_id").(string),
+			LoadbalancerID:         lbID,
+			Name:                   d.Get("name").(string),
+			DefaultPoolID:          d.Get("default_pool_id").(string),
+			Description:            d.Get("description").(string),
+			DefaultTlsContainerRef: d.Get("default_tls_container_ref").(string),
+			SniContainerRefs:       sniContainerRefs,
+			AdminStateUp:           &adminStateUp,
+		}
+
+		if v, ok := d.GetOk("connection_limit"); ok {
+			connectionLimit := v.(int)
+			opts.ConnLimit = &connectionLimit
+		}
+
+		log.Printf("[DEBUG] Create Options: %#v", opts)
+
+		createOpts = opts
+	}
+
 	log.Printf("[DEBUG] Attempting to create listener")
-	var listener *listeners.Listener
+	var listener *neutronlisteners.Listener
 	err = resource.Retry(timeout, func() *resource.RetryError {
-		listener, err = listeners.Create(lbClient, createOpts).Extract()
+		listener, err = neutronlisteners.Create(lbClient, createOpts).Extract()
 		if err != nil {
 			return checkForRetryableError(err)
 		}
@@ -186,29 +262,59 @@ func resourceListenerV2Read(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
-	listener, err := listeners.Get(lbClient, d.Id()).Extract()
-	if err != nil {
-		return CheckDeleted(d, err, "listener")
+	listenerResp := neutronlisteners.Get(lbClient, d.Id())
+
+	// Choose either the Octavia or Neutron response type.
+	if config.useOctavia {
+		var listener octavialisteners.Listener
+		err = listenerResp.ExtractInto(listener)
+		if err != nil {
+			return CheckDeleted(d, err, "listener")
+		}
+
+		log.Printf("[DEBUG] Retrieved listener %s: %#v", d.Id(), listener)
+
+		d.Set("name", listener.Name)
+		d.Set("protocol", listener.Protocol)
+		d.Set("tenant_id", listener.ProjectID)
+		d.Set("description", listener.Description)
+		d.Set("protocol_port", listener.ProtocolPort)
+		d.Set("admin_state_up", listener.AdminStateUp)
+		d.Set("default_pool_id", listener.DefaultPoolID)
+		d.Set("connection_limit", listener.ConnLimit)
+		d.Set("timeout_client_data", listener.TimeoutClientData)
+		d.Set("timeout_member_connect", listener.TimeoutMemberConnect)
+		d.Set("timeout_member_data", listener.TimeoutMemberData)
+		d.Set("timeout_tcp_inspect", listener.TimeoutTCPInspect)
+		d.Set("sni_container_refs", listener.SniContainerRefs)
+		d.Set("default_tls_container_ref", listener.DefaultTlsContainerRef)
+		d.Set("region", GetRegion(d, config))
+	} else {
+		var listener neutronlisteners.Listener
+		err = listenerResp.ExtractInto(listener)
+		if err != nil {
+			return CheckDeleted(d, err, "listener")
+		}
+
+		log.Printf("[DEBUG] Retrieved listener %s: %#v", d.Id(), listener)
+
+		// Required by import
+		if len(listener.Loadbalancers) > 0 {
+			d.Set("loadbalancer_id", listener.Loadbalancers[0].ID)
+		}
+
+		d.Set("name", listener.Name)
+		d.Set("protocol", listener.Protocol)
+		d.Set("tenant_id", listener.TenantID)
+		d.Set("description", listener.Description)
+		d.Set("protocol_port", listener.ProtocolPort)
+		d.Set("admin_state_up", listener.AdminStateUp)
+		d.Set("default_pool_id", listener.DefaultPoolID)
+		d.Set("connection_limit", listener.ConnLimit)
+		d.Set("sni_container_refs", listener.SniContainerRefs)
+		d.Set("default_tls_container_ref", listener.DefaultTlsContainerRef)
+		d.Set("region", GetRegion(d, config))
 	}
-
-	log.Printf("[DEBUG] Retrieved listener %s: %#v", d.Id(), listener)
-
-	// Required by import
-	if len(listener.Loadbalancers) > 0 {
-		d.Set("loadbalancer_id", listener.Loadbalancers[0].ID)
-	}
-
-	d.Set("name", listener.Name)
-	d.Set("protocol", listener.Protocol)
-	d.Set("tenant_id", listener.TenantID)
-	d.Set("description", listener.Description)
-	d.Set("protocol_port", listener.ProtocolPort)
-	d.Set("admin_state_up", listener.AdminStateUp)
-	d.Set("default_pool_id", listener.DefaultPoolID)
-	d.Set("connection_limit", listener.ConnLimit)
-	d.Set("sni_container_refs", listener.SniContainerRefs)
-	d.Set("default_tls_container_ref", listener.DefaultTlsContainerRef)
-	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
@@ -221,43 +327,9 @@ func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Get a clean copy of the listener.
-	listener, err := listeners.Get(lbClient, d.Id()).Extract()
+	listener, err := neutronlisteners.Get(lbClient, d.Id()).Extract()
 	if err != nil {
 		return fmt.Errorf("Unable to retrieve listener %s: %s", d.Id(), err)
-	}
-
-	var updateOpts listeners.UpdateOpts
-	if d.HasChange("name") {
-		name := d.Get("name").(string)
-		updateOpts.Name = &name
-	}
-	if d.HasChange("description") {
-		description := d.Get("description").(string)
-		updateOpts.Description = &description
-	}
-	if d.HasChange("connection_limit") {
-		connLimit := d.Get("connection_limit").(int)
-		updateOpts.ConnLimit = &connLimit
-	}
-	if d.HasChange("default_pool_id") {
-		defaultPoolID := d.Get("default_pool_id").(string)
-		updateOpts.DefaultPoolID = &defaultPoolID
-	}
-	if d.HasChange("default_tls_container_ref") {
-		updateOpts.DefaultTlsContainerRef = d.Get("default_tls_container_ref").(string)
-	}
-	if d.HasChange("sni_container_refs") {
-		var sniContainerRefs []string
-		if raw, ok := d.GetOk("sni_container_refs"); ok {
-			for _, v := range raw.([]interface{}) {
-				sniContainerRefs = append(sniContainerRefs, v.(string))
-			}
-		}
-		updateOpts.SniContainerRefs = sniContainerRefs
-	}
-	if d.HasChange("admin_state_up") {
-		asu := d.Get("admin_state_up").(bool)
-		updateOpts.AdminStateUp = &asu
 	}
 
 	// Wait for the listener to become ACTIVE.
@@ -267,9 +339,103 @@ func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	// Choose either the Octavia or Neutron update options.
+	var updateOpts neutronlisteners.UpdateOptsBuilder
+	if config.useOctavia {
+		// Use Octavia.
+		var opts octavialisteners.UpdateOpts
+		if d.HasChange("name") {
+			name := d.Get("name").(string)
+			opts.Name = &name
+		}
+		if d.HasChange("description") {
+			description := d.Get("description").(string)
+			opts.Description = &description
+		}
+		if d.HasChange("connection_limit") {
+			connLimit := d.Get("connection_limit").(int)
+			opts.ConnLimit = &connLimit
+		}
+		if d.HasChange("timeout_client_data") {
+			timeoutClientData := d.Get("timeout_client_data").(int)
+			opts.ConnLimit = &timeoutClientData
+		}
+		if d.HasChange("timeout_member_connect") {
+			timeoutMemberConnect := d.Get("timeout_member_connect").(int)
+			opts.ConnLimit = &timeoutMemberConnect
+		}
+		if d.HasChange("timeout_member_data") {
+			timeoutMemberData := d.Get("timeout_member_data").(int)
+			opts.ConnLimit = &timeoutMemberData
+		}
+		if d.HasChange("timeout_tcp_inspect") {
+			timeoutTCPInspect := d.Get("timeout_tcp_inspect").(int)
+			opts.ConnLimit = &timeoutTCPInspect
+		}
+		if d.HasChange("default_pool_id") {
+			defaultPoolID := d.Get("default_pool_id").(string)
+			opts.DefaultPoolID = &defaultPoolID
+		}
+		if d.HasChange("default_tls_container_ref") {
+			opts.DefaultTlsContainerRef = d.Get("default_tls_container_ref").(string)
+		}
+		if d.HasChange("sni_container_refs") {
+			var sniContainerRefs []string
+			if raw, ok := d.GetOk("sni_container_refs"); ok {
+				for _, v := range raw.([]interface{}) {
+					sniContainerRefs = append(sniContainerRefs, v.(string))
+				}
+			}
+			opts.SniContainerRefs = sniContainerRefs
+		}
+		if d.HasChange("admin_state_up") {
+			asu := d.Get("admin_state_up").(bool)
+			opts.AdminStateUp = &asu
+		}
+
+		updateOpts = opts
+	} else {
+		// Use Neutron.
+		var opts neutronlisteners.UpdateOpts
+		if d.HasChange("name") {
+			name := d.Get("name").(string)
+			opts.Name = &name
+		}
+		if d.HasChange("description") {
+			description := d.Get("description").(string)
+			opts.Description = &description
+		}
+		if d.HasChange("connection_limit") {
+			connLimit := d.Get("connection_limit").(int)
+			opts.ConnLimit = &connLimit
+		}
+		if d.HasChange("default_pool_id") {
+			defaultPoolID := d.Get("default_pool_id").(string)
+			opts.DefaultPoolID = &defaultPoolID
+		}
+		if d.HasChange("default_tls_container_ref") {
+			opts.DefaultTlsContainerRef = d.Get("default_tls_container_ref").(string)
+		}
+		if d.HasChange("sni_container_refs") {
+			var sniContainerRefs []string
+			if raw, ok := d.GetOk("sni_container_refs"); ok {
+				for _, v := range raw.([]interface{}) {
+					sniContainerRefs = append(sniContainerRefs, v.(string))
+				}
+			}
+			opts.SniContainerRefs = sniContainerRefs
+		}
+		if d.HasChange("admin_state_up") {
+			asu := d.Get("admin_state_up").(bool)
+			opts.AdminStateUp = &asu
+		}
+
+		updateOpts = opts
+	}
+
 	log.Printf("[DEBUG] Updating listener %s with options: %#v", d.Id(), updateOpts)
 	err = resource.Retry(timeout, func() *resource.RetryError {
-		_, err = listeners.Update(lbClient, d.Id(), updateOpts).Extract()
+		_, err = neutronlisteners.Update(lbClient, d.Id(), updateOpts).Extract()
 		if err != nil {
 			return checkForRetryableError(err)
 		}
@@ -298,7 +464,7 @@ func resourceListenerV2Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Get a clean copy of the listener.
-	listener, err := listeners.Get(lbClient, d.Id()).Extract()
+	listener, err := neutronlisteners.Get(lbClient, d.Id()).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "Unable to retrieve listener")
 	}
@@ -307,7 +473,7 @@ func resourceListenerV2Delete(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Deleting listener %s", d.Id())
 	err = resource.Retry(timeout, func() *resource.RetryError {
-		err = listeners.Delete(lbClient, d.Id()).ExtractErr()
+		err = neutronlisteners.Delete(lbClient, d.Id()).ExtractErr()
 		if err != nil {
 			return checkForRetryableError(err)
 		}

--- a/openstack/resource_openstack_lb_listener_v2.go
+++ b/openstack/resource_openstack_lb_listener_v2.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
-	octavialisteners "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
 	neutronlisteners "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners"
 )
 
@@ -143,94 +142,18 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
-	lbID := d.Get("loadbalancer_id").(string)
-	adminStateUp := d.Get("admin_state_up").(bool)
-	var sniContainerRefs []string
-	if raw, ok := d.GetOk("sni_container_refs"); ok {
-		for _, v := range raw.([]interface{}) {
-			sniContainerRefs = append(sniContainerRefs, v.(string))
-		}
-	}
-
 	timeout := d.Timeout(schema.TimeoutCreate)
 
 	// Wait for LoadBalancer to become active before continuing.
-	err = waitForLBV2LoadBalancer(lbClient, lbID, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2LoadBalancer(lbClient, d.Get("loadbalancer_id").(string), "ACTIVE", lbPendingStatuses, timeout)
 	if err != nil {
 		return err
 	}
 
 	// Choose either the Octavia or Neutron create options.
-	var createOpts neutronlisteners.CreateOptsBuilder
-	if config.useOctavia {
-		// Use Octavia.
-		opts := octavialisteners.CreateOpts{
-			Protocol:               octavialisteners.Protocol(d.Get("protocol").(string)),
-			ProtocolPort:           d.Get("protocol_port").(int),
-			ProjectID:              d.Get("tenant_id").(string),
-			LoadbalancerID:         lbID,
-			Name:                   d.Get("name").(string),
-			DefaultPoolID:          d.Get("default_pool_id").(string),
-			Description:            d.Get("description").(string),
-			DefaultTlsContainerRef: d.Get("default_tls_container_ref").(string),
-			SniContainerRefs:       sniContainerRefs,
-			AdminStateUp:           &adminStateUp,
-		}
+	createOpts := chooseLBV2ListenerCreateOpts(d, config)
 
-		if v, ok := d.GetOk("connection_limit"); ok {
-			connectionLimit := v.(int)
-			opts.ConnLimit = &connectionLimit
-		}
-
-		if v, ok := d.GetOk("timeout_client_data"); ok {
-			timeoutClientData := v.(int)
-			opts.TimeoutClientData = &timeoutClientData
-		}
-
-		if v, ok := d.GetOk("timeout_member_connect"); ok {
-			timeoutMemberConnect := v.(int)
-			opts.TimeoutMemberConnect = &timeoutMemberConnect
-		}
-
-		if v, ok := d.GetOk("timeout_member_data"); ok {
-			timeoutMemberData := v.(int)
-			opts.TimeoutMemberData = &timeoutMemberData
-		}
-
-		if v, ok := d.GetOk("timeout_tcp_inspect"); ok {
-			timeoutTCPInspect := v.(int)
-			opts.TimeoutTCPInspect = &timeoutTCPInspect
-		}
-
-		log.Printf("[DEBUG] Create Options: %#v", opts)
-
-		createOpts = opts
-	} else {
-		// Use Neutron.
-		opts := neutronlisteners.CreateOpts{
-			Protocol:               neutronlisteners.Protocol(d.Get("protocol").(string)),
-			ProtocolPort:           d.Get("protocol_port").(int),
-			TenantID:               d.Get("tenant_id").(string),
-			LoadbalancerID:         lbID,
-			Name:                   d.Get("name").(string),
-			DefaultPoolID:          d.Get("default_pool_id").(string),
-			Description:            d.Get("description").(string),
-			DefaultTlsContainerRef: d.Get("default_tls_container_ref").(string),
-			SniContainerRefs:       sniContainerRefs,
-			AdminStateUp:           &adminStateUp,
-		}
-
-		if v, ok := d.GetOk("connection_limit"); ok {
-			connectionLimit := v.(int)
-			opts.ConnLimit = &connectionLimit
-		}
-
-		log.Printf("[DEBUG] Create Options: %#v", opts)
-
-		createOpts = opts
-	}
-
-	log.Printf("[DEBUG] Attempting to create listener")
+	log.Printf("[DEBUG] openstack_lb_listener_v2 create options: %#v", createOpts)
 	var listener *neutronlisteners.Listener
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		listener, err = neutronlisteners.Create(lbClient, createOpts).Extract()
@@ -241,7 +164,7 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("Error creating listener: %s", err)
+		return fmt.Errorf("Error creating openstack_lb_listener_v2: %s", err)
 	}
 
 	// Wait for the listener to become ACTIVE.
@@ -262,61 +185,7 @@ func resourceListenerV2Read(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
-	listenerResp := neutronlisteners.Get(lbClient, d.Id())
-
-	// Choose either the Octavia or Neutron response type.
-	if config.useOctavia {
-		var listener octavialisteners.Listener
-		err = listenerResp.ExtractInto(listener)
-		if err != nil {
-			return CheckDeleted(d, err, "listener")
-		}
-
-		log.Printf("[DEBUG] Retrieved listener %s: %#v", d.Id(), listener)
-
-		d.Set("name", listener.Name)
-		d.Set("protocol", listener.Protocol)
-		d.Set("tenant_id", listener.ProjectID)
-		d.Set("description", listener.Description)
-		d.Set("protocol_port", listener.ProtocolPort)
-		d.Set("admin_state_up", listener.AdminStateUp)
-		d.Set("default_pool_id", listener.DefaultPoolID)
-		d.Set("connection_limit", listener.ConnLimit)
-		d.Set("timeout_client_data", listener.TimeoutClientData)
-		d.Set("timeout_member_connect", listener.TimeoutMemberConnect)
-		d.Set("timeout_member_data", listener.TimeoutMemberData)
-		d.Set("timeout_tcp_inspect", listener.TimeoutTCPInspect)
-		d.Set("sni_container_refs", listener.SniContainerRefs)
-		d.Set("default_tls_container_ref", listener.DefaultTlsContainerRef)
-		d.Set("region", GetRegion(d, config))
-	} else {
-		var listener neutronlisteners.Listener
-		err = listenerResp.ExtractInto(listener)
-		if err != nil {
-			return CheckDeleted(d, err, "listener")
-		}
-
-		log.Printf("[DEBUG] Retrieved listener %s: %#v", d.Id(), listener)
-
-		// Required by import
-		if len(listener.Loadbalancers) > 0 {
-			d.Set("loadbalancer_id", listener.Loadbalancers[0].ID)
-		}
-
-		d.Set("name", listener.Name)
-		d.Set("protocol", listener.Protocol)
-		d.Set("tenant_id", listener.TenantID)
-		d.Set("description", listener.Description)
-		d.Set("protocol_port", listener.ProtocolPort)
-		d.Set("admin_state_up", listener.AdminStateUp)
-		d.Set("default_pool_id", listener.DefaultPoolID)
-		d.Set("connection_limit", listener.ConnLimit)
-		d.Set("sni_container_refs", listener.SniContainerRefs)
-		d.Set("default_tls_container_ref", listener.DefaultTlsContainerRef)
-		d.Set("region", GetRegion(d, config))
-	}
-
-	return nil
+	return chooseLBV2ListenerReadBody(neutronlisteners.Get(lbClient, d.Id()), d, config)
 }
 
 func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
@@ -329,7 +198,7 @@ func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
 	// Get a clean copy of the listener.
 	listener, err := neutronlisteners.Get(lbClient, d.Id()).Extract()
 	if err != nil {
-		return fmt.Errorf("Unable to retrieve listener %s: %s", d.Id(), err)
+		return fmt.Errorf("Unable to retrieve openstack_lb_listener_v2 %s: %s", d.Id(), err)
 	}
 
 	// Wait for the listener to become ACTIVE.
@@ -339,101 +208,9 @@ func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	// Choose either the Octavia or Neutron update options.
-	var updateOpts neutronlisteners.UpdateOptsBuilder
-	if config.useOctavia {
-		// Use Octavia.
-		var opts octavialisteners.UpdateOpts
-		if d.HasChange("name") {
-			name := d.Get("name").(string)
-			opts.Name = &name
-		}
-		if d.HasChange("description") {
-			description := d.Get("description").(string)
-			opts.Description = &description
-		}
-		if d.HasChange("connection_limit") {
-			connLimit := d.Get("connection_limit").(int)
-			opts.ConnLimit = &connLimit
-		}
-		if d.HasChange("timeout_client_data") {
-			timeoutClientData := d.Get("timeout_client_data").(int)
-			opts.ConnLimit = &timeoutClientData
-		}
-		if d.HasChange("timeout_member_connect") {
-			timeoutMemberConnect := d.Get("timeout_member_connect").(int)
-			opts.ConnLimit = &timeoutMemberConnect
-		}
-		if d.HasChange("timeout_member_data") {
-			timeoutMemberData := d.Get("timeout_member_data").(int)
-			opts.ConnLimit = &timeoutMemberData
-		}
-		if d.HasChange("timeout_tcp_inspect") {
-			timeoutTCPInspect := d.Get("timeout_tcp_inspect").(int)
-			opts.ConnLimit = &timeoutTCPInspect
-		}
-		if d.HasChange("default_pool_id") {
-			defaultPoolID := d.Get("default_pool_id").(string)
-			opts.DefaultPoolID = &defaultPoolID
-		}
-		if d.HasChange("default_tls_container_ref") {
-			opts.DefaultTlsContainerRef = d.Get("default_tls_container_ref").(string)
-		}
-		if d.HasChange("sni_container_refs") {
-			var sniContainerRefs []string
-			if raw, ok := d.GetOk("sni_container_refs"); ok {
-				for _, v := range raw.([]interface{}) {
-					sniContainerRefs = append(sniContainerRefs, v.(string))
-				}
-			}
-			opts.SniContainerRefs = sniContainerRefs
-		}
-		if d.HasChange("admin_state_up") {
-			asu := d.Get("admin_state_up").(bool)
-			opts.AdminStateUp = &asu
-		}
+	updateOpts := chooseLBV2ListenerUpdateOpts(d, config)
 
-		updateOpts = opts
-	} else {
-		// Use Neutron.
-		var opts neutronlisteners.UpdateOpts
-		if d.HasChange("name") {
-			name := d.Get("name").(string)
-			opts.Name = &name
-		}
-		if d.HasChange("description") {
-			description := d.Get("description").(string)
-			opts.Description = &description
-		}
-		if d.HasChange("connection_limit") {
-			connLimit := d.Get("connection_limit").(int)
-			opts.ConnLimit = &connLimit
-		}
-		if d.HasChange("default_pool_id") {
-			defaultPoolID := d.Get("default_pool_id").(string)
-			opts.DefaultPoolID = &defaultPoolID
-		}
-		if d.HasChange("default_tls_container_ref") {
-			opts.DefaultTlsContainerRef = d.Get("default_tls_container_ref").(string)
-		}
-		if d.HasChange("sni_container_refs") {
-			var sniContainerRefs []string
-			if raw, ok := d.GetOk("sni_container_refs"); ok {
-				for _, v := range raw.([]interface{}) {
-					sniContainerRefs = append(sniContainerRefs, v.(string))
-				}
-			}
-			opts.SniContainerRefs = sniContainerRefs
-		}
-		if d.HasChange("admin_state_up") {
-			asu := d.Get("admin_state_up").(bool)
-			opts.AdminStateUp = &asu
-		}
-
-		updateOpts = opts
-	}
-
-	log.Printf("[DEBUG] Updating listener %s with options: %#v", d.Id(), updateOpts)
+	log.Printf("[DEBUG] openstack_lb_listener_v2 %s update options: %#v", d.Id(), updateOpts)
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		_, err = neutronlisteners.Update(lbClient, d.Id(), updateOpts).Extract()
 		if err != nil {
@@ -443,7 +220,7 @@ func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("Error updating listener %s: %s", d.Id(), err)
+		return fmt.Errorf("Error updating openstack_lb_listener_v2 %s: %s", d.Id(), err)
 	}
 
 	// Wait for the listener to become ACTIVE.
@@ -466,12 +243,12 @@ func resourceListenerV2Delete(d *schema.ResourceData, meta interface{}) error {
 	// Get a clean copy of the listener.
 	listener, err := neutronlisteners.Get(lbClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Unable to retrieve listener")
+		return CheckDeleted(d, err, "Unable to retrieve openstack_lb_listener_v2")
 	}
 
 	timeout := d.Timeout(schema.TimeoutDelete)
 
-	log.Printf("[DEBUG] Deleting listener %s", d.Id())
+	log.Printf("[DEBUG] Deleting openstack_lb_listener_v2 %s", d.Id())
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err = neutronlisteners.Delete(lbClient, d.Id()).ExtractErr()
 		if err != nil {
@@ -481,7 +258,7 @@ func resourceListenerV2Delete(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	if err != nil {
-		return CheckDeleted(d, err, "Error deleting listener")
+		return CheckDeleted(d, err, "Error deleting openstack_lb_listener_v2")
 	}
 
 	// Wait for the listener to become DELETED.

--- a/openstack/resource_openstack_lb_listener_v2_test.go
+++ b/openstack/resource_openstack_lb_listener_v2_test.go
@@ -38,6 +38,54 @@ func TestAccLBV2Listener_basic(t *testing.T) {
 	})
 }
 
+func TestAccLBV2Listener_octavia(t *testing.T) {
+	var listener listeners.Listener
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckLB(t)
+			testAccPreCheckUseOctavia(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLBV2ListenerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: TestAccLBV2ListenerConfig_octavia,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLBV2ListenerExists("openstack_lb_listener_v2.listener_1", &listener),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_listener_v2.listener_1", "connection_limit", "5"),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_listener_v2.listener_1", "timeout_client_data", "10"),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_listener_v2.listener_1", "timeout_member_connect", "20"),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_listener_v2.listener_1", "timeout_member_data", "30"),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_listener_v2.listener_1", "timeout_tcp_inspect", "40"),
+				),
+			},
+			{
+				Config: TestAccLBV2ListenerConfig_octavia_update,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"openstack_lb_listener_v2.listener_1", "name", "listener_1_updated"),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_listener_v2.listener_1", "connection_limit", "100"),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_listener_v2.listener_1", "timeout_client_data", "40"),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_listener_v2.listener_1", "timeout_member_connect", "30"),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_listener_v2.listener_1", "timeout_member_data", "20"),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_listener_v2.listener_1", "timeout_tcp_inspect", "10"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckLBV2ListenerDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	lbClient, err := chooseLBV2AccTestClient(config, OS_REGION_NAME)
@@ -123,11 +171,11 @@ resource "openstack_lb_listener_v2" "listener_1" {
   default_pool_id = "${openstack_lb_pool_v2.pool_1.id}"
   loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"
 
-	timeouts {
-		create = "5m"
-		update = "5m"
-		delete = "5m"
-	}
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
 }
 `
 
@@ -157,10 +205,101 @@ resource "openstack_lb_listener_v2" "listener_1" {
   admin_state_up = "true"
   loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"
 
-	timeouts {
-		create = "5m"
-		update = "5m"
-		delete = "5m"
-	}
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+`
+
+const TestAccLBV2ListenerConfig_octavia = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name = "subnet_1"
+  cidr = "192.168.199.0/24"
+  ip_version = 4
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+}
+
+resource "openstack_lb_loadbalancer_v2" "loadbalancer_1" {
+  name = "loadbalancer_1"
+  vip_subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+}
+
+resource "openstack_lb_pool_v2" "pool_1" {
+  name            = "pool_1"
+  protocol        = "HTTP"
+  lb_method       = "ROUND_ROBIN"
+  loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"
+}
+
+resource "openstack_lb_listener_v2" "listener_1" {
+  name = "listener_1"
+  protocol = "HTTP"
+  protocol_port = 8080
+  connection_limit = 5
+  timeout_client_data = 10
+  timeout_member_connect = 20
+  timeout_member_data = 30
+  timeout_tcp_inspect = 40
+  default_pool_id = "${openstack_lb_pool_v2.pool_1.id}"
+  loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+`
+
+const TestAccLBV2ListenerConfig_octavia_update = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name = "subnet_1"
+  cidr = "192.168.199.0/24"
+  ip_version = 4
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+}
+
+resource "openstack_lb_loadbalancer_v2" "loadbalancer_1" {
+  name = "loadbalancer_1"
+  vip_subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+}
+
+resource "openstack_lb_pool_v2" "pool_1" {
+  name            = "pool_1"
+  protocol        = "HTTP"
+  lb_method       = "ROUND_ROBIN"
+  loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"
+}
+
+resource "openstack_lb_listener_v2" "listener_1" {
+  name = "listener_1"
+  protocol = "HTTP"
+  protocol_port = 8080
+  connection_limit = 100
+  timeout_client_data = 40
+  timeout_member_connect = 30
+  timeout_member_data = 20
+  timeout_tcp_inspect = 10
+  admin_state_up = "true"
+  default_pool_id = "${openstack_lb_pool_v2.pool_1.id}"
+  loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
 }
 `

--- a/openstack/resource_openstack_lb_listener_v2_test.go
+++ b/openstack/resource_openstack_lb_listener_v2_test.go
@@ -56,13 +56,13 @@ func TestAccLBV2Listener_octavia(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"openstack_lb_listener_v2.listener_1", "connection_limit", "5"),
 					resource.TestCheckResourceAttr(
-						"openstack_lb_listener_v2.listener_1", "timeout_client_data", "10"),
+						"openstack_lb_listener_v2.listener_1", "timeout_client_data", "1000"),
 					resource.TestCheckResourceAttr(
-						"openstack_lb_listener_v2.listener_1", "timeout_member_connect", "20"),
+						"openstack_lb_listener_v2.listener_1", "timeout_member_connect", "2000"),
 					resource.TestCheckResourceAttr(
-						"openstack_lb_listener_v2.listener_1", "timeout_member_data", "30"),
+						"openstack_lb_listener_v2.listener_1", "timeout_member_data", "3000"),
 					resource.TestCheckResourceAttr(
-						"openstack_lb_listener_v2.listener_1", "timeout_tcp_inspect", "40"),
+						"openstack_lb_listener_v2.listener_1", "timeout_tcp_inspect", "4000"),
 				),
 			},
 			{
@@ -73,13 +73,13 @@ func TestAccLBV2Listener_octavia(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"openstack_lb_listener_v2.listener_1", "connection_limit", "100"),
 					resource.TestCheckResourceAttr(
-						"openstack_lb_listener_v2.listener_1", "timeout_client_data", "40"),
+						"openstack_lb_listener_v2.listener_1", "timeout_client_data", "4000"),
 					resource.TestCheckResourceAttr(
-						"openstack_lb_listener_v2.listener_1", "timeout_member_connect", "30"),
+						"openstack_lb_listener_v2.listener_1", "timeout_member_connect", "3000"),
 					resource.TestCheckResourceAttr(
-						"openstack_lb_listener_v2.listener_1", "timeout_member_data", "20"),
+						"openstack_lb_listener_v2.listener_1", "timeout_member_data", "2000"),
 					resource.TestCheckResourceAttr(
-						"openstack_lb_listener_v2.listener_1", "timeout_tcp_inspect", "10"),
+						"openstack_lb_listener_v2.listener_1", "timeout_tcp_inspect", "1000"),
 				),
 			},
 		},
@@ -243,10 +243,10 @@ resource "openstack_lb_listener_v2" "listener_1" {
   protocol = "HTTP"
   protocol_port = 8080
   connection_limit = 5
-  timeout_client_data = 10
-  timeout_member_connect = 20
-  timeout_member_data = 30
-  timeout_tcp_inspect = 40
+  timeout_client_data = 1000
+  timeout_member_connect = 2000
+  timeout_member_data = 3000
+  timeout_tcp_inspect = 4000
   default_pool_id = "${openstack_lb_pool_v2.pool_1.id}"
   loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"
 
@@ -288,10 +288,10 @@ resource "openstack_lb_listener_v2" "listener_1" {
   protocol = "HTTP"
   protocol_port = 8080
   connection_limit = 100
-  timeout_client_data = 40
-  timeout_member_connect = 30
-  timeout_member_data = 20
-  timeout_tcp_inspect = 10
+  timeout_client_data = 4000
+  timeout_member_connect = 3000
+  timeout_member_data = 2000
+  timeout_tcp_inspect = 1000
   admin_state_up = "true"
   default_pool_id = "${openstack_lb_pool_v2.pool_1.id}"
   loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"

--- a/vendor/github.com/gophercloud/gophercloud/go.mod
+++ b/vendor/github.com/gophercloud/gophercloud/go.mod
@@ -5,3 +5,5 @@ require (
 	golang.org/x/sys v0.0.0-20190209173611-3b5209105503 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.13

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies/doc.go
@@ -1,0 +1,123 @@
+/*
+Package l7policies provides information and interaction with L7Policies and
+Rules of the LBaaS v2 extension for the OpenStack Networking service.
+
+Example to Create a L7Policy
+
+	createOpts := l7policies.CreateOpts{
+		Name:        "redirect-example.com",
+		ListenerID:  "023f2e34-7806-443b-bfae-16c324569a3d",
+		Action:      l7policies.ActionRedirectToURL,
+		RedirectURL: "http://www.example.com",
+	}
+	l7policy, err := l7policies.Create(lbClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to List L7Policies
+
+	listOpts := l7policies.ListOpts{
+		ListenerID: "c79a4468-d788-410c-bf79-9a8ef6354852",
+	}
+	allPages, err := l7policies.List(lbClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+	allL7Policies, err := l7policies.ExtractL7Policies(allPages)
+	if err != nil {
+		panic(err)
+	}
+	for _, l7policy := range allL7Policies {
+		fmt.Printf("%+v\n", l7policy)
+	}
+
+Example to Get a L7Policy
+
+	l7policy, err := l7policies.Get(lbClient, "023f2e34-7806-443b-bfae-16c324569a3d").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a L7Policy
+
+	l7policyID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	err := l7policies.Delete(lbClient, l7policyID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a L7Policy
+
+	l7policyID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	name := "new-name"
+	updateOpts := l7policies.UpdateOpts{
+		Name: &name,
+	}
+	l7policy, err := l7policies.Update(lbClient, l7policyID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a Rule
+
+	l7policyID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	createOpts := l7policies.CreateRuleOpts{
+		RuleType:    l7policies.TypePath,
+		CompareType: l7policies.CompareTypeRegex,
+		Value:       "/images*",
+	}
+	rule, err := l7policies.CreateRule(lbClient, l7policyID, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to List L7 Rules
+
+	l7policyID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	listOpts := l7policies.ListRulesOpts{
+		RuleType: l7policies.TypePath,
+	}
+	allPages, err := l7policies.ListRules(lbClient, l7policyID, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+	allRules, err := l7policies.ExtractRules(allPages)
+	if err != nil {
+		panic(err)
+	}
+	for _, rule := allRules {
+		fmt.Printf("%+v\n", rule)
+	}
+
+Example to Get a l7 rule
+
+	l7rule, err := l7policies.GetRule(lbClient, "023f2e34-7806-443b-bfae-16c324569a3d", "53ad8ab8-40fa-11e8-a508-00224d6b7bc1").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a l7 rule
+
+	l7policyID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	ruleID := "64dba99f-8af8-4200-8882-e32a0660f23e"
+	err := l7policies.DeleteRule(lbClient, l7policyID, ruleID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Rule
+
+	l7policyID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	ruleID := "64dba99f-8af8-4200-8882-e32a0660f23e"
+	updateOpts := l7policies.UpdateRuleOpts{
+		RuleType:    l7policies.TypePath,
+		CompareType: l7policies.CompareTypeRegex,
+		Value:       "/images/special*",
+	}
+	rule, err := l7policies.UpdateRule(lbClient, l7policyID, ruleID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
+package l7policies

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies/requests.go
@@ -1,0 +1,376 @@
+package l7policies
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToL7PolicyCreateMap() (map[string]interface{}, error)
+}
+
+type Action string
+type RuleType string
+type CompareType string
+
+const (
+	ActionRedirectToPool Action = "REDIRECT_TO_POOL"
+	ActionRedirectToURL  Action = "REDIRECT_TO_URL"
+	ActionReject         Action = "REJECT"
+
+	TypeCookie   RuleType = "COOKIE"
+	TypeFileType RuleType = "FILE_TYPE"
+	TypeHeader   RuleType = "HEADER"
+	TypeHostName RuleType = "HOST_NAME"
+	TypePath     RuleType = "PATH"
+
+	CompareTypeContains  CompareType = "CONTAINS"
+	CompareTypeEndWith   CompareType = "ENDS_WITH"
+	CompareTypeEqual     CompareType = "EQUAL_TO"
+	CompareTypeRegex     CompareType = "REGEX"
+	CompareTypeStartWith CompareType = "STARTS_WITH"
+)
+
+// CreateOpts is the common options struct used in this package's Create
+// operation.
+type CreateOpts struct {
+	// Name of the L7 policy.
+	Name string `json:"name,omitempty"`
+
+	// The ID of the listener.
+	ListenerID string `json:"listener_id" required:"true"`
+
+	// The L7 policy action. One of REDIRECT_TO_POOL, REDIRECT_TO_URL, or REJECT.
+	Action Action `json:"action" required:"true"`
+
+	// The position of this policy on the listener.
+	Position int32 `json:"position,omitempty"`
+
+	// A human-readable description for the resource.
+	Description string `json:"description,omitempty"`
+
+	// ProjectID is the UUID of the project who owns the L7 policy in octavia.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// Requests matching this policy will be redirected to the pool with this ID.
+	// Only valid if action is REDIRECT_TO_POOL.
+	RedirectPoolID string `json:"redirect_pool_id,omitempty"`
+
+	// Requests matching this policy will be redirected to this URL.
+	// Only valid if action is REDIRECT_TO_URL.
+	RedirectURL string `json:"redirect_url,omitempty"`
+
+	// The administrative state of the Loadbalancer. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+}
+
+// ToL7PolicyCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToL7PolicyCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "l7policy")
+}
+
+// Create accepts a CreateOpts struct and uses the values to create a new l7policy.
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToL7PolicyCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToL7PolicyListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API.
+type ListOpts struct {
+	Name           string `q:"name"`
+	Description    string `q:"description"`
+	ListenerID     string `q:"listener_id"`
+	Action         string `q:"action"`
+	ProjectID      string `q:"project_id"`
+	RedirectPoolID string `q:"redirect_pool_id"`
+	RedirectURL    string `q:"redirect_url"`
+	Position       int32  `q:"position"`
+	AdminStateUp   bool   `q:"admin_state_up"`
+	ID             string `q:"id"`
+	Limit          int    `q:"limit"`
+	Marker         string `q:"marker"`
+	SortKey        string `q:"sort_key"`
+	SortDir        string `q:"sort_dir"`
+}
+
+// ToL7PolicyListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToL7PolicyListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// l7policies. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+//
+// Default policy settings return only those l7policies that are owned by the
+// project who submits the request, unless an admin user submits the request.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(c)
+	if opts != nil {
+		query, err := opts.ToL7PolicyListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return L7PolicyPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves a particular l7policy based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}
+
+// Delete will permanently delete a particular l7policy based on its unique ID.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, id), nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToL7PolicyUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts is the common options struct used in this package's Update
+// operation.
+type UpdateOpts struct {
+	// Name of the L7 policy, empty string is allowed.
+	Name *string `json:"name,omitempty"`
+
+	// The L7 policy action. One of REDIRECT_TO_POOL, REDIRECT_TO_URL, or REJECT.
+	Action Action `json:"action,omitempty"`
+
+	// The position of this policy on the listener.
+	Position int32 `json:"position,omitempty"`
+
+	// A human-readable description for the resource, empty string is allowed.
+	Description *string `json:"description,omitempty"`
+
+	// Requests matching this policy will be redirected to the pool with this ID.
+	// Only valid if action is REDIRECT_TO_POOL.
+	RedirectPoolID *string `json:"redirect_pool_id,omitempty"`
+
+	// Requests matching this policy will be redirected to this URL.
+	// Only valid if action is REDIRECT_TO_URL.
+	RedirectURL *string `json:"redirect_url,omitempty"`
+
+	// The administrative state of the Loadbalancer. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+}
+
+// ToL7PolicyUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToL7PolicyUpdateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "l7policy")
+	if err != nil {
+		return nil, err
+	}
+
+	m := b["l7policy"].(map[string]interface{})
+
+	if m["redirect_pool_id"] == "" {
+		m["redirect_pool_id"] = nil
+	}
+
+	if m["redirect_url"] == "" {
+		m["redirect_url"] = nil
+	}
+
+	return b, nil
+}
+
+// Update allows l7policy to be updated.
+func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToL7PolicyUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(resourceURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// CreateRuleOpts is the common options struct used in this package's CreateRule
+// operation.
+type CreateRuleOpts struct {
+	// The L7 rule type. One of COOKIE, FILE_TYPE, HEADER, HOST_NAME, or PATH.
+	RuleType RuleType `json:"type" required:"true"`
+
+	// The comparison type for the L7 rule. One of CONTAINS, ENDS_WITH, EQUAL_TO, REGEX, or STARTS_WITH.
+	CompareType CompareType `json:"compare_type" required:"true"`
+
+	// The value to use for the comparison. For example, the file type to compare.
+	Value string `json:"value" required:"true"`
+
+	// ProjectID is the UUID of the project who owns the rule in octavia.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// The key to use for the comparison. For example, the name of the cookie to evaluate.
+	Key string `json:"key,omitempty"`
+
+	// When true the logic of the rule is inverted. For example, with invert true,
+	// equal to would become not equal to. Default is false.
+	Invert bool `json:"invert,omitempty"`
+
+	// The administrative state of the Loadbalancer. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+}
+
+// ToRuleCreateMap builds a request body from CreateRuleOpts.
+func (opts CreateRuleOpts) ToRuleCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "rule")
+}
+
+// CreateRule will create and associate a Rule with a particular L7Policy.
+func CreateRule(c *gophercloud.ServiceClient, policyID string, opts CreateRuleOpts) (r CreateRuleResult) {
+	b, err := opts.ToRuleCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(ruleRootURL(c, policyID), b, &r.Body, nil)
+	return
+}
+
+// ListRulesOptsBuilder allows extensions to add additional parameters to the
+// ListRules request.
+type ListRulesOptsBuilder interface {
+	ToRulesListQuery() (string, error)
+}
+
+// ListRulesOpts allows the filtering and sorting of paginated collections
+// through the API.
+type ListRulesOpts struct {
+	RuleType     RuleType    `q:"type"`
+	ProjectID    string      `q:"project_id"`
+	CompareType  CompareType `q:"compare_type"`
+	Value        string      `q:"value"`
+	Key          string      `q:"key"`
+	Invert       bool        `q:"invert"`
+	AdminStateUp bool        `q:"admin_state_up"`
+	ID           string      `q:"id"`
+	Limit        int         `q:"limit"`
+	Marker       string      `q:"marker"`
+	SortKey      string      `q:"sort_key"`
+	SortDir      string      `q:"sort_dir"`
+}
+
+// ToRulesListQuery formats a ListOpts into a query string.
+func (opts ListRulesOpts) ToRulesListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// ListRules returns a Pager which allows you to iterate over a collection of
+// rules. It accepts a ListRulesOptsBuilder, which allows you to filter and
+// sort the returned collection for greater efficiency.
+//
+// Default policy settings return only those rules that are owned by the
+// project who submits the request, unless an admin user submits the request.
+func ListRules(c *gophercloud.ServiceClient, policyID string, opts ListRulesOptsBuilder) pagination.Pager {
+	url := ruleRootURL(c, policyID)
+	if opts != nil {
+		query, err := opts.ToRulesListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return RulePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// GetRule retrieves a particular L7Policy Rule based on its unique ID.
+func GetRule(c *gophercloud.ServiceClient, policyID string, ruleID string) (r GetRuleResult) {
+	_, r.Err = c.Get(ruleResourceURL(c, policyID, ruleID), &r.Body, nil)
+	return
+}
+
+// DeleteRule will remove a Rule from a particular L7Policy.
+func DeleteRule(c *gophercloud.ServiceClient, policyID string, ruleID string) (r DeleteRuleResult) {
+	_, r.Err = c.Delete(ruleResourceURL(c, policyID, ruleID), nil)
+	return
+}
+
+// UpdateRuleOptsBuilder allows to add additional parameters to the PUT request.
+type UpdateRuleOptsBuilder interface {
+	ToRuleUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateRuleOpts is the common options struct used in this package's Update
+// operation.
+type UpdateRuleOpts struct {
+	// The L7 rule type. One of COOKIE, FILE_TYPE, HEADER, HOST_NAME, or PATH.
+	RuleType RuleType `json:"type,omitempty"`
+
+	// The comparison type for the L7 rule. One of CONTAINS, ENDS_WITH, EQUAL_TO, REGEX, or STARTS_WITH.
+	CompareType CompareType `json:"compare_type,omitempty"`
+
+	// The value to use for the comparison. For example, the file type to compare.
+	Value string `json:"value,omitempty"`
+
+	// The key to use for the comparison. For example, the name of the cookie to evaluate.
+	Key *string `json:"key,omitempty"`
+
+	// When true the logic of the rule is inverted. For example, with invert true,
+	// equal to would become not equal to. Default is false.
+	Invert *bool `json:"invert,omitempty"`
+
+	// The administrative state of the Loadbalancer. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+}
+
+// ToRuleUpdateMap builds a request body from UpdateRuleOpts.
+func (opts UpdateRuleOpts) ToRuleUpdateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "rule")
+	if err != nil {
+		return nil, err
+	}
+
+	if m := b["rule"].(map[string]interface{}); m["key"] == "" {
+		m["key"] = nil
+	}
+
+	return b, nil
+}
+
+// UpdateRule allows Rule to be updated.
+func UpdateRule(c *gophercloud.ServiceClient, policyID string, ruleID string, opts UpdateRuleOptsBuilder) (r UpdateRuleResult) {
+	b, err := opts.ToRuleUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(ruleResourceURL(c, policyID, ruleID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies/results.go
@@ -1,0 +1,237 @@
+package l7policies
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// L7Policy is a collection of L7 rules associated with a Listener, and which
+// may also have an association to a back-end pool.
+type L7Policy struct {
+	// The unique ID for the L7 policy.
+	ID string `json:"id"`
+
+	// Name of the L7 policy.
+	Name string `json:"name"`
+
+	// The ID of the listener.
+	ListenerID string `json:"listener_id"`
+
+	// The L7 policy action. One of REDIRECT_TO_POOL, REDIRECT_TO_URL, or REJECT.
+	Action string `json:"action"`
+
+	// The position of this policy on the listener.
+	Position int32 `json:"position"`
+
+	// A human-readable description for the resource.
+	Description string `json:"description"`
+
+	// ProjectID is the UUID of the project who owns the L7 policy in octavia.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id"`
+
+	// Requests matching this policy will be redirected to the pool with this ID.
+	// Only valid if action is REDIRECT_TO_POOL.
+	RedirectPoolID string `json:"redirect_pool_id"`
+
+	// Requests matching this policy will be redirected to this URL.
+	// Only valid if action is REDIRECT_TO_URL.
+	RedirectURL string `json:"redirect_url"`
+
+	// The administrative state of the L7 policy, which is up (true) or down (false).
+	AdminStateUp bool `json:"admin_state_up"`
+
+	// The provisioning status of the L7 policy.
+	// This value is ACTIVE, PENDING_* or ERROR.
+	ProvisioningStatus string `json:"provisioning_status"`
+
+	// The operating status of the L7 policy.
+	OperatingStatus string `json:"operating_status"`
+
+	// Rules are List of associated L7 rule IDs.
+	Rules []Rule `json:"rules"`
+}
+
+// Rule represents layer 7 load balancing rule.
+type Rule struct {
+	// The unique ID for the L7 rule.
+	ID string `json:"id"`
+
+	// The L7 rule type. One of COOKIE, FILE_TYPE, HEADER, HOST_NAME, or PATH.
+	RuleType string `json:"type"`
+
+	// The comparison type for the L7 rule. One of CONTAINS, ENDS_WITH, EQUAL_TO, REGEX, or STARTS_WITH.
+	CompareType string `json:"compare_type"`
+
+	// The value to use for the comparison. For example, the file type to compare.
+	Value string `json:"value"`
+
+	// ProjectID is the UUID of the project who owns the rule in octavia.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id"`
+
+	// The key to use for the comparison. For example, the name of the cookie to evaluate.
+	Key string `json:"key"`
+
+	// When true the logic of the rule is inverted. For example, with invert true,
+	// equal to would become not equal to. Default is false.
+	Invert bool `json:"invert"`
+
+	// The administrative state of the L7 rule, which is up (true) or down (false).
+	AdminStateUp bool `json:"admin_state_up"`
+
+	// The provisioning status of the L7 rule.
+	// This value is ACTIVE, PENDING_* or ERROR.
+	ProvisioningStatus string `json:"provisioning_status"`
+
+	// The operating status of the L7 policy.
+	OperatingStatus string `json:"operating_status"`
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a l7policy.
+func (r commonResult) Extract() (*L7Policy, error) {
+	var s struct {
+		L7Policy *L7Policy `json:"l7policy"`
+	}
+	err := r.ExtractInto(&s)
+	return s.L7Policy, err
+}
+
+// CreateResult represents the result of a Create operation. Call its Extract
+// method to interpret the result as a L7Policy.
+type CreateResult struct {
+	commonResult
+}
+
+// L7PolicyPage is the page returned by a pager when traversing over a
+// collection of l7policies.
+type L7PolicyPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of l7policies has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r L7PolicyPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"l7policies_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a L7PolicyPage struct is empty.
+func (r L7PolicyPage) IsEmpty() (bool, error) {
+	is, err := ExtractL7Policies(r)
+	return len(is) == 0, err
+}
+
+// ExtractL7Policies accepts a Page struct, specifically a L7PolicyPage struct,
+// and extracts the elements into a slice of L7Policy structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractL7Policies(r pagination.Page) ([]L7Policy, error) {
+	var s struct {
+		L7Policies []L7Policy `json:"l7policies"`
+	}
+	err := (r.(L7PolicyPage)).ExtractInto(&s)
+	return s.L7Policies, err
+}
+
+// GetResult represents the result of a Get operation. Call its Extract
+// method to interpret the result as a L7Policy.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a Delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// UpdateResult represents the result of an Update operation. Call its Extract
+// method to interpret the result as a L7Policy.
+type UpdateResult struct {
+	commonResult
+}
+
+type commonRuleResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a rule.
+func (r commonRuleResult) Extract() (*Rule, error) {
+	var s struct {
+		Rule *Rule `json:"rule"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Rule, err
+}
+
+// CreateRuleResult represents the result of a CreateRule operation.
+// Call its Extract method to interpret it as a Rule.
+type CreateRuleResult struct {
+	commonRuleResult
+}
+
+// RulePage is the page returned by a pager when traversing over a
+// collection of Rules in a L7Policy.
+type RulePage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of rules has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r RulePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"rules_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a RulePage struct is empty.
+func (r RulePage) IsEmpty() (bool, error) {
+	is, err := ExtractRules(r)
+	return len(is) == 0, err
+}
+
+// ExtractRules accepts a Page struct, specifically a RulePage struct,
+// and extracts the elements into a slice of Rules structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractRules(r pagination.Page) ([]Rule, error) {
+	var s struct {
+		Rules []Rule `json:"rules"`
+	}
+	err := (r.(RulePage)).ExtractInto(&s)
+	return s.Rules, err
+}
+
+// GetRuleResult represents the result of a GetRule operation.
+// Call its Extract method to interpret it as a Rule.
+type GetRuleResult struct {
+	commonRuleResult
+}
+
+// DeleteRuleResult represents the result of a DeleteRule operation.
+// Call its ExtractErr method to determine if the request succeeded or failed.
+type DeleteRuleResult struct {
+	gophercloud.ErrResult
+}
+
+// UpdateRuleResult represents the result of an UpdateRule operation.
+// Call its Extract method to interpret it as a Rule.
+type UpdateRuleResult struct {
+	commonRuleResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies/urls.go
@@ -1,0 +1,25 @@
+package l7policies
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rootPath     = "lbaas"
+	resourcePath = "l7policies"
+	rulePath     = "rules"
+)
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath, resourcePath)
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id)
+}
+
+func ruleRootURL(c *gophercloud.ServiceClient, policyID string) string {
+	return c.ServiceURL(rootPath, resourcePath, policyID, rulePath)
+}
+
+func ruleResourceURL(c *gophercloud.ServiceClient, policyID string, ruleID string) string {
+	return c.ServiceURL(rootPath, resourcePath, policyID, rulePath, ruleID)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/doc.go
@@ -1,0 +1,74 @@
+/*
+Package listeners provides information and interaction with Listeners of the
+LBaaS v2 extension for the OpenStack Networking service.
+
+Example to List Listeners
+
+	listOpts := listeners.ListOpts{
+		LoadbalancerID : "ca430f80-1737-4712-8dc6-3f640d55594b",
+	}
+
+	allPages, err := listeners.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allListeners, err := listeners.ExtractListeners(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, listener := range allListeners {
+		fmt.Printf("%+v\n", listener)
+	}
+
+Example to Create a Listener
+
+	createOpts := listeners.CreateOpts{
+		Protocol:               "TCP",
+		Name:                   "db",
+		LoadbalancerID:         "79e05663-7f03-45d2-a092-8b94062f22ab",
+		AdminStateUp:           gophercloud.Enabled,
+		DefaultPoolID:          "41efe233-7591-43c5-9cf7-923964759f9e",
+		ProtocolPort:           3306,
+	}
+
+	listener, err := listeners.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Listener
+
+	listenerID := "d67d56a6-4a86-4688-a282-f46444705c64"
+
+	i1001 := 1001
+	i181000 := 181000
+	updateOpts := listeners.UpdateOpts{
+		ConnLimit: &i1001,
+		TimeoutClientData: &i181000,
+		TimeoutMemberData: &i181000,
+	}
+
+	listener, err := listeners.Update(networkClient, listenerID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Listener
+
+	listenerID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	err := listeners.Delete(networkClient, listenerID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Get the Statistics of a Listener
+
+	listenerID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	stats, err := listeners.GetStats(networkClient, listenerID).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
+package listeners

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/results.go
@@ -1,0 +1,190 @@
+package listeners
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type LoadBalancerID struct {
+	ID string `json:"id"`
+}
+
+// Listener is the primary load balancing configuration object that specifies
+// the loadbalancer and port on which client traffic is received, as well
+// as other details such as the load balancing method to be use, protocol, etc.
+type Listener struct {
+	// The unique ID for the Listener.
+	ID string `json:"id"`
+
+	// Owner of the Listener.
+	ProjectID string `json:"project_id"`
+
+	// Human-readable name for the Listener. Does not have to be unique.
+	Name string `json:"name"`
+
+	// Human-readable description for the Listener.
+	Description string `json:"description"`
+
+	// The protocol to loadbalance. A valid value is TCP, HTTP, or HTTPS.
+	Protocol string `json:"protocol"`
+
+	// The port on which to listen to client traffic that is associated with the
+	// Loadbalancer. A valid value is from 0 to 65535.
+	ProtocolPort int `json:"protocol_port"`
+
+	// The UUID of default pool. Must have compatible protocol with listener.
+	DefaultPoolID string `json:"default_pool_id"`
+
+	// A list of load balancer IDs.
+	Loadbalancers []LoadBalancerID `json:"loadbalancers"`
+
+	// The maximum number of connections allowed for the Loadbalancer.
+	// Default is -1, meaning no limit.
+	ConnLimit int `json:"connection_limit"`
+
+	// The list of references to TLS secrets.
+	SniContainerRefs []string `json:"sni_container_refs"`
+
+	// A reference to a Barbican container of TLS secrets.
+	DefaultTlsContainerRef string `json:"default_tls_container_ref"`
+
+	// The administrative state of the Listener. A valid value is true (UP) or false (DOWN).
+	AdminStateUp bool `json:"admin_state_up"`
+
+	// Pools are the pools which are part of this listener.
+	Pools []pools.Pool `json:"pools"`
+
+	// L7policies are the L7 policies which are part of this listener.
+	L7Policies []l7policies.L7Policy `json:"l7policies"`
+
+	// The provisioning status of the Listener.
+	// This value is ACTIVE, PENDING_* or ERROR.
+	ProvisioningStatus string `json:"provisioning_status"`
+
+	// Frontend client inactivity timeout in milliseconds
+	TimeoutClientData int `json:"timeout_client_data"`
+
+	// Backend member inactivity timeout in milliseconds
+	TimeoutMemberData int `json:"timeout_member_data"`
+
+	// Backend member connection timeout in milliseconds
+	TimeoutMemberConnect int `json:"timeout_member_connect"`
+
+	// Time, in milliseconds, to wait for additional TCP packets for content inspection
+	TimeoutTCPInspect int `json:"timeout_tcp_inspect"`
+
+	// A dictionary of optional headers to insert into the request before it is sent to the backend member.
+	InsertHeaders map[string]string `json:"insert_headers"`
+
+	// A list of IPv4, IPv6 or mix of both CIDRs
+	AllowedCIDRs []string `json:"allowed_cidrs"`
+}
+
+type Stats struct {
+	// The currently active connections.
+	ActiveConnections int `json:"active_connections"`
+
+	// The total bytes received.
+	BytesIn int `json:"bytes_in"`
+
+	// The total bytes sent.
+	BytesOut int `json:"bytes_out"`
+
+	// The total requests that were unable to be fulfilled.
+	RequestErrors int `json:"request_errors"`
+
+	// The total connections handled.
+	TotalConnections int `json:"total_connections"`
+}
+
+// ListenerPage is the page returned by a pager when traversing over a
+// collection of listeners.
+type ListenerPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of listeners has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r ListenerPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"listeners_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a ListenerPage struct is empty.
+func (r ListenerPage) IsEmpty() (bool, error) {
+	is, err := ExtractListeners(r)
+	return len(is) == 0, err
+}
+
+// ExtractListeners accepts a Page struct, specifically a ListenerPage struct,
+// and extracts the elements into a slice of Listener structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractListeners(r pagination.Page) ([]Listener, error) {
+	var s struct {
+		Listeners []Listener `json:"listeners"`
+	}
+	err := (r.(ListenerPage)).ExtractInto(&s)
+	return s.Listeners, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a listener.
+func (r commonResult) Extract() (*Listener, error) {
+	var s struct {
+		Listener *Listener `json:"listener"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Listener, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Listener.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Listener.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Listener.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// StatsResult represents the result of a GetStats operation.
+// Call its Extract method to interpret it as a Stats.
+type StatsResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts the status of
+// a Listener.
+func (r StatsResult) Extract() (*Stats, error) {
+	var s struct {
+		Stats *Stats `json:"stats"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Stats, err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/urls.go
@@ -1,0 +1,21 @@
+package listeners
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rootPath       = "lbaas"
+	resourcePath   = "listeners"
+	statisticsPath = "stats"
+)
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath, resourcePath)
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id)
+}
+
+func statisticsRootURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id, statisticsPath)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors/doc.go
@@ -1,0 +1,69 @@
+/*
+Package monitors provides information and interaction with Monitors
+of the LBaaS v2 extension for the OpenStack Networking service.
+
+Example to List Monitors
+
+	listOpts := monitors.ListOpts{
+		PoolID: "c79a4468-d788-410c-bf79-9a8ef6354852",
+	}
+
+	allPages, err := monitors.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allMonitors, err := monitors.ExtractMonitors(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, monitor := range allMonitors {
+		fmt.Printf("%+v\n", monitor)
+	}
+
+Example to Create a Monitor
+
+	createOpts := monitors.CreateOpts{
+		Type:          "HTTP",
+		Name:          "db",
+		PoolID:        "84f1b61f-58c4-45bf-a8a9-2dafb9e5214d",
+		Delay:         20,
+		Timeout:       10,
+		MaxRetries:    5,
+		URLPath:       "/check",
+		ExpectedCodes: "200-299",
+	}
+
+	monitor, err := monitors.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Monitor
+
+	monitorID := "d67d56a6-4a86-4688-a282-f46444705c64"
+
+	updateOpts := monitors.UpdateOpts{
+		Name:          "NewHealthmonitorName",
+		Delay:         3,
+		Timeout:       20,
+		MaxRetries:    10,
+		URLPath:       "/another_check",
+		ExpectedCodes: "301",
+	}
+
+	monitor, err := monitors.Update(networkClient, monitorID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Monitor
+
+	monitorID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	err := monitors.Delete(networkClient, monitorID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package monitors

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors/requests.go
@@ -1,0 +1,239 @@
+package monitors
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToMonitorListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the Monitor attributes you want to see returned. SortKey allows you to
+// sort by a particular Monitor attribute. SortDir sets the direction, and is
+// either `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	ID            string `q:"id"`
+	Name          string `q:"name"`
+	TenantID      string `q:"tenant_id"`
+	ProjectID     string `q:"project_id"`
+	PoolID        string `q:"pool_id"`
+	Type          string `q:"type"`
+	Delay         int    `q:"delay"`
+	Timeout       int    `q:"timeout"`
+	MaxRetries    int    `q:"max_retries"`
+	HTTPMethod    string `q:"http_method"`
+	URLPath       string `q:"url_path"`
+	ExpectedCodes string `q:"expected_codes"`
+	AdminStateUp  *bool  `q:"admin_state_up"`
+	Status        string `q:"status"`
+	Limit         int    `q:"limit"`
+	Marker        string `q:"marker"`
+	SortKey       string `q:"sort_key"`
+	SortDir       string `q:"sort_dir"`
+}
+
+// ToMonitorListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToMonitorListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), nil
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// health monitors. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+//
+// Default policy settings return only those health monitors that are owned by the
+// tenant who submits the request, unless an admin user submits the request.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(c)
+	if opts != nil {
+		query, err := opts.ToMonitorListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return MonitorPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Constants that represent approved monitoring types.
+const (
+	TypePING  = "PING"
+	TypeTCP   = "TCP"
+	TypeHTTP  = "HTTP"
+	TypeHTTPS = "HTTPS"
+)
+
+var (
+	errDelayMustGETimeout = fmt.Errorf("Delay must be greater than or equal to timeout")
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type CreateOptsBuilder interface {
+	ToMonitorCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts is the common options struct used in this package's Create
+// operation.
+type CreateOpts struct {
+	// The Pool to Monitor.
+	PoolID string `json:"pool_id" required:"true"`
+
+	// The type of probe, which is PING, TCP, HTTP, or HTTPS, that is
+	// sent by the load balancer to verify the member state.
+	Type string `json:"type" required:"true"`
+
+	// The time, in seconds, between sending probes to members.
+	Delay int `json:"delay" required:"true"`
+
+	// Maximum number of seconds for a Monitor to wait for a ping reply
+	// before it times out. The value must be less than the delay value.
+	Timeout int `json:"timeout" required:"true"`
+
+	// Number of permissible ping failures before changing the member's
+	// status to INACTIVE. Must be a number between 1 and 10.
+	MaxRetries int `json:"max_retries" required:"true"`
+
+	// URI path that will be accessed if Monitor type is HTTP or HTTPS.
+	URLPath string `json:"url_path,omitempty"`
+
+	// The HTTP method used for requests by the Monitor. If this attribute
+	// is not specified, it defaults to "GET". Required for HTTP(S) types.
+	HTTPMethod string `json:"http_method,omitempty"`
+
+	// Expected HTTP codes for a passing HTTP(S) Monitor. You can either specify
+	// a single status like "200", a range like "200-202", or a combination like
+	// "200-202, 401".
+	ExpectedCodes string `json:"expected_codes,omitempty"`
+
+	// TenantID is the UUID of the project who owns the Monitor.
+	// Only administrative users can specify a project UUID other than their own.
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// ProjectID is the UUID of the project who owns the Monitor.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// The Name of the Monitor.
+	Name string `json:"name,omitempty"`
+
+	// The administrative state of the Monitor. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+}
+
+// ToMonitorCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToMonitorCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "healthmonitor")
+}
+
+/*
+ Create is an operation which provisions a new Health Monitor. There are
+ different types of Monitor you can provision: PING, TCP or HTTP(S). Below
+ are examples of how to create each one.
+
+ Here is an example config struct to use when creating a PING or TCP Monitor:
+
+ CreateOpts{Type: TypePING, Delay: 20, Timeout: 10, MaxRetries: 3}
+ CreateOpts{Type: TypeTCP, Delay: 20, Timeout: 10, MaxRetries: 3}
+
+ Here is an example config struct to use when creating a HTTP(S) Monitor:
+
+ CreateOpts{Type: TypeHTTP, Delay: 20, Timeout: 10, MaxRetries: 3,
+ HttpMethod: "HEAD", ExpectedCodes: "200", PoolID: "2c946bfc-1804-43ab-a2ff-58f6a762b505"}
+*/
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToMonitorCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, nil)
+	return
+}
+
+// Get retrieves a particular Health Monitor based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToMonitorUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts is the common options struct used in this package's Update
+// operation.
+type UpdateOpts struct {
+	// The time, in seconds, between sending probes to members.
+	Delay int `json:"delay,omitempty"`
+
+	// Maximum number of seconds for a Monitor to wait for a ping reply
+	// before it times out. The value must be less than the delay value.
+	Timeout int `json:"timeout,omitempty"`
+
+	// Number of permissible ping failures before changing the member's
+	// status to INACTIVE. Must be a number between 1 and 10.
+	MaxRetries int `json:"max_retries,omitempty"`
+
+	// URI path that will be accessed if Monitor type is HTTP or HTTPS.
+	// Required for HTTP(S) types.
+	URLPath string `json:"url_path,omitempty"`
+
+	// The HTTP method used for requests by the Monitor. If this attribute
+	// is not specified, it defaults to "GET". Required for HTTP(S) types.
+	HTTPMethod string `json:"http_method,omitempty"`
+
+	// Expected HTTP codes for a passing HTTP(S) Monitor. You can either specify
+	// a single status like "200", or a range like "200-202". Required for HTTP(S)
+	// types.
+	ExpectedCodes string `json:"expected_codes,omitempty"`
+
+	// The Name of the Monitor.
+	Name *string `json:"name,omitempty"`
+
+	// The administrative state of the Monitor. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+}
+
+// ToMonitorUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToMonitorUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "healthmonitor")
+}
+
+// Update is an operation which modifies the attributes of the specified
+// Monitor.
+func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToMonitorUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = c.Put(resourceURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	return
+}
+
+// Delete will permanently delete a particular Monitor based on its unique ID.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, id), nil)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors/results.go
@@ -1,0 +1,156 @@
+package monitors
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type PoolID struct {
+	ID string `json:"id"`
+}
+
+// Monitor represents a load balancer health monitor. A health monitor is used
+// to determine whether or not back-end members of the VIP's pool are usable
+// for processing a request. A pool can have several health monitors associated
+// with it. There are different types of health monitors supported:
+//
+// PING: used to ping the members using ICMP.
+// TCP: used to connect to the members using TCP.
+// HTTP: used to send an HTTP request to the member.
+// HTTPS: used to send a secure HTTP request to the member.
+//
+// When a pool has several monitors associated with it, each member of the pool
+// is monitored by all these monitors. If any monitor declares the member as
+// unhealthy, then the member status is changed to INACTIVE and the member
+// won't participate in its pool's load balancing. In other words, ALL monitors
+// must declare the member to be healthy for it to stay ACTIVE.
+type Monitor struct {
+	// The unique ID for the Monitor.
+	ID string `json:"id"`
+
+	// The Name of the Monitor.
+	Name string `json:"name"`
+
+	// The owner of the Monitor.
+	ProjectID string `json:"project_id"`
+
+	// The type of probe sent by the load balancer to verify the member state,
+	// which is PING, TCP, HTTP, or HTTPS.
+	Type string `json:"type"`
+
+	// The time, in seconds, between sending probes to members.
+	Delay int `json:"delay"`
+
+	// The maximum number of seconds for a monitor to wait for a connection to be
+	// established before it times out. This value must be less than the delay
+	// value.
+	Timeout int `json:"timeout"`
+
+	// Number of allowed connection failures before changing the status of the
+	// member to INACTIVE. A valid value is from 1 to 10.
+	MaxRetries int `json:"max_retries"`
+
+	// The HTTP method that the monitor uses for requests.
+	HTTPMethod string `json:"http_method"`
+
+	// The HTTP path of the request sent by the monitor to test the health of a
+	// member. Must be a string beginning with a forward slash (/).
+	URLPath string `json:"url_path" `
+
+	// Expected HTTP codes for a passing HTTP(S) monitor.
+	ExpectedCodes string `json:"expected_codes"`
+
+	// The administrative state of the health monitor, which is up (true) or
+	// down (false).
+	AdminStateUp bool `json:"admin_state_up"`
+
+	// The status of the health monitor. Indicates whether the health monitor is
+	// operational.
+	Status string `json:"status"`
+
+	// List of pools that are associated with the health monitor.
+	Pools []PoolID `json:"pools"`
+
+	// The provisioning status of the Monitor.
+	// This value is ACTIVE, PENDING_* or ERROR.
+	ProvisioningStatus string `json:"provisioning_status"`
+
+	// The operating status of the monitor.
+	OperatingStatus string `json:"operating_status"`
+}
+
+// MonitorPage is the page returned by a pager when traversing over a
+// collection of health monitors.
+type MonitorPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of monitors has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r MonitorPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"healthmonitors_links"`
+	}
+
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a MonitorPage struct is empty.
+func (r MonitorPage) IsEmpty() (bool, error) {
+	is, err := ExtractMonitors(r)
+	return len(is) == 0, err
+}
+
+// ExtractMonitors accepts a Page struct, specifically a MonitorPage struct,
+// and extracts the elements into a slice of Monitor structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractMonitors(r pagination.Page) ([]Monitor, error) {
+	var s struct {
+		Monitors []Monitor `json:"healthmonitors"`
+	}
+	err := (r.(MonitorPage)).ExtractInto(&s)
+	return s.Monitors, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a monitor.
+func (r commonResult) Extract() (*Monitor, error) {
+	var s struct {
+		Monitor *Monitor `json:"healthmonitor"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Monitor, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Monitor.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Monitor.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Monitor.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the result succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors/urls.go
@@ -1,0 +1,16 @@
+package monitors
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rootPath     = "lbaas"
+	resourcePath = "healthmonitors"
+)
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath, resourcePath)
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools/doc.go
@@ -1,0 +1,154 @@
+/*
+Package pools provides information and interaction with Pools and
+Members of the LBaaS v2 extension for the OpenStack Networking service.
+
+Example to List Pools
+
+	listOpts := pools.ListOpts{
+		LoadbalancerID: "c79a4468-d788-410c-bf79-9a8ef6354852",
+	}
+
+	allPages, err := pools.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allPools, err := pools.ExtractMonitors(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, pools := range allPools {
+		fmt.Printf("%+v\n", pool)
+	}
+
+Example to Create a Pool
+
+	createOpts := pools.CreateOpts{
+		LBMethod:       pools.LBMethodRoundRobin,
+		Protocol:       "HTTP",
+		Name:           "Example pool",
+		LoadbalancerID: "79e05663-7f03-45d2-a092-8b94062f22ab",
+	}
+
+	pool, err := pools.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Pool
+
+	poolID := "d67d56a6-4a86-4688-a282-f46444705c64"
+
+	updateOpts := pools.UpdateOpts{
+		Name: "new-name",
+	}
+
+	pool, err := pools.Update(networkClient, poolID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Pool
+
+	poolID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	err := pools.Delete(networkClient, poolID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to List Pool Members
+
+	poolID := "d67d56a6-4a86-4688-a282-f46444705c64"
+
+	listOpts := pools.ListMemberOpts{
+		ProtocolPort: 80,
+	}
+
+	allPages, err := pools.ListMembers(networkClient, poolID, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allMembers, err := pools.ExtractMembers(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, member := allMembers {
+		fmt.Printf("%+v\n", member)
+	}
+
+Example to Create a Member
+
+	poolID := "d67d56a6-4a86-4688-a282-f46444705c64"
+
+	weight := 10
+	createOpts := pools.CreateMemberOpts{
+		Name:         "db",
+		SubnetID:     "1981f108-3c48-48d2-b908-30f7d28532c9",
+		Address:      "10.0.2.11",
+		ProtocolPort: 80,
+		Weight:       &weight,
+	}
+
+	member, err := pools.CreateMember(networkClient, poolID, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Member
+
+	poolID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	memberID := "64dba99f-8af8-4200-8882-e32a0660f23e"
+
+	weight := 4
+	updateOpts := pools.UpdateMemberOpts{
+		Name:   "new-name",
+		Weight: &weight,
+	}
+
+	member, err := pools.UpdateMember(networkClient, poolID, memberID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Member
+
+	poolID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	memberID := "64dba99f-8af8-4200-8882-e32a0660f23e"
+
+	err := pools.DeleteMember(networkClient, poolID, memberID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update Members:
+
+	poolID := "d67d56a6-4a86-4688-a282-f46444705c64"
+
+	weight_1 := 20
+	member1 := pools.BatchUpdateMemberOpts{
+		Address:      "192.0.2.16",
+		ProtocolPort: 80,
+		Name:         "web-server-1",
+		SubnetID:     "bbb35f84-35cc-4b2f-84c2-a6a29bba68aa",
+		Weight:       &weight_1,
+	}
+
+	weight_2 := 10
+	member2 := pools.BatchUpdateMemberOpts{
+		Address:      "192.0.2.17",
+		ProtocolPort: 80,
+		Name:         "web-server-2",
+		Weight:       &weight_2,
+		SubnetID:     "bbb35f84-35cc-4b2f-84c2-a6a29bba68aa",
+	}
+	members := []pools.BatchUpdateMemberOpts{member1, member2}
+
+	err := pools.BatchUpdateMembers(networkClient, poolID, members).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package pools

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools/requests.go
@@ -1,0 +1,378 @@
+package pools
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToPoolListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the Pool attributes you want to see returned. SortKey allows you to
+// sort by a particular Pool attribute. SortDir sets the direction, and is
+// either `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	LBMethod       string `q:"lb_algorithm"`
+	Protocol       string `q:"protocol"`
+	ProjectID      string `q:"project_id"`
+	AdminStateUp   *bool  `q:"admin_state_up"`
+	Name           string `q:"name"`
+	ID             string `q:"id"`
+	LoadbalancerID string `q:"loadbalancer_id"`
+	Limit          int    `q:"limit"`
+	Marker         string `q:"marker"`
+	SortKey        string `q:"sort_key"`
+	SortDir        string `q:"sort_dir"`
+}
+
+// ToPoolListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToPoolListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// pools. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+//
+// Default policy settings return only those pools that are owned by the
+// project who submits the request, unless an admin user submits the request.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(c)
+	if opts != nil {
+		query, err := opts.ToPoolListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return PoolPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+type LBMethod string
+type Protocol string
+
+// Supported attributes for create/update operations.
+const (
+	LBMethodRoundRobin       LBMethod = "ROUND_ROBIN"
+	LBMethodLeastConnections LBMethod = "LEAST_CONNECTIONS"
+	LBMethodSourceIp         LBMethod = "SOURCE_IP"
+
+	ProtocolTCP   Protocol = "TCP"
+	ProtocolUDP   Protocol = "UDP"
+	ProtocolPROXY Protocol = "PROXY"
+	ProtocolHTTP  Protocol = "HTTP"
+	ProtocolHTTPS Protocol = "HTTPS"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToPoolCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts is the common options struct used in this package's Create
+// operation.
+type CreateOpts struct {
+	// The algorithm used to distribute load between the members of the pool. The
+	// current specification supports LBMethodRoundRobin, LBMethodLeastConnections
+	// and LBMethodSourceIp as valid values for this attribute.
+	LBMethod LBMethod `json:"lb_algorithm" required:"true"`
+
+	// The protocol used by the pool members, you can use either
+	// ProtocolTCP, ProtocolUDP, ProtocolPROXY, ProtocolHTTP, or ProtocolHTTPS.
+	Protocol Protocol `json:"protocol" required:"true"`
+
+	// The Loadbalancer on which the members of the pool will be associated with.
+	// Note: one of LoadbalancerID or ListenerID must be provided.
+	LoadbalancerID string `json:"loadbalancer_id,omitempty" xor:"ListenerID"`
+
+	// The Listener on which the members of the pool will be associated with.
+	// Note: one of LoadbalancerID or ListenerID must be provided.
+	ListenerID string `json:"listener_id,omitempty" xor:"LoadbalancerID"`
+
+	// ProjectID is the UUID of the project who owns the Pool.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// Name of the pool.
+	Name string `json:"name,omitempty"`
+
+	// Human-readable description for the pool.
+	Description string `json:"description,omitempty"`
+
+	// Persistence is the session persistence of the pool.
+	// Omit this field to prevent session persistence.
+	Persistence *SessionPersistence `json:"session_persistence,omitempty"`
+
+	// The administrative state of the Pool. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+}
+
+// ToPoolCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToPoolCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "pool")
+}
+
+// Create accepts a CreateOpts struct and uses the values to create a new
+// load balancer pool.
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToPoolCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, nil)
+	return
+}
+
+// Get retrieves a particular pool based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToPoolUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts is the common options struct used in this package's Update
+// operation.
+type UpdateOpts struct {
+	// Name of the pool.
+	Name *string `json:"name,omitempty"`
+
+	// Human-readable description for the pool.
+	Description *string `json:"description,omitempty"`
+
+	// The algorithm used to distribute load between the members of the pool. The
+	// current specification supports LBMethodRoundRobin, LBMethodLeastConnections
+	// and LBMethodSourceIp as valid values for this attribute.
+	LBMethod LBMethod `json:"lb_algorithm,omitempty"`
+
+	// The administrative state of the Pool. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+}
+
+// ToPoolUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToPoolUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "pool")
+}
+
+// Update allows pools to be updated.
+func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToPoolUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(resourceURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete will permanently delete a particular pool based on its unique ID.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, id), nil)
+	return
+}
+
+// ListMemberOptsBuilder allows extensions to add additional parameters to the
+// ListMembers request.
+type ListMembersOptsBuilder interface {
+	ToMembersListQuery() (string, error)
+}
+
+// ListMembersOpts allows the filtering and sorting of paginated collections
+// through the API. Filtering is achieved by passing in struct field values
+// that map to the Member attributes you want to see returned. SortKey allows
+// you to sort by a particular Member attribute. SortDir sets the direction,
+// and is either `asc' or `desc'. Marker and Limit are used for pagination.
+type ListMembersOpts struct {
+	Name         string `q:"name"`
+	Weight       int    `q:"weight"`
+	AdminStateUp *bool  `q:"admin_state_up"`
+	ProjectID    string `q:"project_id"`
+	Address      string `q:"address"`
+	ProtocolPort int    `q:"protocol_port"`
+	ID           string `q:"id"`
+	Limit        int    `q:"limit"`
+	Marker       string `q:"marker"`
+	SortKey      string `q:"sort_key"`
+	SortDir      string `q:"sort_dir"`
+}
+
+// ToMemberListQuery formats a ListOpts into a query string.
+func (opts ListMembersOpts) ToMembersListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// ListMembers returns a Pager which allows you to iterate over a collection of
+// members. It accepts a ListMembersOptsBuilder, which allows you to filter and
+// sort the returned collection for greater efficiency.
+//
+// Default policy settings return only those members that are owned by the
+// project who submits the request, unless an admin user submits the request.
+func ListMembers(c *gophercloud.ServiceClient, poolID string, opts ListMembersOptsBuilder) pagination.Pager {
+	url := memberRootURL(c, poolID)
+	if opts != nil {
+		query, err := opts.ToMembersListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return MemberPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// CreateMemberOptsBuilder allows extensions to add additional parameters to the
+// CreateMember request.
+type CreateMemberOptsBuilder interface {
+	ToMemberCreateMap() (map[string]interface{}, error)
+}
+
+// CreateMemberOpts is the common options struct used in this package's CreateMember
+// operation.
+type CreateMemberOpts struct {
+	// The IP address of the member to receive traffic from the load balancer.
+	Address string `json:"address" required:"true"`
+
+	// The port on which to listen for client traffic.
+	ProtocolPort int `json:"protocol_port" required:"true"`
+
+	// Name of the Member.
+	Name string `json:"name,omitempty"`
+
+	// ProjectID is the UUID of the project who owns the Member.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// A positive integer value that indicates the relative portion of traffic
+	// that this member should receive from the pool. For example, a member with
+	// a weight of 10 receives five times as much traffic as a member with a
+	// weight of 2.
+	Weight *int `json:"weight,omitempty"`
+
+	// If you omit this parameter, LBaaS uses the vip_subnet_id parameter value
+	// for the subnet UUID.
+	SubnetID string `json:"subnet_id,omitempty"`
+
+	// The administrative state of the Pool. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+}
+
+// ToMemberCreateMap builds a request body from CreateMemberOpts.
+func (opts CreateMemberOpts) ToMemberCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "member")
+}
+
+// CreateMember will create and associate a Member with a particular Pool.
+func CreateMember(c *gophercloud.ServiceClient, poolID string, opts CreateMemberOpts) (r CreateMemberResult) {
+	b, err := opts.ToMemberCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(memberRootURL(c, poolID), b, &r.Body, nil)
+	return
+}
+
+// GetMember retrieves a particular Pool Member based on its unique ID.
+func GetMember(c *gophercloud.ServiceClient, poolID string, memberID string) (r GetMemberResult) {
+	_, r.Err = c.Get(memberResourceURL(c, poolID, memberID), &r.Body, nil)
+	return
+}
+
+// UpdateMemberOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type UpdateMemberOptsBuilder interface {
+	ToMemberUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateMemberOpts is the common options struct used in this package's Update
+// operation.
+type UpdateMemberOpts struct {
+	// Name of the Member.
+	Name *string `json:"name,omitempty"`
+
+	// A positive integer value that indicates the relative portion of traffic
+	// that this member should receive from the pool. For example, a member with
+	// a weight of 10 receives five times as much traffic as a member with a
+	// weight of 2.
+	Weight *int `json:"weight,omitempty"`
+
+	// The administrative state of the Pool. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+}
+
+// ToMemberUpdateMap builds a request body from UpdateMemberOpts.
+func (opts UpdateMemberOpts) ToMemberUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "member")
+}
+
+// Update allows Member to be updated.
+func UpdateMember(c *gophercloud.ServiceClient, poolID string, memberID string, opts UpdateMemberOptsBuilder) (r UpdateMemberResult) {
+	b, err := opts.ToMemberUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(memberResourceURL(c, poolID, memberID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	return
+}
+
+// BatchUpdateMemberOptsBuilder allows extensions to add additional parameters to the BatchUpdateMembers request.
+type BatchUpdateMemberOptsBuilder interface {
+	ToBatchMemberUpdateMap() (map[string]interface{}, error)
+}
+
+type BatchUpdateMemberOpts CreateMemberOpts
+
+// ToBatchMemberUpdateMap builds a request body from BatchUpdateMemberOpts.
+func (opts BatchUpdateMemberOpts) ToBatchMemberUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// BatchUpdateMembers updates the pool members in batch
+func BatchUpdateMembers(c *gophercloud.ServiceClient, poolID string, opts []BatchUpdateMemberOpts) (r UpdateMembersResult) {
+	var members []map[string]interface{}
+	for _, opt := range opts {
+		b, err := opt.ToBatchMemberUpdateMap()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		members = append(members, b)
+	}
+
+	b := map[string]interface{}{"members": members}
+
+	_, r.Err = c.Put(memberRootURL(c, poolID), b, nil, &gophercloud.RequestOpts{OkCodes: []int{202}})
+	return
+}
+
+// DisassociateMember will remove and disassociate a Member from a particular
+// Pool.
+func DeleteMember(c *gophercloud.ServiceClient, poolID string, memberID string) (r DeleteMemberResult) {
+	_, r.Err = c.Delete(memberResourceURL(c, poolID, memberID), nil)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools/results.go
@@ -1,0 +1,328 @@
+package pools
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// SessionPersistence represents the session persistence feature of the load
+// balancing service. It attempts to force connections or requests in the same
+// session to be processed by the same member as long as it is ative. Three
+// types of persistence are supported:
+//
+// SOURCE_IP:   With this mode, all connections originating from the same source
+//              IP address, will be handled by the same Member of the Pool.
+// HTTP_COOKIE: With this persistence mode, the load balancing function will
+//              create a cookie on the first request from a client. Subsequent
+//              requests containing the same cookie value will be handled by
+//              the same Member of the Pool.
+// APP_COOKIE:  With this persistence mode, the load balancing function will
+//              rely on a cookie established by the backend application. All
+//              requests carrying the same cookie value will be handled by the
+//              same Member of the Pool.
+type SessionPersistence struct {
+	// The type of persistence mode.
+	Type string `json:"type"`
+
+	// Name of cookie if persistence mode is set appropriately.
+	CookieName string `json:"cookie_name,omitempty"`
+}
+
+// LoadBalancerID represents a load balancer.
+type LoadBalancerID struct {
+	ID string `json:"id"`
+}
+
+// ListenerID represents a listener.
+type ListenerID struct {
+	ID string `json:"id"`
+}
+
+// Pool represents a logical set of devices, such as web servers, that you
+// group together to receive and process traffic. The load balancing function
+// chooses a Member of the Pool according to the configured load balancing
+// method to handle the new requests or connections received on the VIP address.
+type Pool struct {
+	// The load-balancer algorithm, which is round-robin, least-connections, and
+	// so on. This value, which must be supported, is dependent on the provider.
+	// Round-robin must be supported.
+	LBMethod string `json:"lb_algorithm"`
+
+	// The protocol of the Pool, which is TCP, HTTP, or HTTPS.
+	Protocol string `json:"protocol"`
+
+	// Description for the Pool.
+	Description string `json:"description"`
+
+	// A list of listeners objects IDs.
+	Listeners []ListenerID `json:"listeners"` //[]map[string]interface{}
+
+	// A list of member objects IDs.
+	Members []Member `json:"members"`
+
+	// The ID of associated health monitor.
+	MonitorID string `json:"healthmonitor_id"`
+
+	// The network on which the members of the Pool will be located. Only members
+	// that are on this network can be added to the Pool.
+	SubnetID string `json:"subnet_id"`
+
+	// Owner of the Pool.
+	ProjectID string `json:"project_id"`
+
+	// The administrative state of the Pool, which is up (true) or down (false).
+	AdminStateUp bool `json:"admin_state_up"`
+
+	// Pool name. Does not have to be unique.
+	Name string `json:"name"`
+
+	// The unique ID for the Pool.
+	ID string `json:"id"`
+
+	// A list of load balancer objects IDs.
+	Loadbalancers []LoadBalancerID `json:"loadbalancers"`
+
+	// Indicates whether connections in the same session will be processed by the
+	// same Pool member or not.
+	Persistence SessionPersistence `json:"session_persistence"`
+
+	// The load balancer provider.
+	Provider string `json:"provider"`
+
+	// The Monitor associated with this Pool.
+	Monitor monitors.Monitor `json:"healthmonitor"`
+
+	// The provisioning status of the pool.
+	// This value is ACTIVE, PENDING_* or ERROR.
+	ProvisioningStatus string `json:"provisioning_status"`
+
+	// The operating status of the pool.
+	OperatingStatus string `json:"operating_status"`
+}
+
+// PoolPage is the page returned by a pager when traversing over a
+// collection of pools.
+type PoolPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of pools has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r PoolPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"pools_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a PoolPage struct is empty.
+func (r PoolPage) IsEmpty() (bool, error) {
+	is, err := ExtractPools(r)
+	return len(is) == 0, err
+}
+
+// ExtractPools accepts a Page struct, specifically a PoolPage struct,
+// and extracts the elements into a slice of Pool structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractPools(r pagination.Page) ([]Pool, error) {
+	var s struct {
+		Pools []Pool `json:"pools"`
+	}
+	err := (r.(PoolPage)).ExtractInto(&s)
+	return s.Pools, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a pool.
+func (r commonResult) Extract() (*Pool, error) {
+	var s struct {
+		Pool *Pool `json:"pool"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Pool, err
+}
+
+// CreateResult represents the result of a Create operation. Call its Extract
+// method to interpret the result as a Pool.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a Get operation. Call its Extract
+// method to interpret the result as a Pool.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an Update operation. Call its Extract
+// method to interpret the result as a Pool.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a Delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// Member represents the application running on a backend server.
+type Member struct {
+	// Name of the Member.
+	Name string `json:"name"`
+
+	// Weight of Member.
+	Weight int `json:"weight"`
+
+	// The administrative state of the member, which is up (true) or down (false).
+	AdminStateUp bool `json:"admin_state_up"`
+
+	// Owner of the Member.
+	ProjectID string `json:"project_id"`
+
+	// Parameter value for the subnet UUID.
+	SubnetID string `json:"subnet_id"`
+
+	// The Pool to which the Member belongs.
+	PoolID string `json:"pool_id"`
+
+	// The IP address of the Member.
+	Address string `json:"address"`
+
+	// The port on which the application is hosted.
+	ProtocolPort int `json:"protocol_port"`
+
+	// The unique ID for the Member.
+	ID string `json:"id"`
+
+	// The provisioning status of the pool.
+	// This value is ACTIVE, PENDING_* or ERROR.
+	ProvisioningStatus string `json:"provisioning_status"`
+
+	// DateTime when the member was created
+	CreatedAt time.Time `json:"-"`
+
+	// DateTime when the member was updated
+	UpdatedAt time.Time `json:"-"`
+
+	// The operating status of the member
+	OperatingStatus string `json:"operating_status"`
+
+	// Is the member a backup? Backup members only receive traffic when all non-backup members are down.
+	Backup bool `json:"backup"`
+
+	// An alternate IP address used for health monitoring a backend member.
+	MonitorAddress string `json:"monitor_address"`
+
+	// An alternate protocol port used for health monitoring a backend member.
+	MonitorPort int `json:"monitor_port"`
+}
+
+// MemberPage is the page returned by a pager when traversing over a
+// collection of Members in a Pool.
+type MemberPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of members has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r MemberPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"members_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a MemberPage struct is empty.
+func (r MemberPage) IsEmpty() (bool, error) {
+	is, err := ExtractMembers(r)
+	return len(is) == 0, err
+}
+
+// ExtractMembers accepts a Page struct, specifically a MemberPage struct,
+// and extracts the elements into a slice of Members structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractMembers(r pagination.Page) ([]Member, error) {
+	var s struct {
+		Members []Member `json:"members"`
+	}
+	err := (r.(MemberPage)).ExtractInto(&s)
+	return s.Members, err
+}
+
+type commonMemberResult struct {
+	gophercloud.Result
+}
+
+func (r *Member) UnmarshalJSON(b []byte) error {
+	type tmp Member
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339NoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339NoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Member(s.tmp)
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+	return nil
+}
+
+// ExtractMember is a function that accepts a result and extracts a member.
+func (r commonMemberResult) Extract() (*Member, error) {
+	var s struct {
+		Member *Member `json:"member"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Member, err
+}
+
+// CreateMemberResult represents the result of a CreateMember operation.
+// Call its Extract method to interpret it as a Member.
+type CreateMemberResult struct {
+	commonMemberResult
+}
+
+// GetMemberResult represents the result of a GetMember operation.
+// Call its Extract method to interpret it as a Member.
+type GetMemberResult struct {
+	commonMemberResult
+}
+
+// UpdateMemberResult represents the result of an UpdateMember operation.
+// Call its Extract method to interpret it as a Member.
+type UpdateMemberResult struct {
+	commonMemberResult
+}
+
+// UpdateMembersResult represents the result of an UpdateMembers operation.
+// Call its ExtractErr method to determine if the request succeeded or failed.
+type UpdateMembersResult struct {
+	gophercloud.ErrResult
+}
+
+// DeleteMemberResult represents the result of a DeleteMember operation.
+// Call its ExtractErr method to determine if the request succeeded or failed.
+type DeleteMemberResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools/urls.go
@@ -1,0 +1,25 @@
+package pools
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rootPath     = "lbaas"
+	resourcePath = "pools"
+	memberPath   = "members"
+)
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath, resourcePath)
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id)
+}
+
+func memberRootURL(c *gophercloud.ServiceClient, poolId string) string {
+	return c.ServiceURL(rootPath, resourcePath, poolId, memberPath)
+}
+
+func memberResourceURL(c *gophercloud.ServiceClient, poolID string, memberID string) string {
+	return c.ServiceURL(rootPath, resourcePath, poolID, memberPath, memberID)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/requests.go
@@ -158,7 +158,7 @@ func (opts UpdateOpts) ToLoadBalancerUpdateMap() (map[string]interface{}, error)
 
 // Update is an operation which modifies the attributes of the specified
 // LoadBalancer.
-func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToLoadBalancerUpdateMap()
 	if err != nil {
 		r.Err = err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -80,7 +80,7 @@ github.com/google/go-cmp/cmp/internal/value
 github.com/google/uuid
 # github.com/googleapis/gax-go/v2 v2.0.3
 github.com/googleapis/gax-go/v2
-# github.com/gophercloud/gophercloud v0.4.1-0.20190919023608-3d65851f4b68
+# github.com/gophercloud/gophercloud v0.4.1-0.20190919160002-34bae44cf812
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/internal
 github.com/gophercloud/gophercloud/openstack
@@ -128,6 +128,10 @@ github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata
 github.com/gophercloud/gophercloud/openstack/imageservice/v2/images
 github.com/gophercloud/gophercloud/openstack/keymanager/v1/containers
 github.com/gophercloud/gophercloud/openstack/keymanager/v1/secrets
+github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies
+github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners
+github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors
+github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/dns
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external

--- a/website/docs/r/lb_listener_v2.html.markdown
+++ b/website/docs/r/lb_listener_v2.html.markdown
@@ -52,6 +52,15 @@ The following arguments are supported:
 
 * `connection_limit` - (Optional) The maximum number of connections allowed
     for the Listener.
+    
+* `timeout_client_data` - (Optional) The client inactivity timeout in milliseconds.
+    
+* `timeout_member_connect` - (Optional) The member connection timeout in milliseconds.
+    
+* `timeout_member_data` - (Optional) The member inactivity timeout in milliseconds.
+    
+* `timeout_tcp_inspect` - (Optional) The time in milliseconds, to wait for additional
+    TCP packets for content inspection.
 
 * `default_tls_container_ref` - (Optional) A reference to a Barbican Secrets
     container which stores TLS information. This is required if the protocol
@@ -79,6 +88,10 @@ The following attributes are exported:
 * `default_port_id` - See Argument Reference above.
 * `description` - See Argument Reference above.
 * `connection_limit` - See Argument Reference above.
+* `timeout_client_data` - See Argument Reference above.
+* `timeout_member_connect` - See Argument Reference above.
+* `timeout_member_data` - See Argument Reference above.
+* `timeout_tcp_inspect` - See Argument Reference above.
 * `default_tls_container_ref` - See Argument Reference above.
 * `sni_container_refs` - See Argument Reference above.
 * `admin_state_up` - See Argument Reference above.


### PR DESCRIPTION
Add the following arguments into the "openstack_lb_listener_v2"
resource:

 - timeout_client_data
 - timeout_member_connect
 - timeout_member_data
  - timeout_tcp_inspect

Update openstack_lb_listener_v2 tests.
Update openstack_lb_listener_v2 docs.
Cleanup openstack_lb_listener_v2 resource code and log messages.

For #867  #456 