### PR TITLE
Remove mitaka check job as ubuntu-trusty is EOL(stable-website)

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -4,9 +4,6 @@
       jobs:
         - terraform-provider-openstack-unittest
         - terraform-provider-openstack-acceptance-test
-    recheck-mitaka:
-      jobs:
-        - terraform-provider-openstack-acceptance-test-mitaka
     recheck-newton:
       jobs:
         - terraform-provider-openstack-acceptance-test-newton


### PR DESCRIPTION
There are 4 branch including the original zuul  configuration. I will post PRs one by one.