### PR TITLE
Update lb_pool_v2.html.markdown

### DIFF
--- a/website/docs/r/lb_pool_v2.html.markdown
+++ b/website/docs/r/lb_pool_v2.html.markdown
@@ -19,7 +19,7 @@ resource "openstack_lb_pool_v2" "pool_1" {
   listener_id = "d9415786-5f1a-428b-b35f-2f1523e146d2"
 
   persistence {
-    type        = "HTTP_COOKIE"
+    type        = "APP_COOKIE"
     cookie_name = "testCookie"
   }
 }


### PR DESCRIPTION
example states that it supports cookie name for HTTP_COOKIE but terraform wont support cookie_name for HTTP_COOKIE type and the cookie_name feature supports only for APP_COOKIE.
Same has been described in bottom of this page as well.