### PR TITLE
Add compute_instance_v2 data source

### DIFF
--- a/openstack/data_source_openstack_compute_instance_v2.go
+++ b/openstack/data_source_openstack_compute_instance_v2.go
@@ -1,0 +1,230 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/tags"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceComputeInstanceV2() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceComputeInstanceV2Read,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"flavor_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"flavor_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_data": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				// just stash the hash for state & diff comparisons
+			},
+			"security_groups": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"network": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"fixed_ip_v4": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"fixed_ip_v6": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"mac": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"access_ip_v4": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"access_ip_v6": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"key_pair": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"metadata": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	log.Print("[DEBUG] Creating compute client")
+	computeClient, err := config.ComputeV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+
+	id := d.Get("id").(string)
+	log.Printf("[DEBUG] Attempting to retrieve server %s", id)
+	server, err := servers.Get(computeClient, id).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "server")
+	}
+
+	log.Printf("[DEBUG] Retrieved Server %s: %+v", id, server)
+
+	d.SetId(server.ID)
+
+	d.Set("name", server.Name)
+	d.Set("image_id", server.Image["ID"])
+
+	// Get the instance network and address information
+	networks, err := flattenInstanceNetworks(d, meta)
+	if err != nil {
+		return err
+	}
+
+	// Determine the best IPv4 and IPv6 addresses to access the instance with
+	hostv4, hostv6 := getInstanceAccessAddresses(d, networks)
+
+	// AccessIPv4/v6 isn't standard in OpenStack, but there have been reports
+	// of them being used in some environments.
+	if server.AccessIPv4 != "" && hostv4 == "" {
+		hostv4 = server.AccessIPv4
+	}
+
+	if server.AccessIPv6 != "" && hostv6 == "" {
+		hostv6 = server.AccessIPv6
+	}
+
+	log.Printf("[DEBUG] Setting networks: %+v", networks)
+
+	d.Set("network", networks)
+	d.Set("access_ip_v4", hostv4)
+	d.Set("access_ip_v6", hostv6)
+
+	d.Set("metadata", server.Metadata)
+
+	secGrpNames := []string{}
+	for _, sg := range server.SecurityGroups {
+		secGrpNames = append(secGrpNames, sg["name"].(string))
+	}
+
+	log.Printf("[DEBUG] Setting security groups: %+v", secGrpNames)
+
+	d.Set("security_groups", secGrpNames)
+
+	flavorId, ok := server.Flavor["id"].(string)
+	if !ok {
+		return fmt.Errorf("Error setting OpenStack server's flavor: %v", server.Flavor)
+	}
+	d.Set("flavor_id", flavorId)
+
+	d.Set("key_pair", server.KeyName)
+	flavor, err := flavors.Get(computeClient, flavorId).Extract()
+	if err != nil {
+		return err
+	}
+	d.Set("flavor_name", flavor.Name)
+
+	// Set the instance's image information appropriately
+	if err := setImageInformation(computeClient, server, d); err != nil {
+		return err
+	}
+
+	// Build a custom struct for the availability zone extension
+	var serverWithAZ struct {
+		servers.Server
+		availabilityzones.ServerAvailabilityZoneExt
+	}
+
+	// Do another Get so the above work is not disturbed.
+	err = servers.Get(computeClient, d.Id()).ExtractInto(&serverWithAZ)
+	if err != nil {
+		return CheckDeleted(d, err, "server")
+	}
+	// Set the availability zone
+	d.Set("availability_zone", serverWithAZ.AvailabilityZone)
+
+	// Set the region
+	d.Set("region", GetRegion(d, config))
+
+	// Set the current power_state
+	currentStatus := strings.ToLower(server.Status)
+	switch currentStatus {
+	case "active", "shutoff", "error", "migrating", "shelved_offloaded", "shelved":
+		d.Set("power_state", currentStatus)
+	default:
+		return fmt.Errorf("Invalid power_state for instance %s: %s", d.Id(), server.Status)
+	}
+
+	// Populate tags.
+	computeClient.Microversion = computeV2TagsExtensionMicroversion
+	instanceTags, err := tags.List(computeClient, server.ID).Extract()
+	if err != nil {
+		log.Printf("[DEBUG] Unable to get tags for openstack_compute_instance_v2: %s", err)
+	} else {
+		computeV2InstanceReadTags(d, instanceTags)
+	}
+
+	return nil
+}

--- a/openstack/data_source_openstack_compute_instance_v2.go
+++ b/openstack/data_source_openstack_compute_instance_v2.go
@@ -223,7 +223,7 @@ func dataSourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		log.Printf("[DEBUG] Unable to get tags for openstack_compute_instance_v2: %s", err)
 	} else {
-		computeV2InstanceReadTags(d, instanceTags)
+		d.Set("tags", instanceTags)
 	}
 
 	return nil

