### PR TITLE
Docs: update COE V1 cluster fixed net and subnet

### DIFF
--- a/website/docs/d/containerinfra_cluster_v1.html.markdown
+++ b/website/docs/d/containerinfra_cluster_v1.html.markdown
@@ -70,6 +70,10 @@ attributes are exported:
 
 * `node_count` - The number of nodes for the cluster.
 
+* `fixed_network` - The fixed network that is attached to the cluster.
+
+* `fixed_subnet` - The fixed subnet that is attached to the cluster.
+
 * `master_addresses` - IP addresses of the master node of the cluster.
 
 * `node_addresses` - IP addresses of the node of the cluster.

--- a/website/docs/r/containerinfra_cluster_v1.html.markdown
+++ b/website/docs/r/containerinfra_cluster_v1.html.markdown
@@ -75,6 +75,12 @@ The following arguments are supported:
 
 * `node_count` - (Optional) The number of nodes for the cluster. Changing this
     creates a new cluster.
+    
+* `fixed_network` - (Optional) The fixed network that will be attached to the
+    cluster. Changing this creates a new cluster.
+
+* `fixed_subnet` - (Optional) The fixed subnet that will be attached to the
+    cluster. Changing this creates a new cluster.
 
 ## Attributes reference
 
@@ -98,6 +104,8 @@ The following attributes are exported:
 * `labels` - See Argument Reference above.
 * `master_count` - See Argument Reference above.
 * `node_count` - See Argument Reference above.
+* `fixed_network` - See Argument Reference above.
+* `fixed_subnet` - See Argument Reference above.
 * `master_addresses` - IP addresses of the master node of the cluster.
 * `node_addresses` - IP addresses of the node of the cluster.
 * `stack_id` - UUID of the Orchestration service stack.


### PR DESCRIPTION
Add fixed_network, fixed_subnet arguments and attributes to COE V1
cluster resource and datasource.