### PR TITLE
Update object verisoning documentation URL

### DIFF
--- a/website/docs/r/objectstorage_container_v1.html.markdown
+++ b/website/docs/r/objectstorage_container_v1.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 
 The `versioning` block supports:
 
-  * `type` - (Required) Versioning type which can be `versions` or `history` according to [Openstack documentation](https://docs.openstack.org/swift/latest/overview_object_versioning.html).
+  * `type` - (Required) Versioning type which can be `versions` or `history` according to [Openstack documentation](https://docs.openstack.org/swift/latest/api/object_versioning.html).
   * `location` - (Required) Container in which versions will be stored.
 
 


### PR DESCRIPTION
The old URL was no longer valid; updated to the current URL.