### PR TITLE
Add SOURCE_IP_PORT load balancing method

### DIFF
--- a/openstack/resource_openstack_lb_pool_v2.go
+++ b/openstack/resource_openstack_lb_pool_v2.go
@@ -81,7 +81,7 @@ func resourcePoolV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"ROUND_ROBIN", "LEAST_CONNECTIONS", "SOURCE_IP",
+					"ROUND_ROBIN", "LEAST_CONNECTIONS", "SOURCE_IP", "SOURCE_IP_PORT",
 				}, false),
 			},
 

--- a/website/docs/r/lb_pool_v2.html.markdown
+++ b/website/docs/r/lb_pool_v2.html.markdown
@@ -55,7 +55,8 @@ The following arguments are supported:
 
 * `lb_method` - (Required) The load balancing algorithm to
     distribute traffic to the pool's members. Must be one of
-    ROUND_ROBIN, LEAST_CONNECTIONS, or SOURCE_IP.
+    ROUND_ROBIN, LEAST_CONNECTIONS, SOURCE_IP, or SOURCE_IP_PORT (supported only
+    in Octavia).
 
 * `persistence` - Omit this field to prevent session persistence.  Indicates
     whether connections in the same session will be processed by the same Pool


### PR DESCRIPTION
The OVN load balancing provider only supports `SOURCE_IP_PORT` as load balancing method for pools.