### PR TITLE
Add vip_network_id for octavia

### DIFF
--- a/openstack/lb_v2_shared.go
+++ b/openstack/lb_v2_shared.go
@@ -9,16 +9,21 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+
 	octavialisteners "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
+	octavialoadbalancers "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
 	octaviamonitors "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors"
 	octaviapools "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/l7policies"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners"
+
+	neutronl7policies "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/l7policies"
 	neutronlisteners "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers"
+	neutronloadbalancers "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers"
 	neutronmonitors "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/monitors"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools"
+	neutronpools "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools"
 )
+
+const octaviaLBClientType = "load-balancer"
 
 // lbPendingStatuses are the valid statuses a LoadBalancer will be in while
 // it's updating.
@@ -30,7 +35,7 @@ var lbPendingDeleteStatuses = []string{"ERROR", "PENDING_UPDATE", "PENDING_DELET
 var lbSkipLBStatuses = []string{"ERROR", "ACTIVE"}
 
 // chooseLBV2Client will determine which load balacing client to use:
-// Either the Octavia/LBaaS client or the Neutron/Networking v2 client.
+// either the Octavia/LBaaS client or the Neutron/Networking v2 client.
 func chooseLBV2Client(d *schema.ResourceData, config *Config) (*gophercloud.ServiceClient, error) {
 	if config.UseOctavia {
 		return config.LoadBalancerV2Client(GetRegion(d, config))
@@ -39,7 +44,7 @@ func chooseLBV2Client(d *schema.ResourceData, config *Config) (*gophercloud.Serv
 }
 
 // chooseLBV2AccTestClient will determine which load balacing client to use:
-// Either the Octavia/LBaaS client or the Neutron/Networking v2 client.
+// either the Octavia/LBaaS client or the Neutron/Networking v2 client.
 // This is similar to the chooseLBV2Client function but specific for acceptance
 // tests.
 func chooseLBV2AccTestClient(config *Config, region string) (*gophercloud.ServiceClient, error) {
@@ -50,7 +55,7 @@ func chooseLBV2AccTestClient(config *Config, region string) (*gophercloud.Servic
 }
 
 // chooseLBV2ListenerCreateOpts will determine which load balancer listener Create options to use:
-// Either the Octavia/LBaaS or the Neutron/Networking v2.
+// either the Octavia/LBaaS or the Neutron/Networking v2.
 func chooseLBV2ListenerCreateOpts(d *schema.ResourceData, config *Config) (neutronlisteners.CreateOptsBuilder, error) {
 	adminStateUp := d.Get("admin_state_up").(bool)
 
@@ -142,7 +147,7 @@ func chooseLBV2ListenerCreateOpts(d *schema.ResourceData, config *Config) (neutr
 }
 
 // chooseLBV2ListenerUpdateOpts will determine which load balancer listener Update options to use:
-// Either the Octavia/LBaaS or the Neutron/Networking v2.
+// either the Octavia/LBaaS or the Neutron/Networking v2.
 func chooseLBV2ListenerUpdateOpts(d *schema.ResourceData, config *Config) (neutronlisteners.UpdateOptsBuilder, error) {
 	var hasChange bool
 
@@ -308,7 +313,7 @@ func expandLBV2ListenerHeadersMap(raw map[string]interface{}) (map[string]string
 	return m, nil
 }
 
-func waitForLBV2Listener(lbClient *gophercloud.ServiceClient, listener *listeners.Listener, target string, pending []string, timeout time.Duration) error {
+func waitForLBV2Listener(lbClient *gophercloud.ServiceClient, listener *neutronlisteners.Listener, target string, pending []string, timeout time.Duration) error {
 	log.Printf("[DEBUG] Waiting for openstack_lb_listener_v2 %s to become %s.", listener.ID, target)
 
 	if len(listener.Loadbalancers) == 0 {
@@ -340,7 +345,7 @@ func waitForLBV2Listener(lbClient *gophercloud.ServiceClient, listener *listener
 	return nil
 }
 
-func resourceLBV2ListenerRefreshFunc(lbClient *gophercloud.ServiceClient, lbID string, listener *listeners.Listener) resource.StateRefreshFunc {
+func resourceLBV2ListenerRefreshFunc(lbClient *gophercloud.ServiceClient, lbID string, listener *neutronlisteners.Listener) resource.StateRefreshFunc {
 	if listener.ProvisioningStatus != "" {
 		return func() (interface{}, string, error) {
 			lb, status, err := resourceLBV2LoadBalancerRefreshFunc(lbClient, lbID)()
@@ -351,7 +356,7 @@ func resourceLBV2ListenerRefreshFunc(lbClient *gophercloud.ServiceClient, lbID s
 				return lb, status, nil
 			}
 
-			listener, err := listeners.Get(lbClient, listener.ID).Extract()
+			listener, err := neutronlisteners.Get(lbClient, listener.ID).Extract()
 			if err != nil {
 				return nil, "", err
 			}
@@ -364,7 +369,7 @@ func resourceLBV2ListenerRefreshFunc(lbClient *gophercloud.ServiceClient, lbID s
 }
 
 // chooseLBV2MonitorCreateOpts will determine which load balancer monitor Create options to use:
-// Either the Octavia/LBaaS or the Neutron/Networking v2.
+// either the Octavia/LBaaS or the Neutron/Networking v2.
 func chooseLBV2MonitorCreateOpts(d *schema.ResourceData, config *Config) neutronmonitors.CreateOptsBuilder {
 	adminStateUp := d.Get("admin_state_up").(bool)
 
@@ -411,7 +416,7 @@ func chooseLBV2MonitorCreateOpts(d *schema.ResourceData, config *Config) neutron
 }
 
 // chooseLBV2MonitorUpdateOpts will determine which load balancer monitor Update options to use:
-// Either the Octavia/LBaaS or the Neutron/Networking v2.
+// either the Octavia/LBaaS or the Neutron/Networking v2.
 func chooseLBV2MonitorUpdateOpts(d *schema.ResourceData, config *Config) neutronmonitors.UpdateOptsBuilder {
 	var hasChange bool
 
@@ -538,7 +543,7 @@ func waitForLBV2LoadBalancer(lbClient *gophercloud.ServiceClient, lbID string, t
 
 func resourceLBV2LoadBalancerRefreshFunc(lbClient *gophercloud.ServiceClient, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		lb, err := loadbalancers.Get(lbClient, id).Extract()
+		lb, err := neutronloadbalancers.Get(lbClient, id).Extract()
 		if err != nil {
 			return nil, "", err
 		}
@@ -547,7 +552,7 @@ func resourceLBV2LoadBalancerRefreshFunc(lbClient *gophercloud.ServiceClient, id
 	}
 }
 
-func waitForLBV2Member(lbClient *gophercloud.ServiceClient, parentPool *pools.Pool, member *pools.Member, target string, pending []string, timeout time.Duration) error {
+func waitForLBV2Member(lbClient *gophercloud.ServiceClient, parentPool *neutronpools.Pool, member *neutronpools.Member, target string, pending []string, timeout time.Duration) error {
 	log.Printf("[DEBUG] Waiting for member %s to become %s.", member.ID, target)
 
 	lbID, err := lbV2FindLBIDviaPool(lbClient, parentPool)
@@ -578,7 +583,7 @@ func waitForLBV2Member(lbClient *gophercloud.ServiceClient, parentPool *pools.Po
 	return nil
 }
 
-func resourceLBV2MemberRefreshFunc(lbClient *gophercloud.ServiceClient, lbID string, poolID string, member *pools.Member) resource.StateRefreshFunc {
+func resourceLBV2MemberRefreshFunc(lbClient *gophercloud.ServiceClient, lbID string, poolID string, member *neutronpools.Member) resource.StateRefreshFunc {
 	if member.ProvisioningStatus != "" {
 		return func() (interface{}, string, error) {
 			lb, status, err := resourceLBV2LoadBalancerRefreshFunc(lbClient, lbID)()
@@ -589,7 +594,7 @@ func resourceLBV2MemberRefreshFunc(lbClient *gophercloud.ServiceClient, lbID str
 				return lb, status, nil
 			}
 
-			member, err := pools.GetMember(lbClient, poolID, member.ID).Extract()
+			member, err := neutronpools.GetMember(lbClient, poolID, member.ID).Extract()
 			if err != nil {
 				return nil, "", err
 			}
@@ -601,7 +606,7 @@ func resourceLBV2MemberRefreshFunc(lbClient *gophercloud.ServiceClient, lbID str
 	return resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient, lbID, "member", member.ID, poolID)
 }
 
-func waitForLBV2Monitor(lbClient *gophercloud.ServiceClient, parentPool *pools.Pool, monitor *neutronmonitors.Monitor, target string, pending []string, timeout time.Duration) error {
+func waitForLBV2Monitor(lbClient *gophercloud.ServiceClient, parentPool *neutronpools.Pool, monitor *neutronmonitors.Monitor, target string, pending []string, timeout time.Duration) error {
 	log.Printf("[DEBUG] Waiting for openstack_lb_monitor_v2 %s to become %s.", monitor.ID, target)
 
 	lbID, err := lbV2FindLBIDviaPool(lbClient, parentPool)
@@ -654,7 +659,7 @@ func resourceLBV2MonitorRefreshFunc(lbClient *gophercloud.ServiceClient, lbID st
 	return resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient, lbID, "monitor", monitor.ID, "")
 }
 
-func waitForLBV2Pool(lbClient *gophercloud.ServiceClient, pool *pools.Pool, target string, pending []string, timeout time.Duration) error {
+func waitForLBV2Pool(lbClient *gophercloud.ServiceClient, pool *neutronpools.Pool, target string, pending []string, timeout time.Duration) error {
 	log.Printf("[DEBUG] Waiting for pool %s to become %s.", pool.ID, target)
 
 	lbID, err := lbV2FindLBIDviaPool(lbClient, pool)
@@ -685,7 +690,7 @@ func waitForLBV2Pool(lbClient *gophercloud.ServiceClient, pool *pools.Pool, targ
 	return nil
 }
 
-func resourceLBV2PoolRefreshFunc(lbClient *gophercloud.ServiceClient, lbID string, pool *pools.Pool) resource.StateRefreshFunc {
+func resourceLBV2PoolRefreshFunc(lbClient *gophercloud.ServiceClient, lbID string, pool *neutronpools.Pool) resource.StateRefreshFunc {
 	if pool.ProvisioningStatus != "" {
 		return func() (interface{}, string, error) {
 			lb, status, err := resourceLBV2LoadBalancerRefreshFunc(lbClient, lbID)()
@@ -696,7 +701,7 @@ func resourceLBV2PoolRefreshFunc(lbClient *gophercloud.ServiceClient, lbID strin
 				return lb, status, nil
 			}
 
-			pool, err := pools.Get(lbClient, pool.ID).Extract()
+			pool, err := neutronpools.Get(lbClient, pool.ID).Extract()
 			if err != nil {
 				return nil, "", err
 			}
@@ -708,14 +713,14 @@ func resourceLBV2PoolRefreshFunc(lbClient *gophercloud.ServiceClient, lbID strin
 	return resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient, lbID, "pool", pool.ID, "")
 }
 
-func lbV2FindLBIDviaPool(lbClient *gophercloud.ServiceClient, pool *pools.Pool) (string, error) {
+func lbV2FindLBIDviaPool(lbClient *gophercloud.ServiceClient, pool *neutronpools.Pool) (string, error) {
 	if len(pool.Loadbalancers) > 0 {
 		return pool.Loadbalancers[0].ID, nil
 	}
 
 	if len(pool.Listeners) > 0 {
 		listenerID := pool.Listeners[0].ID
-		listener, err := listeners.Get(lbClient, listenerID).Extract()
+		listener, err := neutronlisteners.Get(lbClient, listenerID).Extract()
 		if err != nil {
 			return "", err
 		}
@@ -730,7 +735,7 @@ func lbV2FindLBIDviaPool(lbClient *gophercloud.ServiceClient, pool *pools.Pool) 
 
 func resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient *gophercloud.ServiceClient, lbID, resourceType, resourceID string, parentID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		statuses, err := loadbalancers.GetStatuses(lbClient, lbID).Extract()
+		statuses, err := neutronloadbalancers.GetStatuses(lbClient, lbID).Extract()
 		if err != nil {
 			if _, ok := err.(gophercloud.ErrDefault404); ok {
 				return nil, "", gophercloud.ErrDefault404{
@@ -746,8 +751,8 @@ func resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient *gophercloud.Serv
 
 		// Don't fail, when statuses returns "null"
 		if statuses == nil || statuses.Loadbalancer == nil {
-			statuses = new(loadbalancers.StatusTree)
-			statuses.Loadbalancer = new(loadbalancers.LoadBalancer)
+			statuses = new(neutronloadbalancers.StatusTree)
+			statuses.Loadbalancer = new(neutronloadbalancers.LoadBalancer)
 		} else if !strSliceContains(lbSkipLBStatuses, statuses.Loadbalancer.ProvisioningStatus) {
 			return statuses.Loadbalancer, statuses.Loadbalancer.ProvisioningStatus, nil
 		}
@@ -761,7 +766,7 @@ func resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient *gophercloud.Serv
 					}
 				}
 			}
-			listener, err := listeners.Get(lbClient, resourceID).Extract()
+			listener, err := neutronlisteners.Get(lbClient, resourceID).Extract()
 			return listener, "ACTIVE", err
 
 		case "pool":
@@ -772,7 +777,7 @@ func resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient *gophercloud.Serv
 					}
 				}
 			}
-			pool, err := pools.Get(lbClient, resourceID).Extract()
+			pool, err := neutronpools.Get(lbClient, resourceID).Extract()
 			return pool, "ACTIVE", err
 
 		case "monitor":
@@ -796,7 +801,7 @@ func resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient *gophercloud.Serv
 					}
 				}
 			}
-			member, err := pools.GetMember(lbClient, parentID, resourceID).Extract()
+			member, err := neutronpools.GetMember(lbClient, parentID, resourceID).Extract()
 			return member, "ACTIVE", err
 
 		case "l7policy":
@@ -809,7 +814,7 @@ func resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient *gophercloud.Serv
 					}
 				}
 			}
-			l7policy, err := l7policies.Get(lbClient, resourceID).Extract()
+			l7policy, err := neutronl7policies.Get(lbClient, resourceID).Extract()
 			return l7policy, "ACTIVE", err
 
 		case "l7rule":
@@ -824,7 +829,7 @@ func resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient *gophercloud.Serv
 					}
 				}
 			}
-			l7Rule, err := l7policies.GetRule(lbClient, parentID, resourceID).Extract()
+			l7Rule, err := neutronl7policies.GetRule(lbClient, parentID, resourceID).Extract()
 			return l7Rule, "ACTIVE", err
 		}
 
@@ -832,7 +837,7 @@ func resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient *gophercloud.Serv
 	}
 }
 
-func resourceLBV2L7PolicyRefreshFunc(lbClient *gophercloud.ServiceClient, lbID string, l7policy *l7policies.L7Policy) resource.StateRefreshFunc {
+func resourceLBV2L7PolicyRefreshFunc(lbClient *gophercloud.ServiceClient, lbID string, l7policy *neutronl7policies.L7Policy) resource.StateRefreshFunc {
 	if l7policy.ProvisioningStatus != "" {
 		return func() (interface{}, string, error) {
 			lb, status, err := resourceLBV2LoadBalancerRefreshFunc(lbClient, lbID)()
@@ -843,7 +848,7 @@ func resourceLBV2L7PolicyRefreshFunc(lbClient *gophercloud.ServiceClient, lbID s
 				return lb, status, nil
 			}
 
-			l7policy, err := l7policies.Get(lbClient, l7policy.ID).Extract()
+			l7policy, err := neutronl7policies.Get(lbClient, l7policy.ID).Extract()
 			if err != nil {
 				return nil, "", err
 			}
@@ -855,7 +860,7 @@ func resourceLBV2L7PolicyRefreshFunc(lbClient *gophercloud.ServiceClient, lbID s
 	return resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient, lbID, "l7policy", l7policy.ID, "")
 }
 
-func waitForLBV2L7Policy(lbClient *gophercloud.ServiceClient, parentListener *listeners.Listener, l7policy *l7policies.L7Policy, target string, pending []string, timeout time.Duration) error {
+func waitForLBV2L7Policy(lbClient *gophercloud.ServiceClient, parentListener *neutronlisteners.Listener, l7policy *neutronl7policies.L7Policy, target string, pending []string, timeout time.Duration) error {
 	log.Printf("[DEBUG] Waiting for l7policy %s to become %s.", l7policy.ID, target)
 
 	if len(parentListener.Loadbalancers) == 0 {
@@ -889,18 +894,18 @@ func waitForLBV2L7Policy(lbClient *gophercloud.ServiceClient, parentListener *li
 
 func getListenerIDForL7Policy(lbClient *gophercloud.ServiceClient, id string) (string, error) {
 	log.Printf("[DEBUG] Trying to get Listener ID associated with the %s L7 Policy ID", id)
-	lbsPages, err := loadbalancers.List(lbClient, loadbalancers.ListOpts{}).AllPages()
+	lbsPages, err := neutronloadbalancers.List(lbClient, neutronloadbalancers.ListOpts{}).AllPages()
 	if err != nil {
 		return "", fmt.Errorf("No Load Balancers were found: %s", err)
 	}
 
-	lbs, err := loadbalancers.ExtractLoadBalancers(lbsPages)
+	lbs, err := neutronloadbalancers.ExtractLoadBalancers(lbsPages)
 	if err != nil {
 		return "", fmt.Errorf("Unable to extract Load Balancers list: %s", err)
 	}
 
 	for _, lb := range lbs {
-		statuses, err := loadbalancers.GetStatuses(lbClient, lb.ID).Extract()
+		statuses, err := neutronloadbalancers.GetStatuses(lbClient, lb.ID).Extract()
 		if err != nil {
 			return "", fmt.Errorf("Failed to get Load Balancer statuses: %s", err)
 		}
@@ -916,7 +921,7 @@ func getListenerIDForL7Policy(lbClient *gophercloud.ServiceClient, id string) (s
 	return "", fmt.Errorf("Unable to find Listener ID associated with the %s L7 Policy ID", id)
 }
 
-func resourceLBV2L7RuleRefreshFunc(lbClient *gophercloud.ServiceClient, lbID string, l7policyID string, l7rule *l7policies.Rule) resource.StateRefreshFunc {
+func resourceLBV2L7RuleRefreshFunc(lbClient *gophercloud.ServiceClient, lbID string, l7policyID string, l7rule *neutronl7policies.Rule) resource.StateRefreshFunc {
 	if l7rule.ProvisioningStatus != "" {
 		return func() (interface{}, string, error) {
 			lb, status, err := resourceLBV2LoadBalancerRefreshFunc(lbClient, lbID)()
@@ -927,7 +932,7 @@ func resourceLBV2L7RuleRefreshFunc(lbClient *gophercloud.ServiceClient, lbID str
 				return lb, status, nil
 			}
 
-			l7rule, err := l7policies.GetRule(lbClient, l7policyID, l7rule.ID).Extract()
+			l7rule, err := neutronl7policies.GetRule(lbClient, l7policyID, l7rule.ID).Extract()
 			if err != nil {
 				return nil, "", err
 			}
@@ -939,7 +944,7 @@ func resourceLBV2L7RuleRefreshFunc(lbClient *gophercloud.ServiceClient, lbID str
 	return resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient, lbID, "l7rule", l7rule.ID, l7policyID)
 }
 
-func waitForLBV2L7Rule(lbClient *gophercloud.ServiceClient, parentListener *listeners.Listener, parentL7policy *l7policies.L7Policy, l7rule *l7policies.Rule, target string, pending []string, timeout time.Duration) error {
+func waitForLBV2L7Rule(lbClient *gophercloud.ServiceClient, parentListener *neutronlisteners.Listener, parentL7policy *neutronl7policies.L7Policy, l7rule *neutronl7policies.Rule, target string, pending []string, timeout time.Duration) error {
 	log.Printf("[DEBUG] Waiting for l7rule %s to become %s.", l7rule.ID, target)
 
 	if len(parentListener.Loadbalancers) == 0 {
@@ -971,7 +976,7 @@ func waitForLBV2L7Rule(lbClient *gophercloud.ServiceClient, parentListener *list
 	return nil
 }
 
-func flattenLBPoolPersistenceV2(p pools.SessionPersistence) []map[string]interface{} {
+func flattenLBPoolPersistenceV2(p neutronpools.SessionPersistence) []map[string]interface{} {
 	return []map[string]interface{}{
 		{
 			"type":        p.Type,
@@ -1023,4 +1028,78 @@ func expandLBMembersV2(members *schema.Set) []octaviapools.BatchUpdateMemberOpts
 	}
 
 	return m
+}
+
+// chooseLBV2LoadBalancerCreateOpts will determine which load balancer Create options to use:
+// either the Octavia/LBaaS or the Neutron/Networking v2.
+func chooseLBV2LoadBalancerCreateOpts(d *schema.ResourceData, config *Config) neutronloadbalancers.CreateOptsBuilder {
+	var createOpts neutronloadbalancers.CreateOptsBuilder
+
+	var lbProvider string
+	if v, ok := d.GetOk("loadbalancer_provider"); ok {
+		lbProvider = v.(string)
+	}
+
+	adminStateUp := d.Get("admin_state_up").(bool)
+
+	if config.UseOctavia {
+		// Use Octavia.
+		createOpts = octavialoadbalancers.CreateOpts{
+			Name:         d.Get("name").(string),
+			Description:  d.Get("description").(string),
+			VipNetworkID: d.Get("vip_network_id").(string),
+			VipSubnetID:  d.Get("vip_subnet_id").(string),
+			ProjectID:    d.Get("tenant_id").(string),
+			VipAddress:   d.Get("vip_address").(string),
+			AdminStateUp: &adminStateUp,
+			FlavorID:     d.Get("flavor_id").(string),
+			Provider:     lbProvider,
+		}
+	} else {
+		// Use Neutron.
+		createOpts = neutronloadbalancers.CreateOpts{
+			Name:         d.Get("name").(string),
+			Description:  d.Get("description").(string),
+			VipSubnetID:  d.Get("vip_subnet_id").(string),
+			TenantID:     d.Get("tenant_id").(string),
+			VipAddress:   d.Get("vip_address").(string),
+			AdminStateUp: &adminStateUp,
+			FlavorID:     d.Get("flavor_id").(string),
+			Provider:     lbProvider,
+		}
+	}
+
+	return createOpts
+}
+
+func resourceLoadBalancerV2SetSecurityGroups(networkingClient *gophercloud.ServiceClient, vipPortID string, d *schema.ResourceData) error {
+	if vipPortID != "" {
+		if v, ok := d.GetOk("security_group_ids"); ok {
+			securityGroups := expandToStringSlice(v.(*schema.Set).List())
+			updateOpts := ports.UpdateOpts{
+				SecurityGroups: &securityGroups,
+			}
+
+			log.Printf("[DEBUG] Adding security groups to openstack_lb_loadbalancer_v2 "+
+				"VIP port %s: %#v", vipPortID, updateOpts)
+
+			_, err := ports.Update(networkingClient, vipPortID, updateOpts).Extract()
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func resourceLoadBalancerV2GetSecurityGroups(networkingClient *gophercloud.ServiceClient, vipPortID string, d *schema.ResourceData) error {
+	port, err := ports.Get(networkingClient, vipPortID).Extract()
+	if err != nil {
+		return err
+	}
+
+	d.Set("security_group_ids", port.SecurityGroups)
+
+	return nil
 }

--- a/openstack/resource_openstack_lb_loadbalancer_v2.go
+++ b/openstack/resource_openstack_lb_loadbalancer_v2.go
@@ -8,10 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
-	"github.com/gophercloud/gophercloud"
-	octavia "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+	octavialoadbalancers "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
+	neutronloadbalancers "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers"
 )
 
 func resourceLoadBalancerV2() *schema.Resource {
@@ -118,76 +116,49 @@ func resourceLoadBalancerV2Create(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
-	var lbProvider string
-	if v, ok := d.GetOk("loadbalancer_provider"); ok {
-		lbProvider = v.(string)
-	}
+	var (
+		lbID      string
+		vipPortID string
+	)
 
-	var lbID string
-	var vipPortID string
+	// Choose either the Octavia or Neutron create options.
+	createOpts := chooseLBV2LoadBalancerCreateOpts(d, config)
 
-	adminStateUp := d.Get("admin_state_up").(bool)
-	if lbClient.Type == "load-balancer" { // Using octavia.
-		createOpts := octavia.CreateOpts{
-			Name:         d.Get("name").(string),
-			Description:  d.Get("description").(string),
-			VipNetworkID: d.Get("vip_network_id").(string),
-			VipSubnetID:  d.Get("vip_subnet_id").(string),
-			ProjectID:    d.Get("tenant_id").(string),
-			VipAddress:   d.Get("vip_address").(string),
-			AdminStateUp: &adminStateUp,
-			FlavorID:     d.Get("flavor_id").(string),
-			Provider:     lbProvider,
-		}
-		log.Printf("[DEBUG][OCTAVIA] Create Options: %#v", createOpts)
-		lb, err := octavia.Create(lbClient, createOpts).Extract()
+	if lbClient.Type == octaviaLBClientType {
+		log.Printf("[DEBUG][Octavia] openstack_lb_loadbalancer_v2 create options: %#v", createOpts)
+		lb, err := octavialoadbalancers.Create(lbClient, createOpts).Extract()
 		if err != nil {
-			return fmt.Errorf("Error creating LoadBalancer: %s", err)
+			return fmt.Errorf("Error creating openstack_lb_loadbalancer_v2: %s", err)
 		}
 		lbID = lb.ID
 		vipPortID = lb.VipPortID
 	} else {
-		if d.Get("vip_network_id").(string) != "" {
-			return fmt.Errorf("can only set vip_network_id when using octavia")
-		}
-		createOpts := loadbalancers.CreateOpts{
-			Name:         d.Get("name").(string),
-			Description:  d.Get("description").(string),
-			VipSubnetID:  d.Get("vip_subnet_id").(string),
-			TenantID:     d.Get("tenant_id").(string),
-			VipAddress:   d.Get("vip_address").(string),
-			AdminStateUp: &adminStateUp,
-			FlavorID:     d.Get("flavor_id").(string),
-			Provider:     lbProvider,
-		}
-
-		log.Printf("[DEBUG] Create Options: %#v", createOpts)
-		lb, err := loadbalancers.Create(lbClient, createOpts).Extract()
+		log.Printf("[DEBUG][Neutron] openstack_lb_loadbalancer_v2 create options: %#v", createOpts)
+		lb, err := neutronloadbalancers.Create(lbClient, createOpts).Extract()
 		if err != nil {
-			return fmt.Errorf("Error creating LoadBalancer: %s", err)
+			return fmt.Errorf("Error creating openstack_lb_loadbalancer_v2: %s", err)
 		}
 		lbID = lb.ID
 		vipPortID = lb.VipPortID
 	}
 
-	// Wait for LoadBalancer to become active before continuing
+	// Wait for load-balancer to become active before continuing.
 	timeout := d.Timeout(schema.TimeoutCreate)
 	err = waitForLBV2LoadBalancer(lbClient, lbID, "ACTIVE", lbPendingStatuses, timeout)
 	if err != nil {
 		return err
 	}
 
+	// Once the load-balancer has been created, apply any requested security groups
+	// to the port that was created behind the scenes.
 	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
-	// Once the loadbalancer has been created, apply any requested security groups
-	// to the port that was created behind the scenes.
-	if err := resourceLoadBalancerV2SecurityGroups(networkingClient, vipPortID, d); err != nil {
-		return err
+	if err := resourceLoadBalancerV2SetSecurityGroups(networkingClient, vipPortID, d); err != nil {
+		return fmt.Errorf("Error setting openstack_lb_loadbalancer_v2 security groups: %s", err)
 	}
 
-	// If all has been successful, set the ID on the resource
 	d.SetId(lbID)
 
 	return resourceLoadBalancerV2Read(d, meta)
@@ -202,13 +173,13 @@ func resourceLoadBalancerV2Read(d *schema.ResourceData, meta interface{}) error 
 
 	var vipPortID string
 
-	if lbClient.Type == "load-balancer" { // Using octavia.
-		lb, err := octavia.Get(lbClient, d.Id()).Extract()
+	if lbClient.Type == octaviaLBClientType {
+		lb, err := octavialoadbalancers.Get(lbClient, d.Id()).Extract()
 		if err != nil {
-			return CheckDeleted(d, err, "loadbalancer")
+			return CheckDeleted(d, err, "Unable to retrieve openstack_lb_loadbalancer_v2")
 		}
 
-		log.Printf("[DEBUG][OCTAVIA] Retrieved loadbalancer %s: %#v", d.Id(), lb)
+		log.Printf("[DEBUG][Octavia] Retrieved openstack_lb_loadbalancer_v2 %s: %#v", d.Id(), lb)
 
 		d.Set("name", lb.Name)
 		d.Set("description", lb.Description)
@@ -223,12 +194,12 @@ func resourceLoadBalancerV2Read(d *schema.ResourceData, meta interface{}) error 
 		d.Set("region", GetRegion(d, config))
 		vipPortID = lb.VipPortID
 	} else {
-		lb, err := loadbalancers.Get(lbClient, d.Id()).Extract()
+		lb, err := neutronloadbalancers.Get(lbClient, d.Id()).Extract()
 		if err != nil {
-			return CheckDeleted(d, err, "loadbalancer")
+			return CheckDeleted(d, err, "Unable to retrieve openstack_lb_loadbalancer_v2")
 		}
 
-		log.Printf("[DEBUG] Retrieved loadbalancer %s: %#v", d.Id(), lb)
+		log.Printf("[DEBUG][Neutron] Retrieved openstack_lb_loadbalancer_v2 %s: %#v", d.Id(), lb)
 
 		d.Set("name", lb.Name)
 		d.Set("description", lb.Description)
@@ -243,18 +214,15 @@ func resourceLoadBalancerV2Read(d *schema.ResourceData, meta interface{}) error 
 		vipPortID = lb.VipPortID
 	}
 
-	// Get any security groups on the VIP Port
+	// Get any security groups on the VIP Port.
 	if vipPortID != "" {
 		networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
 		if err != nil {
 			return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 		}
-		port, err := ports.Get(networkingClient, vipPortID).Extract()
-		if err != nil {
-			return err
+		if err := resourceLoadBalancerV2GetSecurityGroups(networkingClient, vipPortID, d); err != nil {
+			return fmt.Errorf("Error getting port security groups for openstack_lb_loadbalancer_v2: %s", err)
 		}
-
-		d.Set("security_group_ids", port.SecurityGroups)
 	}
 
 	return nil
@@ -267,7 +235,7 @@ func resourceLoadBalancerV2Update(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
-	var updateOpts loadbalancers.UpdateOpts
+	var updateOpts neutronloadbalancers.UpdateOpts
 	if d.HasChange("name") {
 		name := d.Get("name").(string)
 		updateOpts.Name = &name
@@ -281,17 +249,17 @@ func resourceLoadBalancerV2Update(d *schema.ResourceData, meta interface{}) erro
 		updateOpts.AdminStateUp = &asu
 	}
 
-	if updateOpts != (loadbalancers.UpdateOpts{}) {
-		// Wait for LoadBalancer to become active before continuing
+	if updateOpts != (neutronloadbalancers.UpdateOpts{}) {
+		// Wait for load-balancer to become active before continuing.
 		timeout := d.Timeout(schema.TimeoutUpdate)
 		err = waitForLBV2LoadBalancer(lbClient, d.Id(), "ACTIVE", lbPendingStatuses, timeout)
 		if err != nil {
 			return err
 		}
 
-		log.Printf("[DEBUG] Updating loadbalancer %s with options: %#v", d.Id(), updateOpts)
+		log.Printf("[DEBUG] Updating openstack_lb_loadbalancer_v2 %s with options: %#v", d.Id(), updateOpts)
 		err = resource.Retry(timeout, func() *resource.RetryError {
-			_, err = loadbalancers.Update(lbClient, d.Id(), updateOpts).Extract()
+			_, err = neutronloadbalancers.Update(lbClient, d.Id(), updateOpts).Extract()
 			if err != nil {
 				return checkForRetryableError(err)
 			}
@@ -299,25 +267,25 @@ func resourceLoadBalancerV2Update(d *schema.ResourceData, meta interface{}) erro
 		})
 
 		if err != nil {
-			return fmt.Errorf("Error updating loadbalancer %s: %s", d.Id(), err)
+			return fmt.Errorf("Error updating openstack_lb_loadbalancer_v2 %s: %s", d.Id(), err)
 		}
 
-		// Wait for LoadBalancer to become active before continuing
+		// Wait for load-balancer to become active before continuing.
 		err = waitForLBV2LoadBalancer(lbClient, d.Id(), "ACTIVE", lbPendingStatuses, timeout)
 		if err != nil {
 			return err
 		}
 	}
 
-	// Security Groups get updated separately
+	// Security Groups get updated separately.
 	if d.HasChange("security_group_ids") {
 		networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
 		if err != nil {
 			return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 		}
 		vipPortID := d.Get("vip_port_id").(string)
-		if err := resourceLoadBalancerV2SecurityGroups(networkingClient, vipPortID, d); err != nil {
-			return err
+		if err := resourceLoadBalancerV2SetSecurityGroups(networkingClient, vipPortID, d); err != nil {
+			return fmt.Errorf("Error setting openstack_lb_loadbalancer_v2 security groups: %s", err)
 		}
 	}
 
@@ -331,10 +299,10 @@ func resourceLoadBalancerV2Delete(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
-	log.Printf("[DEBUG] Deleting loadbalancer %s", d.Id())
+	log.Printf("[DEBUG] Deleting openstack_lb_loadbalancer_v2 %s", d.Id())
 	timeout := d.Timeout(schema.TimeoutDelete)
 	err = resource.Retry(timeout, func() *resource.RetryError {
-		err = loadbalancers.Delete(lbClient, d.Id()).ExtractErr()
+		err = neutronloadbalancers.Delete(lbClient, d.Id()).ExtractErr()
 		if err != nil {
 			return checkForRetryableError(err)
 		}
@@ -342,34 +310,13 @@ func resourceLoadBalancerV2Delete(d *schema.ResourceData, meta interface{}) erro
 	})
 
 	if err != nil {
-		return CheckDeleted(d, err, "Error deleting loadbalancer")
+		return CheckDeleted(d, err, "Error deleting openstack_lb_loadbalancer_v2")
 	}
 
-	// Wait for LoadBalancer to become delete
+	// Wait for load-balancer to become deleted.
 	err = waitForLBV2LoadBalancer(lbClient, d.Id(), "DELETED", lbPendingDeleteStatuses, timeout)
 	if err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func resourceLoadBalancerV2SecurityGroups(networkingClient *gophercloud.ServiceClient, vipPortID string, d *schema.ResourceData) error {
-	if vipPortID != "" {
-		if v, ok := d.GetOk("security_group_ids"); ok {
-			securityGroups := expandToStringSlice(v.(*schema.Set).List())
-			updateOpts := ports.UpdateOpts{
-				SecurityGroups: &securityGroups,
-			}
-
-			log.Printf("[DEBUG] Adding security groups to loadbalancer "+
-				"VIP Port %s: %#v", vipPortID, updateOpts)
-
-			_, err := ports.Update(networkingClient, vipPortID, updateOpts).Extract()
-			if err != nil {
-				return err
-			}
-		}
 	}
 
 	return nil

--- a/openstack/resource_openstack_lb_loadbalancer_v2_test.go
+++ b/openstack/resource_openstack_lb_loadbalancer_v2_test.go
@@ -387,8 +387,9 @@ resource "openstack_lb_loadbalancer_v2" "loadbalancer_1" {
   loadbalancer_provider = "octavia"
   vip_network_id = "${openstack_networking_network_v2.network_1.id}"
   timeouts {
-  create = "15m"
-  update = "15m"
-  delete = "15m"
+    create = "15m"
+    update = "15m"
+    delete = "15m"
+  }
 }
 `

--- a/openstack/resource_openstack_lb_loadbalancer_v2_test.go
+++ b/openstack/resource_openstack_lb_loadbalancer_v2_test.go
@@ -386,6 +386,7 @@ resource "openstack_lb_loadbalancer_v2" "loadbalancer_1" {
   name = "loadbalancer_1"
   loadbalancer_provider = "octavia"
   vip_network_id = "${openstack_networking_network_v2.network_1.id}"
+  depends_on = ["openstack_networking_subnet_v2.subnet_1"]
   timeouts {
     create = "15m"
     update = "15m"

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers/doc.go
@@ -1,0 +1,92 @@
+/*
+Package loadbalancers provides information and interaction with Load Balancers
+of the LBaaS v2 extension for the OpenStack Networking service.
+
+Example to List Load Balancers
+
+	listOpts := loadbalancers.ListOpts{
+		Provider: "haproxy",
+	}
+
+	allPages, err := loadbalancers.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allLoadbalancers, err := loadbalancers.ExtractLoadBalancers(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, lb := range allLoadbalancers {
+		fmt.Printf("%+v\n", lb)
+	}
+
+Example to Create a Load Balancer
+
+	createOpts := loadbalancers.CreateOpts{
+		Name:         "db_lb",
+		AdminStateUp: gophercloud.Enabled,
+		VipSubnetID:  "9cedb85d-0759-4898-8a4b-fa5a5ea10086",
+		VipAddress:   "10.30.176.48",
+		FlavorID:     "60df399a-ee85-11e9-81b4-2a2ae2dbcce4",
+		Provider:     "haproxy",
+		Tags:         []string{"test", "stage"},
+	}
+
+	lb, err := loadbalancers.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Load Balancer
+
+	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	name := "new-name"
+	updateOpts := loadbalancers.UpdateOpts{
+		Name: &name,
+	}
+	lb, err := loadbalancers.Update(networkClient, lbID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Load Balancers
+
+	deleteOpts := loadbalancers.DeleteOpts{
+		Cascade: true,
+	}
+
+	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"
+
+	err := loadbalancers.Delete(networkClient, lbID, deleteOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Get the Status of a Load Balancer
+
+	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	status, err := loadbalancers.GetStatuses(networkClient, LBID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Get the Statistics of a Load Balancer
+
+	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	stats, err := loadbalancers.GetStats(networkClient, LBID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Failover a Load Balancers
+
+	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"
+
+	err := loadbalancers.Failover(networkClient, lbID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package loadbalancers

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers/requests.go
@@ -133,13 +133,15 @@ func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResul
 		r.Err = err
 		return
 	}
-	_, r.Err = c.Post(rootURL(c), b, &r.Body, nil)
+	resp, err := c.Post(rootURL(c), b, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Get retrieves a particular Loadbalancer based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
-	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	resp, err := c.Get(resourceURL(c, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
@@ -179,9 +181,10 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateR
 		r.Err = err
 		return
 	}
-	_, r.Err = c.Put(resourceURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+	resp, err := c.Put(resourceURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 202},
 	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
@@ -216,26 +219,30 @@ func Delete(c *gophercloud.ServiceClient, id string, opts DeleteOptsBuilder) (r 
 		}
 		url += query
 	}
-	_, r.Err = c.Delete(url, nil)
+	resp, err := c.Delete(url, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // GetStatuses will return the status of a particular LoadBalancer.
 func GetStatuses(c *gophercloud.ServiceClient, id string) (r GetStatusesResult) {
-	_, r.Err = c.Get(statusRootURL(c, id), &r.Body, nil)
+	resp, err := c.Get(statusRootURL(c, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // GetStats will return the shows the current statistics of a particular LoadBalancer.
 func GetStats(c *gophercloud.ServiceClient, id string) (r StatsResult) {
-	_, r.Err = c.Get(statisticsRootURL(c, id), &r.Body, nil)
+	resp, err := c.Get(statisticsRootURL(c, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Failover performs a failover of a load balancer.
 func Failover(c *gophercloud.ServiceClient, id string) (r FailoverResult) {
-	_, r.Err = c.Put(failoverRootURL(c, id), nil, nil, &gophercloud.RequestOpts{
+	resp, err := c.Put(failoverRootURL(c, id), nil, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers/requests.go
@@ -1,0 +1,241 @@
+package loadbalancers
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToLoadBalancerListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the Loadbalancer attributes you want to see returned. SortKey allows you to
+// sort by a particular attribute. SortDir sets the direction, and is
+// either `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	Description        string   `q:"description"`
+	AdminStateUp       *bool    `q:"admin_state_up"`
+	ProjectID          string   `q:"project_id"`
+	ProvisioningStatus string   `q:"provisioning_status"`
+	VipAddress         string   `q:"vip_address"`
+	VipPortID          string   `q:"vip_port_id"`
+	VipSubnetID        string   `q:"vip_subnet_id"`
+	VipNetworkID       string   `q:"vip_network_id"`
+	ID                 string   `q:"id"`
+	OperatingStatus    string   `q:"operating_status"`
+	Name               string   `q:"name"`
+	FlavorID           string   `q:"flavor_id"`
+	Provider           string   `q:"provider"`
+	Limit              int      `q:"limit"`
+	Marker             string   `q:"marker"`
+	SortKey            string   `q:"sort_key"`
+	SortDir            string   `q:"sort_dir"`
+	Tags               []string `q:"tags"`
+	TagsAny            []string `q:"tags-any"`
+	TagsNot            []string `q:"not-tags"`
+	TagsNotAny         []string `q:"not-tags-any"`
+}
+
+// ToLoadBalancerListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToLoadBalancerListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// load balancers. It accepts a ListOpts struct, which allows you to filter
+// and sort the returned collection for greater efficiency.
+//
+// Default policy settings return only those load balancers that are owned by
+// the project who submits the request, unless an admin user submits the request.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(c)
+	if opts != nil {
+		query, err := opts.ToLoadBalancerListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return LoadBalancerPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToLoadBalancerCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts is the common options struct used in this package's Create
+// operation.
+type CreateOpts struct {
+	// Human-readable name for the Loadbalancer. Does not have to be unique.
+	Name string `json:"name,omitempty"`
+
+	// Human-readable description for the Loadbalancer.
+	Description string `json:"description,omitempty"`
+
+	// Providing a neutron port ID for the vip_port_id tells Octavia to use this
+	// port for the VIP. If the port has more than one subnet you must specify
+	// either the vip_subnet_id or vip_address to clarify which address should
+	// be used for the VIP.
+	VipPortID string `json:"vip_port_id,omitempty"`
+
+	// The subnet on which to allocate the Loadbalancer's address. A project can
+	// only create Loadbalancers on networks authorized by policy (e.g. networks
+	// that belong to them or networks that are shared).
+	VipSubnetID string `json:"vip_subnet_id,omitempty"`
+
+	// The network on which to allocate the Loadbalancer's address. A tenant can
+	// only create Loadbalancers on networks authorized by policy (e.g. networks
+	// that belong to them or networks that are shared).
+	VipNetworkID string `json:"vip_network_id,omitempty"`
+
+	// ProjectID is the UUID of the project who owns the Loadbalancer.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// The IP address of the Loadbalancer.
+	VipAddress string `json:"vip_address,omitempty"`
+
+	// The administrative state of the Loadbalancer. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// The UUID of a flavor.
+	FlavorID string `json:"flavor_id,omitempty"`
+
+	// The name of the provider.
+	Provider string `json:"provider,omitempty"`
+
+	// Tags is a set of resource tags.
+	Tags []string `json:"tags,omitempty"`
+}
+
+// ToLoadBalancerCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToLoadBalancerCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "loadbalancer")
+}
+
+// Create is an operation which provisions a new loadbalancer based on the
+// configuration defined in the CreateOpts struct. Once the request is
+// validated and progress has started on the provisioning process, a
+// CreateResult will be returned.
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToLoadBalancerCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, nil)
+	return
+}
+
+// Get retrieves a particular Loadbalancer based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToLoadBalancerUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts is the common options struct used in this package's Update
+// operation.
+type UpdateOpts struct {
+	// Human-readable name for the Loadbalancer. Does not have to be unique.
+	Name *string `json:"name,omitempty"`
+
+	// Human-readable description for the Loadbalancer.
+	Description *string `json:"description,omitempty"`
+
+	// The administrative state of the Loadbalancer. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// Tags is a set of resource tags.
+	Tags *[]string `json:"tags,omitempty"`
+}
+
+// ToLoadBalancerUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToLoadBalancerUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "loadbalancer")
+}
+
+// Update is an operation which modifies the attributes of the specified
+// LoadBalancer.
+func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+	b, err := opts.ToLoadBalancerUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(resourceURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	return
+}
+
+// DeleteOptsBuilder allows extensions to add additional parameters to the
+// Delete request.
+type DeleteOptsBuilder interface {
+	ToLoadBalancerDeleteQuery() (string, error)
+}
+
+// DeleteOpts is the common options struct used in this package's Delete
+// operation.
+type DeleteOpts struct {
+	// Cascade will delete all children of the load balancer (listners, monitors, etc).
+	Cascade bool `q:"cascade"`
+}
+
+// ToLoadBalancerDeleteQuery formats a DeleteOpts into a query string.
+func (opts DeleteOpts) ToLoadBalancerDeleteQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Delete will permanently delete a particular LoadBalancer based on its
+// unique ID.
+func Delete(c *gophercloud.ServiceClient, id string, opts DeleteOptsBuilder) (r DeleteResult) {
+	url := resourceURL(c, id)
+	if opts != nil {
+		query, err := opts.ToLoadBalancerDeleteQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+	_, r.Err = c.Delete(url, nil)
+	return
+}
+
+// GetStatuses will return the status of a particular LoadBalancer.
+func GetStatuses(c *gophercloud.ServiceClient, id string) (r GetStatusesResult) {
+	_, r.Err = c.Get(statusRootURL(c, id), &r.Body, nil)
+	return
+}
+
+// GetStats will return the shows the current statistics of a particular LoadBalancer.
+func GetStats(c *gophercloud.ServiceClient, id string) (r StatsResult) {
+	_, r.Err = c.Get(statisticsRootURL(c, id), &r.Body, nil)
+	return
+}
+
+// Failover performs a failover of a load balancer.
+func Failover(c *gophercloud.ServiceClient, id string) (r FailoverResult) {
+	_, r.Err = c.Put(failoverRootURL(c, id), nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers/results.go
@@ -1,0 +1,246 @@
+package loadbalancers
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// LoadBalancer is the primary load balancing configuration object that
+// specifies the virtual IP address on which client traffic is received, as well
+// as other details such as the load balancing method to be use, protocol, etc.
+type LoadBalancer struct {
+	// Human-readable description for the Loadbalancer.
+	Description string `json:"description"`
+
+	// The administrative state of the Loadbalancer.
+	// A valid value is true (UP) or false (DOWN).
+	AdminStateUp bool `json:"admin_state_up"`
+
+	// Owner of the LoadBalancer.
+	ProjectID string `json:"project_id"`
+
+	// UpdatedAt and CreatedAt contain ISO-8601 timestamps of when the state of the
+	// loadbalancer last changed, and when it was created.
+	UpdatedAt time.Time `json:"-"`
+	CreatedAt time.Time `json:"-"`
+
+	// The provisioning status of the LoadBalancer.
+	// This value is ACTIVE, PENDING_CREATE or ERROR.
+	ProvisioningStatus string `json:"provisioning_status"`
+
+	// The IP address of the Loadbalancer.
+	VipAddress string `json:"vip_address"`
+
+	// The UUID of the port associated with the IP address.
+	VipPortID string `json:"vip_port_id"`
+
+	// The UUID of the subnet on which to allocate the virtual IP for the
+	// Loadbalancer address.
+	VipSubnetID string `json:"vip_subnet_id"`
+
+	// The UUID of the network on which to allocate the virtual IP for the
+	// Loadbalancer address.
+	VipNetworkID string `json:"vip_network_id"`
+
+	// The unique ID for the LoadBalancer.
+	ID string `json:"id"`
+
+	// The operating status of the LoadBalancer. This value is ONLINE or OFFLINE.
+	OperatingStatus string `json:"operating_status"`
+
+	// Human-readable name for the LoadBalancer. Does not have to be unique.
+	Name string `json:"name"`
+
+	// The UUID of a flavor if set.
+	FlavorID string `json:"flavor_id"`
+
+	// The name of the provider.
+	Provider string `json:"provider"`
+
+	// Listeners are the listeners related to this Loadbalancer.
+	Listeners []listeners.Listener `json:"listeners"`
+
+	// Pools are the pools related to this Loadbalancer.
+	Pools []pools.Pool `json:"pools"`
+
+	// Tags is a list of resource tags. Tags are arbitrarily defined strings
+	// attached to the resource.
+	Tags []string `json:"tags"`
+}
+
+func (r *LoadBalancer) UnmarshalJSON(b []byte) error {
+	type tmp LoadBalancer
+
+	// Support for older neutron time format
+	var s1 struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339NoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339NoZ `json:"updated_at"`
+	}
+
+	err := json.Unmarshal(b, &s1)
+	if err == nil {
+		*r = LoadBalancer(s1.tmp)
+		r.CreatedAt = time.Time(s1.CreatedAt)
+		r.UpdatedAt = time.Time(s1.UpdatedAt)
+
+		return nil
+	}
+
+	// Support for newer neutron time format
+	var s2 struct {
+		tmp
+		CreatedAt time.Time `json:"created_at"`
+		UpdatedAt time.Time `json:"updated_at"`
+	}
+
+	err = json.Unmarshal(b, &s2)
+	if err != nil {
+		return err
+	}
+
+	*r = LoadBalancer(s2.tmp)
+	r.CreatedAt = time.Time(s2.CreatedAt)
+	r.UpdatedAt = time.Time(s2.UpdatedAt)
+
+	return nil
+}
+
+// StatusTree represents the status of a loadbalancer.
+type StatusTree struct {
+	Loadbalancer *LoadBalancer `json:"loadbalancer"`
+}
+
+type Stats struct {
+	// The currently active connections.
+	ActiveConnections int `json:"active_connections"`
+
+	// The total bytes received.
+	BytesIn int `json:"bytes_in"`
+
+	// The total bytes sent.
+	BytesOut int `json:"bytes_out"`
+
+	// The total requests that were unable to be fulfilled.
+	RequestErrors int `json:"request_errors"`
+
+	// The total connections handled.
+	TotalConnections int `json:"total_connections"`
+}
+
+// LoadBalancerPage is the page returned by a pager when traversing over a
+// collection of load balancers.
+type LoadBalancerPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of load balancers has
+// reached the end of a page and the pager seeks to traverse over a new one.
+// In order to do this, it needs to construct the next page's URL.
+func (r LoadBalancerPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"loadbalancers_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a LoadBalancerPage struct is empty.
+func (r LoadBalancerPage) IsEmpty() (bool, error) {
+	is, err := ExtractLoadBalancers(r)
+	return len(is) == 0, err
+}
+
+// ExtractLoadBalancers accepts a Page struct, specifically a LoadbalancerPage
+// struct, and extracts the elements into a slice of LoadBalancer structs. In
+// other words, a generic collection is mapped into a relevant slice.
+func ExtractLoadBalancers(r pagination.Page) ([]LoadBalancer, error) {
+	var s struct {
+		LoadBalancers []LoadBalancer `json:"loadbalancers"`
+	}
+	err := (r.(LoadBalancerPage)).ExtractInto(&s)
+	return s.LoadBalancers, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a loadbalancer.
+func (r commonResult) Extract() (*LoadBalancer, error) {
+	var s struct {
+		LoadBalancer *LoadBalancer `json:"loadbalancer"`
+	}
+	err := r.ExtractInto(&s)
+	return s.LoadBalancer, err
+}
+
+// GetStatusesResult represents the result of a GetStatuses operation.
+// Call its Extract method to interpret it as a StatusTree.
+type GetStatusesResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts the status of
+// a Loadbalancer.
+func (r GetStatusesResult) Extract() (*StatusTree, error) {
+	var s struct {
+		Statuses *StatusTree `json:"statuses"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Statuses, err
+}
+
+// StatsResult represents the result of a GetStats operation.
+// Call its Extract method to interpret it as a Stats.
+type StatsResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts the status of
+// a Loadbalancer.
+func (r StatsResult) Extract() (*Stats, error) {
+	var s struct {
+		Stats *Stats `json:"stats"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Stats, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a LoadBalancer.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a LoadBalancer.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a LoadBalancer.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// FailoverResult represents the result of a failover operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type FailoverResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers/urls.go
@@ -1,0 +1,31 @@
+package loadbalancers
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rootPath       = "lbaas"
+	resourcePath   = "loadbalancers"
+	statusPath     = "status"
+	statisticsPath = "stats"
+	failoverPath   = "failover"
+)
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath, resourcePath)
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id)
+}
+
+func statusRootURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id, statusPath)
+}
+
+func statisticsRootURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id, statisticsPath)
+}
+
+func failoverRootURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id, failoverPath)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -141,6 +141,7 @@ github.com/gophercloud/gophercloud/openstack/keymanager/v1/orders
 github.com/gophercloud/gophercloud/openstack/keymanager/v1/secrets
 github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies
 github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners
+github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers
 github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors
 github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags

--- a/website/docs/r/lb_loadbalancer_v2.html.markdown
+++ b/website/docs/r/lb_loadbalancer_v2.html.markdown
@@ -27,10 +27,17 @@ The following arguments are supported:
     `region` argument of the provider is used. Changing this creates a new
     LB member.
 
-* `vip_subnet_id` - (Required) The network on which to allocate the
+* `vip_subnet_id` - (Optional) The subnet on which to allocate the
     Loadbalancer's address. A tenant can only create Loadbalancers on networks
     authorized by policy (e.g. networks that belong to them or networks that
     are shared).  Changing this creates a new loadbalancer.
+    It is required to Neutron LBaaS but optional for Octavia.
+    
+* `vip_network_id` - (Optional) The network on which to allocate the
+    Loadbalancer's address. A tenant can only create Loadbalancers on networks
+    authorized by policy (e.g. networks that belong to them or networks that
+    are shared).  Changing this creates a new loadbalancer.
+    It is available only for Octavia.
 
 * `name` - (Optional) Human-readable name for the Loadbalancer. Does not have
     to be unique.
@@ -63,6 +70,7 @@ The following attributes are exported:
 
 * `region` - See Argument Reference above.
 * `vip_subnet_id` - See Argument Reference above.
+* `vip_network_id` - See Argument Reference above.
 * `name` - See Argument Reference above.
 * `description` - See Argument Reference above.
 * `tenant_id` - See Argument Reference above.


### PR DESCRIPTION
Add handling of vip_network_id fields.  Octavia allows creation of a load balancer using the network id (instead of providing the subnet id)

Closes: #683