### PR TITLE
Object Storage Container V1: Add reading fields and import

### DIFF
--- a/openstack/import_openstack_objectstorage_container_v1_test.go
+++ b/openstack/import_openstack_objectstorage_container_v1_test.go
@@ -24,6 +24,7 @@ func TestAccObjectStorageV1Container_importBasic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"force_destroy",
 					"content_type",
+					"metadata",
 				},
 			},
 		},

--- a/openstack/import_openstack_objectstorage_container_v1_test.go
+++ b/openstack/import_openstack_objectstorage_container_v1_test.go
@@ -1,0 +1,30 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccObjectStorageContainerV1_importBasic(t *testing.T) {
+	resourceName := "openstack_objectstorage_container_v1.container_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckSwift(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObjectStorageV1ContainerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObjectStorageV1Container_complete,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy",
+				},
+			},
+		},
+	})
+}

--- a/openstack/import_openstack_objectstorage_container_v1_test.go
+++ b/openstack/import_openstack_objectstorage_container_v1_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccObjectStorageContainerV1_importBasic(t *testing.T) {
+func TestAccObjectStorageV1Container_importBasic(t *testing.T) {
 	resourceName := "openstack_objectstorage_container_v1.container_1"
 
 	resource.Test(t, resource.TestCase{
@@ -23,6 +23,7 @@ func TestAccObjectStorageContainerV1_importBasic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"force_destroy",
+					"content_type",
 				},
 			},
 		},

--- a/openstack/resource_openstack_objectstorage_container_v1.go
+++ b/openstack/resource_openstack_objectstorage_container_v1.go
@@ -196,12 +196,6 @@ func resourceObjectStorageContainerV1Read(d *schema.ResourceData, meta interface
 		err = d.Set("versioning", schema.NewSet(schema.HashResource(versioningResource), []interface{}{versioning}))
 	}
 
-	lowercaseMetadata := map[string]string{}
-	for k, v := range metadata {
-		lowercaseMetadata[strings.ToLower(k)] = v
-	}
-	err = d.Set("metadata", lowercaseMetadata)
-
 	err = d.Set("region", GetRegion(d, config))
 
 	if err != nil {

--- a/openstack/resource_openstack_objectstorage_container_v1.go
+++ b/openstack/resource_openstack_objectstorage_container_v1.go
@@ -165,7 +165,6 @@ func resourceObjectStorageContainerV1Read(d *schema.ResourceData, meta interface
 	log.Printf("[DEBUG] Retrieved ObjectStorage Metadata for container '%s' : %#v", d.Id(), metadata)
 
 	err = d.Set("name", d.Id())
-	err = d.Set("content_type", strings.Split(container.ContentType, ";")[0])
 
 	if len(container.Read) > 0 && container.Read[0] != "" {
 		err = d.Set("container_read", strings.Join(container.Read, ","))

--- a/openstack/resource_openstack_objectstorage_container_v1_test.go
+++ b/openstack/resource_openstack_objectstorage_container_v1_test.go
@@ -24,6 +24,10 @@ func TestAccObjectStorageV1Container_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"openstack_objectstorage_container_v1.container_1", "name", "container_1"),
 					resource.TestCheckResourceAttr(
+						"openstack_objectstorage_container_v1.container_1", "metadata.test", "true"),
+					resource.TestCheckResourceAttr(
+						"openstack_objectstorage_container_v1.container_1", "metadata.upperTest", "true"),
+					resource.TestCheckResourceAttr(
 						"openstack_objectstorage_container_v1.container_1", "content_type", "application/json"),
 				),
 			},
@@ -64,6 +68,7 @@ resource "openstack_objectstorage_container_v1" "container_1" {
   name = "container_1"
   metadata = {
     test = "true"
+    upperTest = "true"
   }
   content_type = "application/json"
 }
@@ -74,6 +79,7 @@ resource "openstack_objectstorage_container_v1" "container_1" {
   name = "container_1"
   metadata = {
     test = "true"
+    upperTest = "true"
   }
   content_type = "application/json"
   versioning {

--- a/openstack/resource_openstack_objectstorage_container_v1_test.go
+++ b/openstack/resource_openstack_objectstorage_container_v1_test.go
@@ -69,6 +69,22 @@ resource "openstack_objectstorage_container_v1" "container_1" {
 }
 `
 
+const testAccObjectStorageV1Container_complete = `
+resource "openstack_objectstorage_container_v1" "container_1" {
+  name = "container_1"
+  metadata = {
+    test = "true"
+  }
+  content_type = "application/json"
+  versioning {
+    type = "versions"
+    location = "othercontainer"
+  }
+  container_read = ".r:*,.rlistings"
+  container_write = "*"
+}
+`
+
 const testAccObjectStorageV1Container_update = `
 resource "openstack_objectstorage_container_v1" "container_1" {
   name = "container_1"

--- a/website/docs/r/objectstorage_container_v1.html.markdown
+++ b/website/docs/r/objectstorage_container_v1.html.markdown
@@ -138,6 +138,7 @@ This resource can be imported by specifying the name of the container:
 Some attributes can't be imported :
 * `force_destroy`
 * `content_type`
+* `metadata`
 * `container_sync_to` (missing reading field in [Gophercloud](https://github.com/gophercloud/gophercloud/issues/1958))
 * `container_sync_key` (missing reading field in [Gophercloud](https://github.com/gophercloud/gophercloud/issues/1958))
 

--- a/website/docs/r/objectstorage_container_v1.html.markdown
+++ b/website/docs/r/objectstorage_container_v1.html.markdown
@@ -139,8 +139,8 @@ Some attributes can't be imported :
 * `force_destroy`
 * `content_type`
 * `metadata`
-* `container_sync_to` (missing reading field in [Gophercloud](https://github.com/gophercloud/gophercloud/issues/1958))
-* `container_sync_key` (missing reading field in [Gophercloud](https://github.com/gophercloud/gophercloud/issues/1958))
+* `container_sync_to`
+* `container_sync_key`
 
 So you'll have to `terraform plan` and `terraform apply` after the import to fix those missing attributes.
 

--- a/website/docs/r/objectstorage_container_v1.html.markdown
+++ b/website/docs/r/objectstorage_container_v1.html.markdown
@@ -137,6 +137,7 @@ This resource can be imported by specifying the name of the container:
 
 Some attributes can't be imported :
 * `force_destroy`
+* `content_type`
 * `container_sync_to` (missing reading field in [Gophercloud](https://github.com/gophercloud/gophercloud/issues/1958))
 * `container_sync_key` (missing reading field in [Gophercloud](https://github.com/gophercloud/gophercloud/issues/1958))
 

--- a/website/docs/r/objectstorage_container_v1.html.markdown
+++ b/website/docs/r/objectstorage_container_v1.html.markdown
@@ -141,6 +141,8 @@ Some attributes can't be imported :
 * `container_sync_to` (missing reading field in [Gophercloud](https://github.com/gophercloud/gophercloud/issues/1958))
 * `container_sync_key` (missing reading field in [Gophercloud](https://github.com/gophercloud/gophercloud/issues/1958))
 
+So you'll have to `terraform plan` and `terraform apply` after the import to fix those missing attributes.
+
 ```
 $ terraform import openstack_objectstorage_container_v1.container_1 <name>
 ```

--- a/website/docs/r/objectstorage_container_v1.html.markdown
+++ b/website/docs/r/objectstorage_container_v1.html.markdown
@@ -130,3 +130,16 @@ The following attributes are exported:
 * `versioning` - See Argument Reference above.
 * `metadata` - See Argument Reference above.
 * `content_type` - See Argument Reference above.
+
+## Import
+
+This resource can be imported by specifying the name of the container:
+
+Some attributes can't be imported :
+* `force_destroy`
+* `container_sync_to` (missing reading field in [Gophercloud](https://github.com/gophercloud/gophercloud/issues/1958))
+* `container_sync_key` (missing reading field in [Gophercloud](https://github.com/gophercloud/gophercloud/issues/1958))
+
+```
+$ terraform import openstack_objectstorage_container_v1.container_1 <name>
+```


### PR DESCRIPTION
This PR adds missing fields when reading a `openstack_objectstorage_container_v1`, and allows importing.

`container_sync_to` and `container_sync_key` can't be set because the respective fields are not returned by Gophercloud (see issue https://github.com/gophercloud/gophercloud/issues/1958).

We can either wait for those fields to be available in Gophercloud and then bump Gophecloud dep, or merge as-is ?

NB : I'm a beginner in Golang, so feel free to raise any warning regarding the code style/golang usage

ToDo : better handling for metadata keys