### PR TITLE
Fixed openstack_lb_loadbalancer_v2 flavor selection.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-openstack
 
 require (
-	github.com/gophercloud/gophercloud v0.4.1-0.20191011151343-9c34d1968ad7
+	github.com/gophercloud/gophercloud v0.5.1-0.20191016015529-6f9cb195db52
 	github.com/gophercloud/utils v0.0.0-20190829151529-94e6842399e5
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/gophercloud/gophercloud v0.0.0-20190212181753-892256c46858/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/gophercloud v0.4.1-0.20191011151343-9c34d1968ad7 h1:IFWEXgvvAQ/XNtnBSsfrZt7bXtKZCGJGtsPU/Ur/VDQ=
 github.com/gophercloud/gophercloud v0.4.1-0.20191011151343-9c34d1968ad7/go.mod h1:b1k/BkBA9smzYde6p6zYLIe5JNAEoJzUWaIRh+9A/j0=
+github.com/gophercloud/gophercloud v0.5.1-0.20191016015529-6f9cb195db52 h1:wgVapaBReQLPQl3eyMG5Rr4NTAqwmGvJecroIBpwgGI=
+github.com/gophercloud/gophercloud v0.5.1-0.20191016015529-6f9cb195db52/go.mod h1:b1k/BkBA9smzYde6p6zYLIe5JNAEoJzUWaIRh+9A/j0=
 github.com/gophercloud/utils v0.0.0-20190829151529-94e6842399e5 h1:W6TC1Dd95ocK2YK5jLmKmh1lg+oZaXdLl+CRP7pUdfA=
 github.com/gophercloud/utils v0.0.0-20190829151529-94e6842399e5/go.mod h1:SZ9FTKibIotDtCrxAU/evccoyu1yhKST6hgBvwTB5Eg=
 github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/openstack/resource_openstack_lb_loadbalancer_v2.go
+++ b/openstack/resource_openstack_lb_loadbalancer_v2.go
@@ -78,7 +78,7 @@ func resourceLoadBalancerV2() *schema.Resource {
 				Optional: true,
 			},
 
-			"flavor": {
+			"flavor_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
@@ -122,7 +122,7 @@ func resourceLoadBalancerV2Create(d *schema.ResourceData, meta interface{}) erro
 		TenantID:     d.Get("tenant_id").(string),
 		VipAddress:   d.Get("vip_address").(string),
 		AdminStateUp: &adminStateUp,
-		Flavor:       d.Get("flavor").(string),
+		FlavorID:     d.Get("flavor_id").(string),
 		Provider:     lbProvider,
 	}
 
@@ -176,7 +176,7 @@ func resourceLoadBalancerV2Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("vip_address", lb.VipAddress)
 	d.Set("vip_port_id", lb.VipPortID)
 	d.Set("admin_state_up", lb.AdminStateUp)
-	d.Set("flavor", lb.Flavor)
+	d.Set("flavor_id", lb.FlavorID)
 	d.Set("loadbalancer_provider", lb.Provider)
 	d.Set("region", GetRegion(d, config))
 

--- a/vendor/github.com/gophercloud/gophercloud/CHANGELOG.md
+++ b/vendor/github.com/gophercloud/gophercloud/CHANGELOG.md
@@ -1,4 +1,16 @@
-## 0.5.0 (Unreleased)
+## 0.6.0 (Unreleased)
+
+IMPROVEMENTS
+
+* Added `networking/v2/extensions/quotas.Get` [GH-1742](https://github.com/gophercloud/gophercloud/pull/1742)
+* Added `networking/v2/extensions/quotas.Update` [GH-1747](https://github.com/gophercloud/gophercloud/pull/1747)
+
+BUG FIXES
+
+* Changed `Flavor` to `FlavorID` in `loadbalancer/v2/loadbalancers` [GH-1744](https://github.com/gophercloud/gophercloud/pull/1744)
+* Changed `Flavor` to `FlavorID` in `networking/v2/extensions/lbaas_v2/loadbalancers` [GH-1744](https://github.com/gophercloud/gophercloud/pull/1744)
+
+## 0.5.0 (October 13, 2019)
 
 IMPROVEMENTS
 
@@ -21,6 +33,7 @@ IMPROVEMENTS
 * Added `AttachedVolumes` to `compute/v2/servers.Server` [GH-1732](https://github.com/gophercloud/gophercloud/pull/1732)
 * Enable unmarshaling server tags to a `compute/v2/servers.Server` struct [GH-1734]
 * Allow setting an empty members list in `loadbalancer/v2/pools.BatchUpdateMembers` [GH-1736](https://github.com/gophercloud/gophercloud/pull/1736)
+* Allow unsetting members' subnet ID and name in `loadbalancer/v2/pools.BatchUpdateMemberOpts` [GH-1738](https://github.com/gophercloud/gophercloud/pull/1738)
 
 BUG FIXES
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools/requests.go
@@ -345,11 +345,49 @@ type BatchUpdateMemberOptsBuilder interface {
 	ToBatchMemberUpdateMap() (map[string]interface{}, error)
 }
 
-type BatchUpdateMemberOpts CreateMemberOpts
+// BatchUpdateMemberOpts is the common options struct used in this package's BatchUpdateMembers
+// operation.
+type BatchUpdateMemberOpts struct {
+	// The IP address of the member to receive traffic from the load balancer.
+	Address string `json:"address" required:"true"`
+
+	// The port on which to listen for client traffic.
+	ProtocolPort int `json:"protocol_port" required:"true"`
+
+	// Name of the Member.
+	Name *string `json:"name,omitempty"`
+
+	// ProjectID is the UUID of the project who owns the Member.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// A positive integer value that indicates the relative portion of traffic
+	// that this member should receive from the pool. For example, a member with
+	// a weight of 10 receives five times as much traffic as a member with a
+	// weight of 2.
+	Weight *int `json:"weight,omitempty"`
+
+	// If you omit this parameter, LBaaS uses the vip_subnet_id parameter value
+	// for the subnet UUID.
+	SubnetID *string `json:"subnet_id,omitempty"`
+
+	// The administrative state of the Pool. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+}
 
 // ToBatchMemberUpdateMap builds a request body from BatchUpdateMemberOpts.
 func (opts BatchUpdateMemberOpts) ToBatchMemberUpdateMap() (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, "")
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if b["subnet_id"] == "" {
+		b["subnet_id"] = nil
+	}
+
+	return b, nil
 }
 
 // BatchUpdateMembers updates the pool members in batch

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/doc.go
@@ -29,7 +29,7 @@ Example to Create a Load Balancer
 		AdminStateUp: gophercloud.Enabled,
 		VipSubnetID:  "9cedb85d-0759-4898-8a4b-fa5a5ea10086",
 		VipAddress:   "10.30.176.48",
-		Flavor:       "medium",
+		FlavorID:     "60df399a-ee85-11e9-81b4-2a2ae2dbcce4",
 		Provider:     "haproxy",
 	}
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/requests.go
@@ -30,7 +30,7 @@ type ListOpts struct {
 	ID                 string `q:"id"`
 	OperatingStatus    string `q:"operating_status"`
 	Name               string `q:"name"`
-	Flavor             string `q:"flavor"`
+	FlavorID           string `q:"flavor_id"`
 	Provider           string `q:"provider"`
 	Limit              int    `q:"limit"`
 	Marker             string `q:"marker"`
@@ -100,7 +100,7 @@ type CreateOpts struct {
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 
 	// The UUID of a flavor.
-	Flavor string `json:"flavor,omitempty"`
+	FlavorID string `json:"flavor_id,omitempty"`
 
 	// The name of the provider.
 	Provider string `json:"provider,omitempty"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/results.go
@@ -45,7 +45,7 @@ type LoadBalancer struct {
 	Name string `json:"name"`
 
 	// The UUID of a flavor if set.
-	Flavor string `json:"flavor"`
+	FlavorID string `json:"flavor_id"`
 
 	// The name of the provider.
 	Provider string `json:"provider"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -75,8 +75,9 @@ github.com/google/go-cmp/cmp/internal/value
 github.com/google/uuid
 # github.com/googleapis/gax-go/v2 v2.0.5
 github.com/googleapis/gax-go/v2
-# github.com/gophercloud/gophercloud v0.4.1-0.20191011151343-9c34d1968ad7
+github.com/gophercloud/gophercloud v0.5.1-0.20191016015529-6f9cb195db52
 github.com/gophercloud/gophercloud
+github.com/gophercloud/gophercloud/internal
 github.com/gophercloud/gophercloud/openstack
 github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets
 github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions
@@ -104,10 +105,13 @@ github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters
 github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates
 github.com/gophercloud/gophercloud/openstack/db/v1/configurations
 github.com/gophercloud/gophercloud/openstack/db/v1/databases
+github.com/gophercloud/gophercloud/openstack/db/v1/datastores
 github.com/gophercloud/gophercloud/openstack/db/v1/instances
 github.com/gophercloud/gophercloud/openstack/db/v1/users
 github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets
 github.com/gophercloud/gophercloud/openstack/dns/v2/zones
+github.com/gophercloud/gophercloud/openstack/identity/v2/tenants
+github.com/gophercloud/gophercloud/openstack/identity/v2/tokens
 github.com/gophercloud/gophercloud/openstack/identity/v3/applicationcredentials
 github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints
 github.com/gophercloud/gophercloud/openstack/identity/v3/groups
@@ -121,7 +125,10 @@ github.com/gophercloud/gophercloud/openstack/imageservice/v2/images
 github.com/gophercloud/gophercloud/openstack/imageservice/v2/members
 github.com/gophercloud/gophercloud/openstack/keymanager/v1/containers
 github.com/gophercloud/gophercloud/openstack/keymanager/v1/secrets
+github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies
 github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners
+github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors
+github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/dns
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external
@@ -162,6 +169,7 @@ github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/sit
 github.com/gophercloud/gophercloud/openstack/networking/v2/networks
 github.com/gophercloud/gophercloud/openstack/networking/v2/ports
 github.com/gophercloud/gophercloud/openstack/networking/v2/subnets
+github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts
 github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers
 github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects
 github.com/gophercloud/gophercloud/openstack/objectstorage/v1/swauth
@@ -173,18 +181,10 @@ github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/securityservic
 github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharenetworks
 github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares
 github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/snapshots
-github.com/gophercloud/gophercloud/pagination
-github.com/gophercloud/gophercloud/openstack/identity/v2/tokens
 github.com/gophercloud/gophercloud/openstack/utils
-github.com/gophercloud/gophercloud/openstack/db/v1/datastores
-github.com/gophercloud/gophercloud/internal
-github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies
-github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools
-github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts
+github.com/gophercloud/gophercloud/pagination
 github.com/gophercloud/gophercloud/testhelper
 github.com/gophercloud/gophercloud/testhelper/client
-github.com/gophercloud/gophercloud/openstack/identity/v2/tenants
-github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors
 # github.com/gophercloud/utils v0.0.0-20190829151529-94e6842399e5
 github.com/gophercloud/utils/openstack/clientconfig
 # github.com/hashicorp/errwrap v1.0.0

--- a/website/docs/r/lb_loadbalancer_v2.html.markdown
+++ b/website/docs/r/lb_loadbalancer_v2.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 * `admin_state_up` - (Optional) The administrative state of the Loadbalancer.
     A valid value is true (UP) or false (DOWN).
 
-* `flavor` - (Optional) The UUID of a flavor. Changing this creates a new
+* `flavor_id` - (Optional) The UUID of a flavor. Changing this creates a new
     loadbalancer.
 
 * `loadbalancer_provider` - (Optional) The name of the provider. Changing this
@@ -68,7 +68,7 @@ The following attributes are exported:
 * `tenant_id` - See Argument Reference above.
 * `vip_address` - See Argument Reference above.
 * `admin_state_up` - See Argument Reference above.
-* `flavor` - See Argument Reference above.
+* `flavor_id` - See Argument Reference above.
 * `loadbalancer_provider` - See Argument Reference above.
 * `security_group_ids` - See Argument Reference above.
 * `vip_port_id` - The Port ID of the Load Balancer IP.


### PR DESCRIPTION
Fixes #903 

Incorporates upstream gophercloud fix.

https://github.com/gophercloud/gophercloud/issues/1743

The openstack_lb_loadbalancer_v2 flavor attribute is now
`flavor_id` to match the Neutron LBaaSv2 and Octavia
api attribute.