### PR TITLE
LBaaS: Typo fixed in lbaas l7 policy documentation

### DIFF
--- a/website/docs/r/lb_l7policy_v2.html.markdown
+++ b/website/docs/r/lb_l7policy_v2.html.markdown
@@ -93,7 +93,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The unique ID for the L7 {olicy.
+* `id` - The unique ID for the L7 Policy.
 * `region` - See Argument Reference above.
 * `tenant_id` - See Argument Reference above.
 * `name` - See Argument Reference above.


### PR DESCRIPTION
tiny typo has been noticed and fixed