### PR TITLE
Missing character

### DIFF
--- a/website/docs/r/identity_user_v3.html.markdown
+++ b/website/docs/r/identity_user_v3.html.markdown
@@ -39,7 +39,7 @@ resource "openstack_identity_user_v3" "user_1" {
     rule = ["password"]
   }
 
-  extra {
+  extra = {
     email = "user_1@foobar.com"
   }
 }


### PR DESCRIPTION
Add missing character to documentation for fixing the error:
`Blocks of type "extra" are not expected here. Did you mean to define argument
"extra"? If so, use the equals sign to assign it a value.`

The example lacks an equal sign, which is the reason for the error. The solution is described in the following article. [https://www.terraform.io/docs/extend/best-practices/detecting-drift.html#error-checking-aggregate-types](https://www.terraform.io/docs/extend/best-practices/detecting-drift.html#error-checking-aggregate-types) 