### PR TITLE
Add "allowed_cidrs" option for Octavia listeners

### DIFF
--- a/openstack/lb_v2_shared.go
+++ b/openstack/lb_v2_shared.go
@@ -117,6 +117,14 @@ func chooseLBV2ListenerCreateOpts(d *schema.ResourceData, config *Config) (neutr
 
 		opts.InsertHeaders = headers
 
+		if raw, ok := d.GetOk("allowed_cidrs"); ok {
+			allowedCidrs := make([]string, len(raw.([]interface{})))
+			for i, v := range raw.([]interface{}) {
+				allowedCidrs[i] = v.(string)
+			}
+			opts.AllowedCIDRs = allowedCidrs
+		}
+
 		createOpts = opts
 
 		return createOpts, nil
@@ -236,6 +244,17 @@ func chooseLBV2ListenerUpdateOpts(d *schema.ResourceData, config *Config) (neutr
 			}
 
 			opts.InsertHeaders = &headers
+		}
+
+		if d.HasChange("allowed_cidrs") {
+			hasChange = true
+			var allowedCidrs []string
+			if raw, ok := d.GetOk("allowed_cidrs"); ok {
+				for _, v := range raw.([]interface{}) {
+					allowedCidrs = append(allowedCidrs, v.(string))
+				}
+			}
+			opts.AllowedCIDRs = &allowedCidrs
 		}
 
 		if hasChange {

--- a/openstack/resource_openstack_lb_listener_v2.go
+++ b/openstack/resource_openstack_lb_listener_v2.go
@@ -134,6 +134,12 @@ func resourceListenerV2() *schema.Resource {
 				Optional: true,
 				ForceNew: false,
 			},
+
+			"allowed_cidrs": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -214,6 +220,7 @@ func resourceListenerV2Read(d *schema.ResourceData, meta interface{}) error {
 		d.Set("timeout_tcp_inspect", listener.TimeoutTCPInspect)
 		d.Set("sni_container_refs", listener.SniContainerRefs)
 		d.Set("default_tls_container_ref", listener.DefaultTlsContainerRef)
+		d.Set("allowed_cidrs", listener.AllowedCIDRs)
 		d.Set("region", GetRegion(d, config))
 
 		// Required by import.

--- a/website/docs/r/lb_listener_v2.html.markdown
+++ b/website/docs/r/lb_listener_v2.html.markdown
@@ -80,10 +80,13 @@ The following arguments are supported:
 
 * `admin_state_up` - (Optional) The administrative state of the Listener.
     A valid value is true (UP) or false (DOWN).
-    
+
 * `insert_headers` - (Optional) The list of key value pairs representing headers to insert
     into the request before it is sent to the backend members. Changing this updates the headers of the
     existing listener.
+
+* `allowed_cidrs` - (Optional) A list of CIDR blocks that are permitted to connect to this listener, denying
+    all other source addresses. If not present, defaults to allow all.
 
 ## Attributes Reference
 
@@ -105,6 +108,7 @@ The following attributes are exported:
 * `sni_container_refs` - See Argument Reference above.
 * `admin_state_up` - See Argument Reference above.
 * `insert_headers` - See Argument Reference above.
+* `allowed_cidrs` - See Argument Reference above.
 
 ## Import
 


### PR DESCRIPTION
This adds support for Octavia's "allowed CIDRs" option on load balancer listeners. Gophercloud already supported the API, so this is just wiring up support in the provider side. It accepts a list of CIDR blocks as strings.

Fixes #1029 