### PR TITLE
Enable delayed_auth and allow_reauth options by default

### DIFF
--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -209,14 +209,14 @@ func Provider() terraform.ResourceProvider {
 			"delayed_auth": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_DELAYED_AUTH", false),
+				DefaultFunc: schema.EnvDefaultFunc("OS_DELAYED_AUTH", true),
 				Description: descriptions["delayed_auth"],
 			},
 
 			"allow_reauth": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_ALLOW_REAUTH", false),
+				DefaultFunc: schema.EnvDefaultFunc("OS_ALLOW_REAUTH", true),
 				Description: descriptions["allow_reauth"],
 			},
 
@@ -454,13 +454,11 @@ func init() {
 		"use_octavia": "If set to `true`, API requests will go the Load Balancer\n" +
 			"service (Octavia) instead of the Networking service (Neutron).",
 
-		"delayed_auth": "If set to `true`, OpenStack authorization will be perfomed,\n" +
-			"when the service provider client is called.",
+		"delayed_auth": "If set to `false`, OpenStack authorization will be perfomed,\n" +
+			"every time the service provider client is called. Defaults to `true`.",
 
-		"allow_reauth": "If set to `true`, OpenStack authorization will be perfomed\n" +
-			"automatically, if the initial auth token get expired. This is useful,\n" +
-			"when the token TTL is low or the overall Terraform provider execution\n" +
-			"time expected to be greater than the initial token TTL.",
+		"allow_reauth": "If set to `false`, OpenStack authorization won't be perfomed\n" +
+			"automatically, if the initial auth token get expired. Defaults to `true`",
 
 		"cloud": "An entry in a `clouds.yaml` file to use.",
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -153,13 +153,11 @@ The following arguments are supported:
   If omitted this header is added to all API requests to force HTTP caches (if any)
   to go upstream instead of serving cached responses.
 
-* `delayed_auth` - (Optional) If set to `true`, OpenStack authorization will be perfomed,
-  when the service provider client is called.
+* `delayed_auth` - (Optional) If set to `false`, OpenStack authorization will be perfomed,
+  every time the service provider client is called. Defaults to `true`.
 
-* `allow_reauth` - (Optional) If set to `true`, OpenStack authorization will be
-  perfomed automatically, if the initial auth token get expired. This is useful,
-  when the token TTL is low or the overall Terraform provider execution time
-  expected to be greater than the initial token TTL.
+* `allow_reauth` - (Optional) If set to `false`, OpenStack authorization won't be
+  perfomed automatically, if the initial auth token get expired. Defaults to `true`.
 
 ## Overriding Service API Endpoints
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -58,17 +58,16 @@ The following arguments are supported:
   `OS_USER_ID` environment variable is used.
 
 * `application_credential_id` - (Optional) (Identity v3 only) The ID of an
-    application credential to authenticate with. An
-    `application_credential_secret` has to bet set along with this parameter.
+  application credential to authenticate with. An
+  `application_credential_secret` has to bet set along with this parameter.
 
 * `application_credential_name` - (Optional) (Identity v3 only) The name of an
-    application credential to authenticate with. Conflicts with the
-    `application_credential_name`, requires `user_id`, or `user_name` and
-    `user_domain_name` (or `user_domain_id`) to be set.
+  application credential to authenticate with. Requires `user_id`, or
+  `user_name` and `user_domain_name` (or `user_domain_id`) to be set.
 
-* `application_credential_secret` - (Optional) (Identity v3 only) The secret of an
-    application credential to authenticate with. Required by
-    `application_credential_id` or `application_credential_name`.
+* `application_credential_secret` - (Optional) (Identity v3 only) The secret of
+  an application credential to authenticate with. Required by
+  `application_credential_id` or `application_credential_name`.
 
 * `tenant_id` - (Optional) The ID of the Tenant (Identity v2) or Project
   (Identity v3) to login with. If omitted, the `OS_TENANT_ID` or


### PR DESCRIPTION
Our tests showed that enabling delayed_auth option reduced an amount of keystone auth calls and helped to avoid nginx request limits in case of running terraform with complex logic.

See #861, when this feature was introduced initially.

In addition it's worth enabling the `allow_reauth` option by default as well.

/cc @ozerovandrei @jtopjian 