### PR TITLE
Remove mitaka test job "terraform-provider-openstack-acceptance-test-mitaka" which use ubuntu-trusty

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -4,9 +4,6 @@
       jobs:
         - terraform-provider-openstack-unittest
         - terraform-provider-openstack-acceptance-test
-    recheck-mitaka:
-      jobs:
-        - terraform-provider-openstack-acceptance-test-mitaka
     recheck-newton:
       jobs:
         - terraform-provider-openstack-acceptance-test-newton


### PR DESCRIPTION
Remove job terraform-provider-openstack-acceptance-test-mitaka, as ubuntu-trusty is EOL.