### PR TITLE
Implemented Security Group Rule Mutex 

### DIFF
--- a/openstack/resource_openstack_networking_secgroup_rule_v2.go
+++ b/openstack/resource_openstack_networking_secgroup_rule_v2.go
@@ -107,7 +107,6 @@ func resourceNetworkingSecGroupRuleV2() *schema.Resource {
 }
 
 func resourceNetworkingSecGroupRuleV2Create(d *schema.ResourceData, meta interface{}) error {
-
 	securityGroupId := d.Get("security_group_id").(string)
 	osMutexKV.Lock(securityGroupId)
 	defer osMutexKV.Unlock(securityGroupId)
@@ -205,7 +204,6 @@ func resourceNetworkingSecGroupRuleV2Read(d *schema.ResourceData, meta interface
 }
 
 func resourceNetworkingSecGroupRuleV2Delete(d *schema.ResourceData, meta interface{}) error {
-
 	securityGroupId := d.Get("security_group_id").(string)
 	osMutexKV.Lock(securityGroupId)
 	defer osMutexKV.Unlock(securityGroupId)

--- a/openstack/resource_openstack_networking_secgroup_rule_v2.go
+++ b/openstack/resource_openstack_networking_secgroup_rule_v2.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -12,8 +11,6 @@ import (
 
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 )
-
-var resourceNetworkingSecGroupRuleMutex = &sync.Mutex{}
 
 func resourceNetworkingSecGroupRuleV2() *schema.Resource {
 	return &schema.Resource{
@@ -110,6 +107,11 @@ func resourceNetworkingSecGroupRuleV2() *schema.Resource {
 }
 
 func resourceNetworkingSecGroupRuleV2Create(d *schema.ResourceData, meta interface{}) error {
+
+	securityGroupId := d.Get("security_group_id").(string)
+	osMutexKV.Lock(securityGroupId)
+	defer osMutexKV.Unlock(securityGroupId)
+
 	config := meta.(*Config)
 	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
@@ -162,9 +164,6 @@ func resourceNetworkingSecGroupRuleV2Create(d *schema.ResourceData, meta interfa
 
 	log.Printf("[DEBUG] openstack_networking_secgroup_rule_v2 create options: %#v", opts)
 
-	resourceNetworkingSecGroupRuleMutex.Lock()
-	defer resourceNetworkingSecGroupRuleMutex.Unlock()
-
 	sgRule, err := rules.Create(networkingClient, opts).Extract()
 	if err != nil {
 		return fmt.Errorf("Error creating openstack_networking_secgroup_rule_v2: %s", err)
@@ -206,14 +205,16 @@ func resourceNetworkingSecGroupRuleV2Read(d *schema.ResourceData, meta interface
 }
 
 func resourceNetworkingSecGroupRuleV2Delete(d *schema.ResourceData, meta interface{}) error {
+
+	securityGroupId := d.Get("security_group_id").(string)
+	osMutexKV.Lock(securityGroupId)
+	defer osMutexKV.Unlock(securityGroupId)
+
 	config := meta.(*Config)
 	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
-
-	resourceNetworkingSecGroupRuleMutex.Lock()
-	defer resourceNetworkingSecGroupRuleMutex.Unlock()
 
 	if err := rules.Delete(networkingClient, d.Id()).ExtractErr(); err != nil {
 		return CheckDeleted(d, err, "Error deleting openstack_networking_secgroup_rule_v2")


### PR DESCRIPTION
Resolves #879 

This fix could help each user who uses Contrail module instead of neutron. 

In the Contrail model, SG rule is not a separate object, but an entry element inside the security-group object's security-group-entries property.

Very often Juniper provides installation of contrail to a datacenter without some important fixes as this -> which is already implemented [here](https://github.com/Juniper/contrail-controller/blob/32cf7fa1c888e229d37027a9d805d6d40cf2bb28/src/config/vnc_openstack/vnc_openstack/neutron_plugin_db.py#L443). It adjusts a lock mechanism for creation of security group rules.

It makes using of openstack terraform provider to create/delete security group rules totally annoying. (There are two WA described in issue.) 

I added synchronization of calls. 
It will take years for users to update theirs legacy contrail with new patches and it would be great to have the synchronization in terraform provider. 
