### PR TITLE
Update to allow special network option in create server

### DIFF
--- a/openstack/compute_instance_v2.go
+++ b/openstack/compute_instance_v2.go
@@ -23,9 +23,10 @@ import (
 )
 
 const (
-	computeV2InstanceCreateServerWithTagsMicroversion  = "2.52"
-	computeV2TagsExtensionMicroversion                 = "2.26"
-	computeV2InstanceBlockDeviceVolumeTypeMicroversion = "2.67"
+	computeV2InstanceCreateServerWithNetworkModeMicroversion = "2.37"
+	computeV2InstanceCreateServerWithTagsMicroversion        = "2.52"
+	computeV2TagsExtensionMicroversion                       = "2.26"
+	computeV2InstanceBlockDeviceVolumeTypeMicroversion       = "2.67"
 )
 
 // InstanceNIC is a structured representation of a Gophercloud servers.Server

--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -327,6 +327,10 @@ The following arguments are supported:
     instance. The network object structure is documented below. Changing this
     creates a new server.
 
+* `network_mode` - (Optional) Special string for `network` option to create
+  the server. `network_mode` can be `"auto"` or `"none"`.
+  Please see the following [reference](https://docs.openstack.org/api-ref/compute/?expanded=create-server-detail#id11) for more information. Conflicts with `network`.
+
 * `metadata` - (Optional) Metadata key/value pairs to make available from
     within the instance. Changing this updates the existing server metadata.
 


### PR DESCRIPTION
In official OpenStack Compute API documentation,
we can specify the network settings by putting special characters in the network option.

But the current provider does not have a related function.
To satisfy this functionality, add `network_mode` options to resource.

reference
- [Compute API Document](https://docs.openstack.org/api-ref/compute/?expanded=create-server-detail#id11)