### PR TITLE
Match type on master_addresses and node_addresses on containerinfra_cluster

### DIFF
--- a/openstack/data_source_openstack_containerinfra_cluster_v1.go
+++ b/openstack/data_source_openstack_containerinfra_cluster_v1.go
@@ -110,13 +110,15 @@ func dataSourceContainerInfraCluster() *schema.Resource {
 			},
 
 			"master_addresses": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeList,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"node_addresses": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeList,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"stack_id": {

--- a/openstack/resource_openstack_containerinfra_cluster_v1.go
+++ b/openstack/resource_openstack_containerinfra_cluster_v1.go
@@ -156,15 +156,17 @@ func resourceContainerInfraClusterV1() *schema.Resource {
 			},
 
 			"master_addresses": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeList,
 				ForceNew: false,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"node_addresses": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeList,
 				ForceNew: false,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"stack_id": {


### PR DESCRIPTION
Resolves #968

GopherCloud shows these are lists, update provider to suit.
Per ask on [twitter](https://twitter.com/aurynn/status/1241918377276239872)

No test updates, as I could not find any other reference to `master_addresses` or `node_addresses` in the codebase 

Unchecked code, depending on repo's CI to validate (could not run tests locally)