### PR TITLE
Networking V2: rename "Quotas" resource to "Quota"

### DIFF
--- a/openstack/import_openstack_networking_quotas_v2_test.go
+++ b/openstack/import_openstack_networking_quotas_v2_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccNetworkingQuotasV2_importBasic(t *testing.T) {
-	resourceName := "openstack_networking_quotas_v2.quotas_1"
+func TestAccNetworkingQuotaV2_importBasic(t *testing.T) {
+	resourceName := "openstack_networking_quota_v2.quota_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -18,7 +18,7 @@ func TestAccNetworkingQuotasV2_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckIdentityV3ProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkingQuotasV2_basic,
+				Config: testAccNetworkingQuotaV2_basic,
 			},
 			{
 				ResourceName:      resourceName,

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -333,7 +333,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_networking_qos_dscp_marking_rule_v2":      resourceNetworkingQoSDSCPMarkingRuleV2(),
 			"openstack_networking_qos_minimum_bandwidth_rule_v2": resourceNetworkingQoSMinimumBandwidthRuleV2(),
 			"openstack_networking_qos_policy_v2":                 resourceNetworkingQoSPolicyV2(),
-			"openstack_networking_quotas_v2":                     resourceNetworkingQuotasV2(),
+			"openstack_networking_quota_v2":                      resourceNetworkingQuotaV2(),
 			"openstack_networking_router_v2":                     resourceNetworkingRouterV2(),
 			"openstack_networking_router_interface_v2":           resourceNetworkingRouterInterfaceV2(),
 			"openstack_networking_router_route_v2":               resourceNetworkingRouterRouteV2(),

--- a/openstack/resource_openstack_networking_quota_v2.go
+++ b/openstack/resource_openstack_networking_quota_v2.go
@@ -9,12 +9,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-func resourceNetworkingQuotasV2() *schema.Resource {
+func resourceNetworkingQuotaV2() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceNetworkingQuotasV2Create,
-		Read:   resourceNetworkingQuotasV2Read,
-		Update: resourceNetworkingQuotasV2Update,
-		Delete: resourceNetworkingQuotasV2Delete,
+		Create: resourceNetworkingQuotaV2Create,
+		Read:   resourceNetworkingQuotaV2Read,
+		Update: resourceNetworkingQuotaV2Update,
+		Delete: schema.RemoveFromState,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -96,7 +96,7 @@ func resourceNetworkingQuotasV2() *schema.Resource {
 	}
 }
 
-func resourceNetworkingQuotasV2Create(d *schema.ResourceData, meta interface{}) error {
+func resourceNetworkingQuotaV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
@@ -128,17 +128,17 @@ func resourceNetworkingQuotasV2Create(d *schema.ResourceData, meta interface{}) 
 
 	q, err := quotas.Update(networkingClient, projectID, updateOpts).Extract()
 	if err != nil {
-		return fmt.Errorf("Error creating openstack_networking_quotas_v2: %s", err)
+		return fmt.Errorf("Error creating openstack_networking_quota_v2: %s", err)
 	}
 
 	d.SetId(projectID)
 
-	log.Printf("[DEBUG] Created openstack_networking_quotas_v2 %#v", q)
+	log.Printf("[DEBUG] Created openstack_networking_quota_v2 %#v", q)
 
-	return resourceNetworkingQuotasV2Read(d, meta)
+	return resourceNetworkingQuotaV2Read(d, meta)
 }
 
-func resourceNetworkingQuotasV2Read(d *schema.ResourceData, meta interface{}) error {
+func resourceNetworkingQuotaV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
@@ -147,10 +147,10 @@ func resourceNetworkingQuotasV2Read(d *schema.ResourceData, meta interface{}) er
 
 	q, err := quotas.Get(networkingClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving openstack_networking_quotas_v2")
+		return CheckDeleted(d, err, "Error retrieving openstack_networking_quota_v2")
 	}
 
-	log.Printf("[DEBUG] Retrieved openstack_networking_quotas_v2 %s: %#v", d.Id(), q)
+	log.Printf("[DEBUG] Retrieved openstack_networking_quota_v2 %s: %#v", d.Id(), q)
 
 	d.Set("project_id", d.Id())
 	d.Set("floatingip", q.FloatingIP)
@@ -166,7 +166,7 @@ func resourceNetworkingQuotasV2Read(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceNetworkingQuotasV2Update(d *schema.ResourceData, meta interface{}) error {
+func resourceNetworkingQuotaV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
@@ -233,18 +233,12 @@ func resourceNetworkingQuotasV2Update(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if hasChange {
-		log.Printf("[DEBUG] openstack_networking_quotas_v2 %s update options: %#v", d.Id(), updateOpts)
+		log.Printf("[DEBUG] openstack_networking_quota_v2 %s update options: %#v", d.Id(), updateOpts)
 		_, err := quotas.Update(networkingClient, d.Id(), updateOpts).Extract()
 		if err != nil {
-			return fmt.Errorf("Error updating openstack_networking_quotas_v2: %s", err)
+			return fmt.Errorf("Error updating openstack_networking_quota_v2: %s", err)
 		}
 	}
 
-	return resourceNetworkingQuotasV2Read(d, meta)
-}
-
-func resourceNetworkingQuotasV2Delete(_ *schema.ResourceData, _ interface{}) error {
-	log.Printf("[DEBUG] openstack_networking_quotas_v2 deletion is a no-op operation")
-
-	return nil
+	return resourceNetworkingQuotaV2Read(d, meta)
 }

--- a/openstack/resource_openstack_networking_quota_v2_test.go
+++ b/openstack/resource_openstack_networking_quota_v2_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccNetworkingQuotasV2_basic(t *testing.T) {
+func TestAccNetworkingQuotaV2_basic(t *testing.T) {
 	var project projects.Project
 
 	resource.Test(t, resource.TestCase{
@@ -19,87 +19,87 @@ func TestAccNetworkingQuotasV2_basic(t *testing.T) {
 		CheckDestroy: testAccCheckIdentityV3ProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkingQuotasV2_basic,
+				Config: testAccNetworkingQuotaV2_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityV3ProjectExists("openstack_identity_project_v3.project_1", &project),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "floatingip", "2"),
+						"openstack_networking_quota_v2.quota_1", "floatingip", "2"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "network", "2"),
+						"openstack_networking_quota_v2.quota_1", "network", "2"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "port", "2"),
+						"openstack_networking_quota_v2.quota_1", "port", "2"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "rbac_policy", "1"),
+						"openstack_networking_quota_v2.quota_1", "rbac_policy", "1"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "router", "2"),
+						"openstack_networking_quota_v2.quota_1", "router", "2"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "security_group", "2"),
+						"openstack_networking_quota_v2.quota_1", "security_group", "2"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "security_group_rule", "2"),
+						"openstack_networking_quota_v2.quota_1", "security_group_rule", "2"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "subnet", "1"),
+						"openstack_networking_quota_v2.quota_1", "subnet", "1"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "subnetpool", "1"),
+						"openstack_networking_quota_v2.quota_1", "subnetpool", "1"),
 				),
 			},
 			{
-				Config: testAccNetworkingQuotasV2_update_1,
+				Config: testAccNetworkingQuotaV2_update_1,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityV3ProjectExists("openstack_identity_project_v3.project_1", &project),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "floatingip", "3"),
+						"openstack_networking_quota_v2.quota_1", "floatingip", "3"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "network", "3"),
+						"openstack_networking_quota_v2.quota_1", "network", "3"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "port", "4"),
+						"openstack_networking_quota_v2.quota_1", "port", "4"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "rbac_policy", "1"),
+						"openstack_networking_quota_v2.quota_1", "rbac_policy", "1"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "router", "2"),
+						"openstack_networking_quota_v2.quota_1", "router", "2"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "security_group", "2"),
+						"openstack_networking_quota_v2.quota_1", "security_group", "2"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "security_group_rule", "2"),
+						"openstack_networking_quota_v2.quota_1", "security_group_rule", "2"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "subnet", "1"),
+						"openstack_networking_quota_v2.quota_1", "subnet", "1"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "subnetpool", "1"),
+						"openstack_networking_quota_v2.quota_1", "subnetpool", "1"),
 				),
 			},
 			{
-				Config: testAccNetworkingQuotasV2_update_2,
+				Config: testAccNetworkingQuotaV2_update_2,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityV3ProjectExists("openstack_identity_project_v3.project_1", &project),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "floatingip", "2"),
+						"openstack_networking_quota_v2.quota_1", "floatingip", "2"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "network", "2"),
+						"openstack_networking_quota_v2.quota_1", "network", "2"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "port", "2"),
+						"openstack_networking_quota_v2.quota_1", "port", "2"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "rbac_policy", "4"),
+						"openstack_networking_quota_v2.quota_1", "rbac_policy", "4"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "router", "4"),
+						"openstack_networking_quota_v2.quota_1", "router", "4"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "security_group", "3"),
+						"openstack_networking_quota_v2.quota_1", "security_group", "3"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "security_group_rule", "3"),
+						"openstack_networking_quota_v2.quota_1", "security_group_rule", "3"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "subnet", "3"),
+						"openstack_networking_quota_v2.quota_1", "subnet", "3"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_quotas_v2.quotas_1", "subnetpool", "3"),
+						"openstack_networking_quota_v2.quota_1", "subnetpool", "3"),
 				),
 			},
 		},
 	})
 }
 
