### PR TITLE
Shared filesystem V2: cleanup securityservice

### DIFF
--- a/openstack/resource_openstack_sharedfilesystem_share_access_v2.go
+++ b/openstack/resource_openstack_sharedfilesystem_share_access_v2.go
@@ -85,7 +85,7 @@ func resourceSharedFilesystemShareAccessV2Create(d *schema.ResourceData, meta in
 		return fmt.Errorf("Error creating OpenStack sharedfilesystem client: %s", err)
 	}
 
-	sfsClient.Microversion = minManilaMicroversion
+	sfsClient.Microversion = sharedFilesystemV2MinMicroversion
 	accessType := d.Get("access_type").(string)
 	if accessType == "cephx" {
 		sfsClient.Microversion = "2.13"
@@ -144,7 +144,7 @@ func resourceSharedFilesystemShareAccessV2Read(d *schema.ResourceData, meta inte
 	}
 
 	// Set the client to the minimum supported microversion.
-	sfsClient.Microversion = minManilaMicroversion
+	sfsClient.Microversion = sharedFilesystemV2MinMicroversion
 
 	// Now check and see if the OpenStack environment supports microversion 2.21.
 	// If so, use that for the API request for access_key support.
@@ -198,7 +198,7 @@ func resourceSharedFilesystemShareAccessV2Delete(d *schema.ResourceData, meta in
 		return fmt.Errorf("Error creating OpenStack sharedfilesystem client: %s", err)
 	}
 
-	sfsClient.Microversion = minManilaMicroversion
+	sfsClient.Microversion = sharedFilesystemV2MinMicroversion
 
 	shareID := d.Get("share_id").(string)
 
@@ -253,7 +253,7 @@ func resourceSharedFilesystemShareAccessV2Import(d *schema.ResourceData, meta in
 		return nil, fmt.Errorf("Error creating OpenStack sharedfilesystem client: %s", err)
 	}
 
-	sfsClient.Microversion = minManilaMicroversion
+	sfsClient.Microversion = sharedFilesystemV2MinMicroversion
 
 	shareID := parts[0]
 	accessID := parts[1]

--- a/openstack/resource_openstack_sharedfilesystem_share_access_v2_test.go
+++ b/openstack/resource_openstack_sharedfilesystem_share_access_v2_test.go
@@ -118,7 +118,7 @@ func testAccCheckSFSV2ShareAccessExists(n string, share *shares.AccessRight) res
 			}
 		}
 
-		sfsClient.Microversion = minManilaMicroversion
+		sfsClient.Microversion = sharedFilesystemV2MinMicroversion
 
 		access, err := shares.ListAccessRights(sfsClient, shareID).Extract()
 		if err != nil {

--- a/openstack/sharedfilesystem_shared_v2.go
+++ b/openstack/sharedfilesystem_shared_v2.go
@@ -1,0 +1,6 @@
+package openstack
+
+const (
+	sharedFilesystemV2MinMicroversion               = "2.7"
+	sharedFilesystemV2SecurityServiceOUMicroversion = "2.44"
+)


### PR DESCRIPTION
Cleanup openstack_sharedfilesystem_securityservice_v2 resource.

Move basic Manila microversions from
resource_openstack_sharedfilesystem_securityservice_v2.go into
sharedfilesystem_shared_v2.go.

For #456 