### PR TITLE
Auth: AllowReauth option should be exported

### DIFF
--- a/openstack/config.go
+++ b/openstack/config.go
@@ -49,7 +49,7 @@ type Config struct {
 	DisableNoCacheHeader        bool
 
 	delayedAuth   bool
-	allowReauth   bool
+	AllowReauth   bool
 	OsClient      *gophercloud.ProviderClient
 	authOpts      *gophercloud.AuthOptions
 	authenticated bool
@@ -148,8 +148,8 @@ func (c *Config) LoadAndValidate() error {
 		return err
 	}
 
-	log.Printf("[DEBUG] OpenStack allowReauth: %t", c.allowReauth)
-	ao.AllowReauth = c.allowReauth
+	log.Printf("[DEBUG] OpenStack allowReauth: %t", c.AllowReauth)
+	ao.AllowReauth = c.AllowReauth
 
 	client, err := openstack.NewClient(ao.IdentityEndpoint)
 	if err != nil {

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -488,7 +488,7 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 		ApplicationCredentialSecret: d.Get("application_credential_secret").(string),
 		useOctavia:                  d.Get("use_octavia").(bool),
 		delayedAuth:                 d.Get("delayed_auth").(bool),
-		allowReauth:                 d.Get("allow_reauth").(bool),
+		AllowReauth:                 d.Get("allow_reauth").(bool),
 		MaxRetries:                  d.Get("max_retries").(int),
 		DisableNoCacheHeader:        d.Get("disable_no_cache_header").(bool),
 		terraformVersion:            terraformVersion,


### PR DESCRIPTION
Follow up for the #918 
It should be possible to use this option in terraform [swift backend](https://github.com/hashicorp/terraform/blob/cd7c3e4231c3730b56812881756ac82a6a569583/backend/remote-state/swift/backend.go#L343)