-const testAccNetworkingQuotasV2_basic = `
+const testAccNetworkingQuotaV2_basic = `
 resource "openstack_identity_project_v3" "project_1" {
   name = "project_1"
 }
 
-resource "openstack_networking_quotas_v2" "quotas_1" {
+resource "openstack_networking_quota_v2" "quota_1" {
   project_id          = "${openstack_identity_project_v3.project_1.id}"
   floatingip          = 2
   network             = 2
@@ -113,12 +113,12 @@ resource "openstack_networking_quotas_v2" "quotas_1" {
 }
 `
 
-const testAccNetworkingQuotasV2_update_1 = `
+const testAccNetworkingQuotaV2_update_1 = `
 resource "openstack_identity_project_v3" "project_1" {
   name = "project_1"
 }
 
-resource "openstack_networking_quotas_v2" "quotas_1" {
+resource "openstack_networking_quota_v2" "quota_1" {
   project_id          = "${openstack_identity_project_v3.project_1.id}"
   floatingip          = 3
   network             = 3
@@ -132,12 +132,12 @@ resource "openstack_networking_quotas_v2" "quotas_1" {
 }
 `
 
-const testAccNetworkingQuotasV2_update_2 = `
+const testAccNetworkingQuotaV2_update_2 = `
 resource "openstack_identity_project_v3" "project_1" {
   name = "project_1"
 }
 
-resource "openstack_networking_quotas_v2" "quotas_1" {
+resource "openstack_networking_quota_v2" "quota_1" {
   project_id          = "${openstack_identity_project_v3.project_1.id}"
   floatingip          = 2
   network             = 2

--- a/website/docs/r/networking_quota_v2.html.markdown
+++ b/website/docs/r/networking_quota_v2.html.markdown
@@ -1,14 +1,14 @@
 ---
 layout: "openstack"
-page_title: "OpenStack: openstack_networking_quotas_v2"
-sidebar_current: "docs-openstack-resource-networking-quotas-v2"
+page_title: "OpenStack: openstack_networking_quota_v2"
+sidebar_current: "docs-openstack-resource-networking-quota-v2"
 description: |-
-  Manages a V2 quotas resource within OpenStack.
+  Manages a V2 networking quota resource within OpenStack.
 ---
 
-# openstack\_networking\_quotas\_v2
+# openstack\_networking\_quota\_v2
 
-Manages a V2 networking quotas resource within OpenStack.
+Manages a V2 networking quota resource within OpenStack.
 
 ~> **Note:** This usually requires admin privileges.
 
@@ -22,7 +22,7 @@ resource "openstack_identity_project_v2" "project_1" {
   name = project_1
 }
 
-resource "openstack_networking_quotas_v2" "quotas_1" {
+resource "openstack_networking_quota_v2" "quota_1" {
   project_id          = "${openstack_identity_project_v2.project_1.id}"
   floatingip          = 10
   network             = 4
@@ -40,39 +40,39 @@ resource "openstack_networking_quotas_v2" "quotas_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to create the quotas. If
+* `region` - (Optional) The region in which to create the quota. If
     omitted, the `region` argument of the provider is used. Changing this
-    creates new quotas.
+    creates new quota.
 
-* `project_id` - (Required) ID of the project to manage quotas. Changing this
-    creates new quotas.
+* `project_id` - (Required) ID of the project to manage quota. Changing this
+    creates new quota.
 
 * `floatingip` - (Optional) Quota value for floating IPs. Changing this updates the
-    existing quotas.
+    existing quota.
 
 * `network` - (Optional) Quota value for networks. Changing this updates the
-    existing quotas.
+    existing quota.
 
 * `port` - (Optional) Quota value for ports. Changing this updates the
-    existing quotas.
+    existing quota.
 
 * `rbac_policy` - (Optional) Quota value for RBAC policies.
-    Changing this updates the existing quotas.
+    Changing this updates the existing quota.
 
 * `router` - (Optional) Quota value for routers. Changing this updates the
-    existing quotas.
+    existing quota.
 
 * `security_group` - (Optional) Quota value for security groups. Changing
-    this updates the existing quotas.
+    this updates the existing quota.
 
 * `security_group_rule` - (Optional) Quota value for security group rules.
-    Changing this updates the existing quotas.
+    Changing this updates the existing quota.
     
 * `subnet` - (Optional) Quota value for subnets. Changing
-    this updates the existing quotas.
+    this updates the existing quota.
 
 * `subnetpool` - (Optional) Quota value for subnetpools.
-    Changing this updates the existing quotas.
+    Changing this updates the existing quota.
 
 ## Attributes Reference
 
@@ -95,5 +95,5 @@ The following attributes are exported:
 Quotas can be imported using the `project_id`, e.g.
 
 ```
-$ terraform import openstack_networking_quotas_v2.quotas_1 2a0f2240-c5e6-41de-896d-e80d97428d6b
+$ terraform import openstack_networking_quota_v2.quota_1 2a0f2240-c5e6-41de-896d-e80d97428d6b
 ```

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -309,8 +309,8 @@
             <li<%= sidebar_current("docs-openstack-resource-networking-qos-policy-v2") %>>
               <a href="/docs/providers/openstack/r/networking_qos_policy_v2.html">openstack_networking_qos_policy_v2</a>
             </li>
-            <li<%= sidebar_current("docs-openstack-resource-networking-quotas-v2") %>>
-              <a href="/docs/providers/openstack/r/networking_quotas_v2.html">openstack_networking_quotas_v2</a>
+            <li<%= sidebar_current("docs-openstack-resource-networking-quota-v2") %>>
+              <a href="/docs/providers/openstack/r/networking_quota_v2.html">openstack_networking_quota_v2</a>
             </li>
             <li<%= sidebar_current("docs-openstack-resource-networking-router-interface-v2") %>>
               <a href="/docs/providers/openstack/r/networking_router_interface_v2.html">openstack_networking_router_interface_v2</a>


### PR DESCRIPTION
Use singular name like all other resources do.

Use schema.RemoveFromState for Delete instead of a custom empty method.

For #657 