--- a/openstack/data_source_openstack_compute_instance_v2_test.go
+++ b/openstack/data_source_openstack_compute_instance_v2_test.go
@@ -1,0 +1,67 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccComputeV2InstanceDataSource(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeV2InstanceDataSource_basic,
+			},
+			{
+				Config: testAccComputeV2InstanceDataSource_source,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceV2DataSourceId("data.openstack_compute_instance_v2.source_1"),
+					resource.TestCheckResourceAttr("data.openstack_compute_instance_v2.source_1", "name", "instance_1"),
+					resource.TestCheckResourceAttrPair("data.openstack_compute_instance_v2.source_1", "metadata", "openstack_compute_instance_v2.instance_1", "metadata"),
+					resource.TestCheckResourceAttr("data.openstack.compute_instance_v2.source_1", "network.0.uuid", OS_NETWORK_ID),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckComputeInstanceV2DataSourceId(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find compute instance data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Compute instance data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+var testAccComputeV2InstanceDataSource_basic = fmt.Sprintf(`
+resource "openstack_compute_instance_v2" "instance_1" {
+  name = "instance_1"
+  security_groups = ["default"]
+  metadata = {
+    foo = "bar"
+  }
+  network {
+    uuid = "%s"
+  }
+}
+`, OS_NETWORK_ID)
+
+var testAccComputeV2InstanceDataSource_source = fmt.Sprintf(`
+%s
+
+data "openstack_compute_instance_v2" "source_1" {
+  id = "${openstack_compute_instance_v2.instance_1.id}"
+}
+`, testAccComputeV2InstanceDataSource_basic)

--- a/openstack/data_source_openstack_compute_instance_v2_test.go
+++ b/openstack/data_source_openstack_compute_instance_v2_test.go
@@ -23,7 +23,7 @@ func TestAccComputeV2InstanceDataSource(t *testing.T) {
 					testAccCheckComputeInstanceV2DataSourceId("data.openstack_compute_instance_v2.source_1"),
 					resource.TestCheckResourceAttr("data.openstack_compute_instance_v2.source_1", "name", "instance_1"),
 					resource.TestCheckResourceAttrPair("data.openstack_compute_instance_v2.source_1", "metadata", "openstack_compute_instance_v2.instance_1", "metadata"),
-					resource.TestCheckResourceAttr("data.openstack.compute_instance_v2.source_1", "network.0.uuid", OS_NETWORK_ID),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_instance_v2.source_1", "network.0.name"),
 				),
 			},
 		},

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -255,6 +255,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_blockstorage_volume_v2":                   dataSourceBlockStorageVolumeV2(),
 			"openstack_blockstorage_volume_v3":                   dataSourceBlockStorageVolumeV3(),
 			"openstack_compute_availability_zones_v2":            dataSourceComputeAvailabilityZonesV2(),
+			"openstack_compute_instance_v2":                      dataSourceComputeInstanceV2(),
 			"openstack_compute_flavor_v2":                        dataSourceComputeFlavorV2(),
 			"openstack_compute_keypair_v2":                       dataSourceComputeKeypairV2(),
 			"openstack_containerinfra_clustertemplate_v1":        dataSourceContainerInfraClusterTemplateV1(),

--- a/website/docs/d/compute_instance_v2.html.markdown
+++ b/website/docs/d/compute_instance_v2.html.markdown
@@ -1,0 +1,70 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_compute_instance_v2"
+sidebar_current: "docs-openstack-datasource-compute-instance-v2"
+description: |-
+  Get information on an OpenStack Instance
+---
+
+# openstack\_compute\_flavor\_v2
+
+Use this data source to get the details of a running server
+
+## Example Usage
+
+```hcl
+data "openstack_compute_instance_v2" "instance" {
+  # Randomly generated UUID, for demonstration purposes
+  id = "2ba26dc6-a12d-4889-8f25-794ea5bf4453"
+}
+```
+
+## Argument Reference
+
+* `id` - (Required) The UUID of the instance
+
+
+## Attributes Reference
+
+In addition to the above, the following attributes are exported:
+
+* `name` - The name of the server.
+
+* `image_id` - The image ID used to create the server.
+
+* `flavor_id` - The flavor ID used to create the server.
+
+* `flavor_name` - The flavor name used to create the server.
+
+* `user_data` - The user data added when the server was created.
+
+* `security_groups` - An array of security group names associated with this server.
+
+* `availability_zone` - The availability zone of this server.
+
+* `network` - An array of maps, detailed below.
+
+* `access_ip_v4` - The first IPv4 address assigned to this server.
+
+* `access_ip_v6` - The first IPv6 address assigned to this server.
+
+* `key_pair` - The name of the key pair assigned to this server.
+
+* `tags` - A set of string tags assigned to this server.
+
+* `metadata` - A set of key/value pairs made available to the server.
+
+
+The `network` block is defined as:
+
+* `uuid` - The UUID of the network
+
+* `name` - The name of the network
+
+* `fixed_ip_v4` - The IPv4 address assigned to this network port.
+
+* `fixed_ip_v6` - The IPv6 address assigned to this network port.
+
+* `port` - The port UUID for this network
+
+* `mac` - The MAC address assigned to this network interface.


### PR DESCRIPTION
Resolves #982 

This is largely copied from `resource.openstack_compute_instance_v2`.

I've checked the data source itself locally, but I have no way to run the full test suite, so relying on project CI.