### PR TITLE
Networking V2: cleanup secgroup resource

### DIFF
--- a/openstack/networking_secgroup_v2.go
+++ b/openstack/networking_secgroup_v2.go
@@ -1,0 +1,44 @@
+package openstack
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
+)
+
+// networkingSecgroupV2StateRefreshFuncDelete returns a special case resource.StateRefreshFunc to try to delete a secgroup.
+func networkingSecgroupV2StateRefreshFuncDelete(networkingClient *gophercloud.ServiceClient, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		log.Printf("[DEBUG] Attempting to delete openstack_networking_secgroup_v2 %s", id)
+
+		r, err := groups.Get(networkingClient, id).Extract()
+		if err != nil {
+			if _, ok := err.(gophercloud.ErrDefault404); ok {
+				log.Printf("[DEBUG] Successfully deleted openstack_networking_secgroup_v2 %s", id)
+				return r, "DELETED", nil
+			}
+
+			return r, "ACTIVE", err
+		}
+
+		err = groups.Delete(networkingClient, id).ExtractErr()
+		if err != nil {
+			if _, ok := err.(gophercloud.ErrDefault404); ok {
+				log.Printf("[DEBUG] Successfully deleted openstack_networking_secgroup_v2 %s", id)
+				return r, "DELETED", nil
+			}
+			if _, ok := err.(gophercloud.ErrDefault409); ok {
+				return r, "ACTIVE", nil
+			}
+
+			return r, "ACTIVE", err
+		}
+
+		log.Printf("[DEBUG] openstack_networking_secgroup_v2 %s is still active", id)
+
+		return r, "ACTIVE", nil
+	}
+}

--- a/openstack/resource_openstack_networking_secgroup_v2_test.go
+++ b/openstack/resource_openstack_networking_secgroup_v2_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
-	var security_group groups.SecGroup
+	var securityGroup groups.SecGroup
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,18 +21,15 @@ func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
 			{
 				Config: testAccNetworkingV2SecGroup_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingV2SecGroupExists(
-						"openstack_networking_secgroup_v2.secgroup_1", &security_group),
-					testAccCheckNetworkingV2SecGroupRuleCount(&security_group, 2),
+					testAccCheckNetworkingV2SecGroupExists("openstack_networking_secgroup_v2.secgroup_1", &securityGroup),
+					testAccCheckNetworkingV2SecGroupRuleCount(&securityGroup, 2),
 				),
 			},
 			{
 				Config: testAccNetworkingV2SecGroup_update,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPtr(
-						"openstack_networking_secgroup_v2.secgroup_1", "id", &security_group.ID),
-					resource.TestCheckResourceAttr(
-						"openstack_networking_secgroup_v2.secgroup_1", "name", "security_group_2"),
+					resource.TestCheckResourceAttrPtr("openstack_networking_secgroup_v2.secgroup_1", "id", &securityGroup.ID),
+					resource.TestCheckResourceAttr("openstack_networking_secgroup_v2.secgroup_1", "name", "security_group_2"),
 				),
 			},
 		},
@@ -40,7 +37,7 @@ func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
 }
 
 func TestAccNetworkingV2SecGroup_noDefaultRules(t *testing.T) {
-	var security_group groups.SecGroup
+	var securityGroup groups.SecGroup
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -51,8 +48,8 @@ func TestAccNetworkingV2SecGroup_noDefaultRules(t *testing.T) {
 				Config: testAccNetworkingV2SecGroup_noDefaultRules,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2SecGroupExists(
-						"openstack_networking_secgroup_v2.secgroup_1", &security_group),
-					testAccCheckNetworkingV2SecGroupRuleCount(&security_group, 0),
+						"openstack_networking_secgroup_v2.secgroup_1", &securityGroup),
+					testAccCheckNetworkingV2SecGroupRuleCount(&securityGroup, 0),
 				),
 			},
 		},
@@ -60,7 +57,7 @@ func TestAccNetworkingV2SecGroup_noDefaultRules(t *testing.T) {
 }
 
 func TestAccNetworkingV2SecGroup_timeout(t *testing.T) {
-	var security_group groups.SecGroup
+	var securityGroup groups.SecGroup
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -71,7 +68,7 @@ func TestAccNetworkingV2SecGroup_timeout(t *testing.T) {
 				Config: testAccNetworkingV2SecGroup_timeout,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2SecGroupExists(
-						"openstack_networking_secgroup_v2.secgroup_1", &security_group),
+						"openstack_networking_secgroup_v2.secgroup_1", &securityGroup),
 				),
 			},
 		},


### PR DESCRIPTION
Add helpers into openstack/networking_secgroup_v2.go.

Refactor networking_secgroup_v2 resource code with tests.

For #456