### PR TITLE
LoadBalancer listener V2: fix Read method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-openstack
 
 require (
-	github.com/gophercloud/gophercloud v0.4.1-0.20190919160002-34bae44cf812
+	github.com/gophercloud/gophercloud v0.4.1-0.20190920074709-6e93a6ba3b09
 	github.com/gophercloud/utils v0.0.0-20190313033024-0bcc8e728cb5
 	github.com/hashicorp/terraform v0.12.8
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/googleapis/gax-go/v2 v2.0.3 h1:siORttZ36U2R/WjiJuDz8znElWBiAlO9rVt+mq
 github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
 github.com/gophercloud/gophercloud v0.0.0-20190208042652-bc37892e1968/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gophercloud/gophercloud v0.0.0-20190212181753-892256c46858/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
-github.com/gophercloud/gophercloud v0.4.1-0.20190919160002-34bae44cf812 h1:HH08ExBAaU0cS0Hi9G9rmqdCHLi5+gTOu9euPcsZNNU=
-github.com/gophercloud/gophercloud v0.4.1-0.20190919160002-34bae44cf812/go.mod h1:OKfORD99ar9Nkmj0z4HEsUmwqqLgQB+z9jwKpJOGQVA=
+github.com/gophercloud/gophercloud v0.4.1-0.20190920074709-6e93a6ba3b09 h1:6LeYVuUyp73zndCXz0Pr8poOnnZM255YF3V1J9kRfy8=
+github.com/gophercloud/gophercloud v0.4.1-0.20190920074709-6e93a6ba3b09/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/utils v0.0.0-20190128072930-fbb6ab446f01/go.mod h1:wjDF8z83zTeg5eMLml5EBSlAhbF7G8DobyI1YsMuyzw=
 github.com/gophercloud/utils v0.0.0-20190313033024-0bcc8e728cb5 h1:8USoe8m65WcTOYy+MUu+EtLJJysSODnoNDNCEWhDMso=
 github.com/gophercloud/utils v0.0.0-20190313033024-0bcc8e728cb5/go.mod h1:SZ9FTKibIotDtCrxAU/evccoyu1yhKST6hgBvwTB5Eg=

--- a/openstack/import_openstack_lb_listener_v2_test.go
+++ b/openstack/import_openstack_lb_listener_v2_test.go
@@ -26,3 +26,24 @@ func TestAccLBV2Listener_importBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccLBV2Listener_importOctavia(t *testing.T) {
+	resourceName := "openstack_lb_listener_v2.listener_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckLB(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLBV2ListenerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: TestAccLBV2ListenerConfig_octavia,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/openstack/lb_v2_shared.go
+++ b/openstack/lb_v2_shared.go
@@ -228,63 +228,6 @@ func chooseLBV2ListenerUpdateOpts(d *schema.ResourceData, config *Config) neutro
 	return updateOpts
 }
 
-// chooseLBV2ListenerReadBody will determine which load balancer listener response body to use:
-// Either the Octavia/LBaaS or the Neutron/Networking v2.
-func chooseLBV2ListenerReadBody(res neutronlisteners.GetResult, d *schema.ResourceData, config *Config) error {
-	if config.useOctavia {
-		var listener octavialisteners.Listener
-		err := res.ExtractInto(listener)
-		if err != nil {
-			return CheckDeleted(d, err, "openstack_lb_listener_v2")
-		}
-
-		log.Printf("[DEBUG] Retrieved openstack_lb_listener_v2 %s: %#v", d.Id(), listener)
-
-		d.Set("name", listener.Name)
-		d.Set("protocol", listener.Protocol)
-		d.Set("tenant_id", listener.ProjectID)
-		d.Set("description", listener.Description)
-		d.Set("protocol_port", listener.ProtocolPort)
-		d.Set("admin_state_up", listener.AdminStateUp)
-		d.Set("default_pool_id", listener.DefaultPoolID)
-		d.Set("connection_limit", listener.ConnLimit)
-		d.Set("timeout_client_data", listener.TimeoutClientData)
-		d.Set("timeout_member_connect", listener.TimeoutMemberConnect)
-		d.Set("timeout_member_data", listener.TimeoutMemberData)
-		d.Set("timeout_tcp_inspect", listener.TimeoutTCPInspect)
-		d.Set("sni_container_refs", listener.SniContainerRefs)
-		d.Set("default_tls_container_ref", listener.DefaultTlsContainerRef)
-		d.Set("region", GetRegion(d, config))
-	} else {
-		var listener neutronlisteners.Listener
-		err := res.ExtractInto(listener)
-		if err != nil {
-			return CheckDeleted(d, err, "openstack_lb_listener_v2")
-		}
-
-		log.Printf("[DEBUG] Retrieved openstack_lb_listener_v2 %s: %#v", d.Id(), listener)
-
-		// Required by import
-		if len(listener.Loadbalancers) > 0 {
-			d.Set("loadbalancer_id", listener.Loadbalancers[0].ID)
-		}
-
-		d.Set("name", listener.Name)
-		d.Set("protocol", listener.Protocol)
-		d.Set("tenant_id", listener.TenantID)
-		d.Set("description", listener.Description)
-		d.Set("protocol_port", listener.ProtocolPort)
-		d.Set("admin_state_up", listener.AdminStateUp)
-		d.Set("default_pool_id", listener.DefaultPoolID)
-		d.Set("connection_limit", listener.ConnLimit)
-		d.Set("sni_container_refs", listener.SniContainerRefs)
-		d.Set("default_tls_container_ref", listener.DefaultTlsContainerRef)
-		d.Set("region", GetRegion(d, config))
-	}
-
-	return nil
-}
-
 func waitForLBV2Listener(lbClient *gophercloud.ServiceClient, listener *listeners.Listener, target string, pending []string, timeout time.Duration) error {
 	log.Printf("[DEBUG] Waiting for openstack_lb_listener_v2 %s to become %s.", listener.ID, target)
 

--- a/openstack/lb_v2_shared.go
+++ b/openstack/lb_v2_shared.go
@@ -150,19 +150,19 @@ func chooseLBV2ListenerUpdateOpts(d *schema.ResourceData, config *Config) neutro
 		}
 		if d.HasChange("timeout_client_data") {
 			timeoutClientData := d.Get("timeout_client_data").(int)
-			opts.ConnLimit = &timeoutClientData
+			opts.TimeoutClientData = &timeoutClientData
 		}
 		if d.HasChange("timeout_member_connect") {
 			timeoutMemberConnect := d.Get("timeout_member_connect").(int)
-			opts.ConnLimit = &timeoutMemberConnect
+			opts.TimeoutMemberConnect = &timeoutMemberConnect
 		}
 		if d.HasChange("timeout_member_data") {
 			timeoutMemberData := d.Get("timeout_member_data").(int)
-			opts.ConnLimit = &timeoutMemberData
+			opts.TimeoutMemberData = &timeoutMemberData
 		}
 		if d.HasChange("timeout_tcp_inspect") {
 			timeoutTCPInspect := d.Get("timeout_tcp_inspect").(int)
-			opts.ConnLimit = &timeoutTCPInspect
+			opts.TimeoutTCPInspect = &timeoutTCPInspect
 		}
 		if d.HasChange("default_pool_id") {
 			defaultPoolID := d.Get("default_pool_id").(string)

--- a/openstack/resource_openstack_lb_listener_v2_test.go
+++ b/openstack/resource_openstack_lb_listener_v2_test.go
@@ -284,7 +284,7 @@ resource "openstack_lb_pool_v2" "pool_1" {
 }
 
 resource "openstack_lb_listener_v2" "listener_1" {
-  name = "listener_1"
+  name = "listener_1_updated"
   protocol = "HTTP"
   protocol_port = 8080
   connection_limit = 100

--- a/vendor/github.com/gophercloud/gophercloud/CHANGELOG.md
+++ b/vendor/github.com/gophercloud/gophercloud/CHANGELOG.md
@@ -12,6 +12,15 @@ IMPROVEMENTS
 * Added `AllowedCIDRs` to `loadbalancer/v2/listeners.CreateOpts` [GH-1710]
 * Added `AllowedCIDRs` to `loadbalancer/v2/listeners.UpdateOpts` [GH-1710]
 * Added `AllowedCIDRs` to `loadbalancer/v2/listeners.Listener` [GH-1710]
+* Added `compute/v2/extensions/tags.Add` [GH-1695]
+* Added `compute/v2/extensions/tags.ReplaceAll` [GH-1694]
+* Added `compute/v2/extensions/tags.Delete` [GH-1699]
+* Added `compute/v2/extensions/tags.DeleteAll` [GH-1700]
+
+BUG FIXES
+
+* Changed struct type for options in `networking/v2/extensions/lbaas_v2/listeners` to `UpdateOptsBuilder` interface instead of specific UpdateOpts type [GH-1705]
+* Changed struct type for options in `networking/v2/extensions/lbaas_v2/loadbalancers` to `UpdateOptsBuilder` interface instead of specific UpdateOpts type [GH-1706]
 
 ## 0.4.0 (September 3, 2019)
 

--- a/vendor/github.com/gophercloud/gophercloud/go.mod
+++ b/vendor/github.com/gophercloud/gophercloud/go.mod
@@ -5,5 +5,3 @@ require (
 	golang.org/x/sys v0.0.0-20190209173611-3b5209105503 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )
-
-go 1.13

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -80,7 +80,7 @@ github.com/google/go-cmp/cmp/internal/value
 github.com/google/uuid
 # github.com/googleapis/gax-go/v2 v2.0.3
 github.com/googleapis/gax-go/v2
-# github.com/gophercloud/gophercloud v0.4.1-0.20190919160002-34bae44cf812
+# github.com/gophercloud/gophercloud v0.4.1-0.20190920074709-6e93a6ba3b09
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/internal
 github.com/gophercloud/gophercloud/openstack


### PR DESCRIPTION
Fix "json: Unmarshal(non-pointer listeners.Listener)" by not using any
common interfaces or methods for Get method.

Add len(listener.Loadbalancers) check for setting valid id of the
openstack_lb_listener_v2 resource.

Add TestAccLBV2Listener_importOctavia().

For #867